### PR TITLE
feat: add explicit lint target and target-dir scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ To lint while skipping specific rules:
 vaar lint --skip=trailing-whitespace
 ```
 
+To lint one explicit dotenv file or one directory tree:
+
+```bash
+vaar lint --target=.env.staging
+vaar lint --target-dir=src
+```
+
 For the lint-specific command reference and rule catalog, see [docs/lint/README.md](./docs/lint/README.md).
 
 ### Examples

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -7,7 +7,7 @@ This page contains the lint-specific command reference for Vaar. Refer to [READM
 
 ## Description of the Command
 
-`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json`, explicit rule selection or exclusion with `--only` and `--skip`, and explicit scope selection with `--target` and `--target-dir`.
+`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json`, explicit rule selection or exclusion with `--only` and `--skip` and explicit scope selection with either `--target` or `--target-dir`.
 
 To use lint, run the command:
 
@@ -34,13 +34,15 @@ Renders findings as a JSON output. To be used when a CI job, editor integration 
 
 ### `--target`
 
-Lints only the specified file path. The path can be relative or absolute, and the file does not need to match the default dotenv filename list.
+Lints only the specified file path. The path can be relative or absolute, and the file does not need to match the default dotenv filename list. 
+
+`--target` and `--target-dir` are mutually exclusive. If both `--target` and `--target-dir` are supplied, `vaar lint` returns an error.
 
 ### `--target-dir`
 
 Recursively discovers dotenv files under the specified directory while keeping the normal repository ignore behavior.
 
-`--target` and `--target-dir` are mutually exclusive.
+`--target` and `--target-dir` are mutually exclusive. If both `--target` and `--target-dir` are supplied, `vaar lint` returns an error.
 
 ### `--only`
 

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -7,7 +7,7 @@ This page contains the lint-specific command reference for Vaar. Refer to [READM
 
 ## Description of the Command
 
-`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json` and explicit rule selection or exclusion with `--only` and `--skip` respectively.
+`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json`, explicit rule selection or exclusion with `--only` and `--skip`, and explicit scope selection with `--target` and `--target-dir`.
 
 To use lint, run the command:
 
@@ -19,6 +19,8 @@ Lint also comes with additional flags such as:
 - `vaar lint --json`
 - `vaar lint --only=[rule-name]`
 - `vaar lint --skip=[rule-name]`
+- `vaar lint --target=.env.staging`
+- `vaar lint --target-dir=src`
 
 ## Lint Flags
 
@@ -29,6 +31,16 @@ Applies only the safe formatting fixes that can be made deterministically.
 ### `--json`
 
 Renders findings as a JSON output. To be used when a CI job, editor integration or wrapper script needs structured output instead of text.
+
+### `--target`
+
+Lints only the specified file path. The path can be relative or absolute, and the file does not need to match the default dotenv filename list.
+
+### `--target-dir`
+
+Recursively discovers dotenv files under the specified directory while keeping the normal repository ignore behavior.
+
+`--target` and `--target-dir` are mutually exclusive.
 
 ### `--only`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ For installation, verification and the fastest first run, start with [README](..
 | Command                                                                          | What it does                            | Read more                                          |
 | -------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------- |
 | `vaar lint`                                                                      | Runs the repository lint checks.        | [Lint guide](./lint/README.md)                     |
-| `vaar lint --fix` / `vaar lint --json` / `vaar lint --only` / `vaar lint --skip` | Adjusts lint output and rule selection. | [Lint guide](./lint/README.md)                     |
+| `vaar lint --fix` / `vaar lint --json` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, rule selection and scope. | [Lint guide](./lint/README.md)                     |
 | `vaar --help` / `vaar help`                                                      | Shows the root help screen.             | [Help guide](./help/README.md)                     |
 | `vaar lint --help` / `vaar help lint`                                            | Shows the lint help screen.             | [Lint help guide](./help/help-lint.md)             |
 | `vaar completion <shell>`                                                        | Prints a shell completion script.       | [Completion guide](./completion/README.md)         |

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -15,7 +15,8 @@ import (
 )
 
 // newLintCmd builds the lint subcommand, wires the built-in rule set and
-// exposes the flag surface for safe fixes, JSON output and rule selection.
+// exposes the flag surface for safe fixes, JSON output, rule selection and
+// explicit discovery scopes.
 func newLintCmd() *cobra.Command {
 	var selection lint.Options
 	var lintFix bool
@@ -26,24 +27,33 @@ func newLintCmd() *cobra.Command {
 		Short: "Run environment lint checks",
 		Long: `Run Vaar's lint rules against discovered dotenv files in the current repository.
 
-The command supports safe fixes, JSON output and repeatable rule selection
-flags. Use --only to narrow the selected rules and --skip to remove rules after
-selection:
+The command supports safe fixes, JSON output, repeatable rule selection flags
+and explicit target scopes. Use --only to narrow the selected rules, --skip to
+remove rules after selection, --target to lint one file and --target-dir to
+discover files under one directory:
 
   vaar lint --only=duplicate-key
   vaar lint --only=duplicate-key --only=invalid-key-name
   vaar lint --skip=trailing-whitespace
-  vaar lint --skip=trailing-whitespace --skip=extra-blank-line`,
+  vaar lint --skip=trailing-whitespace --skip=extra-blank-line
+  vaar lint --target=.env.staging
+  vaar lint --target-dir=src
+
+Use either --target or --target-dir, not both.`,
 		Example: `  vaar lint
   vaar lint --json
   vaar lint --fix
   vaar lint --only=duplicate-key --only=invalid-key-name
-  vaar lint --skip=trailing-whitespace --skip=extra-blank-line`,
+  vaar lint --skip=trailing-whitespace --skip=extra-blank-line
+  vaar lint --target=.env.staging
+  vaar lint --target-dir=src`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := lint.NewRunner(rules.All()...)
 			result, err := runner.Run(cmd.Context(), lint.Options{
 				Root:      ".",
+				Target:    selection.Target,
+				TargetDir: selection.TargetDir,
 				OnlyRules: selection.OnlyRules,
 				SkipRules: selection.SkipRules,
 				Fix:       lintFix,
@@ -79,6 +89,8 @@ selection:
 	flags := cmd.Flags()
 	flags.BoolVar(&lintFix, "fix", false, "Apply safe formatting fixes before reporting")
 	flags.BoolVar(&lintJSON, "json", false, "Render findings as JSON")
+	flags.StringVar(&selection.Target, "target", "", "Lint only the specified file path.")
+	flags.StringVar(&selection.TargetDir, "target-dir", "", "Recursively lint dotenv files under the specified directory.")
 	flags.StringArrayVar(&selection.OnlyRules, "only", nil, "Run only the specified rule ID. Can be repeated.")
 	flags.StringArrayVar(&selection.SkipRules, "skip", nil, "Skip the specified rule ID. Can be repeated.")
 

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -205,6 +205,204 @@ func TestLintCommandAcceptsRepeatableSkipFlags(t *testing.T) {
 	}
 }
 
+func TestLintCommandTargetFileModeSupportsJsonAndOnly(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("ROOT=value\nROOT=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.staging"), []byte("STAGING=value\nSTAGING=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--json", "--only=duplicate-key", "--target=.env.staging")
+	if err == nil {
+		t.Fatal("expected findings error")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	var payload struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got, want := len(payload.Findings), 1; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+	if got, want := payload.Findings[0].File, ".env.staging"; got != want {
+		t.Fatalf("unexpected finding file: got %q want %q", got, want)
+	}
+	if got, want := payload.Findings[0].Rule, "duplicate-key"; got != want {
+		t.Fatalf("unexpected finding rule: got %q want %q", got, want)
+	}
+}
+
+func TestLintCommandTargetDirModeSupportsFix(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("ROOT=value  \n\n\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	path := filepath.Join(root, "src", "app", ".env.example")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("APP=value  \n\n\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--fix", "--target-dir=src")
+	if err != nil {
+		t.Fatalf("expected lint --fix to succeed, got %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no output after fixing, got %q", stdout)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(got) != "APP=value\n" {
+		t.Fatalf("unexpected fixed content: got %q want %q", string(got), "APP=value\n")
+	}
+
+	rootGot, err := os.ReadFile(filepath.Join(root, ".env"))
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(rootGot) != "ROOT=value  \n\n\n" {
+		t.Fatalf("unexpected root file content after target-dir fix: %q", string(rootGot))
+	}
+}
+
+func TestLintCommandTargetDirModeSupportsSkip(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "src", "app", ".env.example")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("APP=value  \nAPP=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--json", "--skip=duplicate-key", "--target-dir=src")
+	if err == nil {
+		t.Fatal("expected findings error")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	var payload struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got, want := len(payload.Findings), 1; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+	if got, want := payload.Findings[0].File, filepath.Join("src", "app", ".env.example"); got != want {
+		t.Fatalf("unexpected finding file: got %q want %q", got, want)
+	}
+	if got, want := payload.Findings[0].Rule, "trailing-whitespace"; got != want {
+		t.Fatalf("unexpected finding rule: got %q want %q", got, want)
+	}
+}
+
+func TestLintCommandTargetScopeErrors(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "conflicting flags",
+			args:     []string{"--target=.env", "--target-dir=src"},
+			wantText: "--target and --target-dir cannot be used together",
+		},
+		{
+			name:     "missing target file",
+			args:     []string{"--target=missing.env"},
+			wantText: "--target path does not exist: missing.env",
+		},
+		{
+			name:     "target points to directory",
+			args:     []string{"--target=src"},
+			wantText: "--target must point to a file: src",
+		},
+		{
+			name:     "missing target dir",
+			args:     []string{"--target-dir=missing-dir"},
+			wantText: "--target-dir path does not exist: missing-dir",
+		},
+		{
+			name:     "target dir points to file",
+			args:     []string{"--target-dir=.env"},
+			wantText: "--target-dir must point to a directory: .env",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runLintCommand(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLintCommandTargetFileReportsUnreadablePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied fixtures are not portable on windows")
+	}
+
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.Mkdir(locked, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(locked, ".env.staging"), []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(locked, 0o755); err != nil {
+			t.Errorf("restore permissions failed: %v", err)
+		}
+	})
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+
+	_, err := runLintCommand(t, root, "--target=locked/.env.staging")
+	if err == nil {
+		t.Fatal("expected lint --target to fail")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "--target path cannot be read: locked/.env.staging") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLintCommandDoesNotLeakSecretValues(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")

--- a/internal/lint/rule.go
+++ b/internal/lint/rule.go
@@ -14,6 +14,10 @@ import "github.com/envaar/vaar/internal/envfile"
 type Options struct {
 	// Root is the repository root to scan.
 	Root string
+	// Target limits a run to one explicit file path.
+	Target string
+	// TargetDir limits a run to dotenv files discovered under one directory.
+	TargetDir string
 	// OnlyRules keeps only the named rule IDs.
 	OnlyRules []string
 	// SkipRules removes the named rule IDs after selection.

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -46,10 +46,10 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 
 	absRoot, err := filepath.Abs(opts.Root)
 	if err != nil {
-		return Result{}, err
+		return Result{}, fmt.Errorf("resolve root %q: %w", opts.Root, err)
 	}
 
-	paths, err := fs.Discover(absRoot)
+	paths, err := discoverPaths(absRoot, opts.Root, opts.Target, opts.TargetDir)
 	if err != nil {
 		return Result{}, err
 	}
@@ -95,6 +95,67 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 	}, nil
 }
 
+// discoverPaths resolves the active lint scope and keeps the default recursive
+// repository walk unchanged when no explicit target flags are provided.
+func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) {
+	if target != "" && targetDir != "" {
+		return nil, fmt.Errorf("--target and --target-dir cannot be used together")
+	}
+
+	if target != "" {
+		path := resolvePath(root, target)
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, scopePathError("--target", target, err)
+		}
+		if info.IsDir() {
+			return nil, fmt.Errorf("--target must point to a file: %s", target)
+		}
+		return []string{path}, nil
+	}
+
+	if targetDir != "" {
+		path := resolvePath(root, targetDir)
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, scopePathError("--target-dir", targetDir, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
+		}
+
+		paths, err := fs.Discover(path)
+		if err != nil {
+			return nil, fmt.Errorf("discovering files under %q: %w", targetDir, err)
+		}
+		return paths, nil
+	}
+
+	paths, err := fs.Discover(root)
+	if err != nil {
+		return nil, fmt.Errorf("discovering files under %q: %w", rootLabel, err)
+	}
+	return paths, nil
+}
+
+// resolvePath turns a user-supplied relative or absolute scope path into an
+// absolute path anchored to the current lint root.
+func resolvePath(root, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(root, path)
+}
+
+// scopePathError keeps target scope failures easy to understand while
+// preserving the underlying OS error for troubleshooting.
+func scopePathError(flag, path string, err error) error {
+	if os.IsNotExist(err) {
+		return fmt.Errorf("%s path does not exist: %s", flag, path)
+	}
+	return fmt.Errorf("%s path cannot be read: %s: %w", flag, path, err)
+}
+
 // loadFiles reads each discovered path and parses it relative to the configured
 // repository root.
 func loadFiles(root string, paths []string) ([]envfile.File, error) {
@@ -102,12 +163,12 @@ func loadFiles(root string, paths []string) ([]envfile.File, error) {
 	for _, path := range paths {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read %q: %w", displayPath(root, path), err)
 		}
 
 		parsed, err := envfile.Parse(displayPath(root, path), data)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse %q: %w", displayPath(root, path), err)
 		}
 		files = append(files, parsed)
 	}

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -202,6 +202,87 @@ func TestRunnerOnlySelectionStillUsesRealRules(t *testing.T) {
 	}
 }
 
+func TestRunnerTargetFileModeUsesExplicitPath(t *testing.T) {
+	root := t.TempDir()
+
+	mustWrite := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+
+	mustWrite(filepath.Join(root, ".env"), "ROOT=value\nROOT=other\n")
+	mustWrite(filepath.Join(root, ".env.staging"), "STAGING=value\nSTAGING=other\n")
+
+	runner := lint.NewRunner(rules.All()...)
+	result, err := runner.Run(context.Background(), lint.Options{
+		Root:   root,
+		Target: ".env.staging",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if got, want := len(result.Files), 1; got != want {
+		t.Fatalf("unexpected file count: got %d want %d", got, want)
+	}
+	if got, want := result.Files[0].Path, ".env.staging"; got != want {
+		t.Fatalf("unexpected parsed path: got %q want %q", got, want)
+	}
+	if got, want := len(result.Findings), 1; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+	if got, want := result.Findings[0].File, ".env.staging"; got != want {
+		t.Fatalf("unexpected finding file: got %q want %q", got, want)
+	}
+}
+
+func TestRunnerTargetDirModeRecursesAndSkipsIgnoredDirs(t *testing.T) {
+	root := t.TempDir()
+
+	mustWrite := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir failed: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+
+	mustWrite(filepath.Join(root, ".env"), "ROOT=value\nROOT=other\n")
+	mustWrite(filepath.Join(root, "src", "app", ".env.example"), "APP=value\nAPP=other\n")
+	mustWrite(filepath.Join(root, "src", "examples", "broken", ".env.example"), "EXAMPLE=value\nEXAMPLE=other\n")
+	mustWrite(filepath.Join(root, "src", "dist", ".env.local"), "DIST=value\nDIST=other\n")
+
+	runner := lint.NewRunner(rules.All()...)
+	result, err := runner.Run(context.Background(), lint.Options{
+		Root:      root,
+		TargetDir: "src",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if got, want := len(result.Files), 1; got != want {
+		t.Fatalf("unexpected file count: got %d want %d", got, want)
+	}
+	wantPath := filepath.Join("src", "app", ".env.example")
+	if got, want := result.Files[0].Path, wantPath; got != want {
+		t.Fatalf("unexpected parsed path: got %q want %q", got, want)
+	}
+	if got, want := len(result.Findings), 1; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+	if got, want := result.Findings[0].File, wantPath; got != want {
+		t.Fatalf("unexpected finding file: got %q want %q", got, want)
+	}
+}
+
 func testRules() ([]lint.Rule, map[string]*int) {
 	counts := map[string]*int{
 		"duplicate-key":       new(int),


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->
## Summary

Closes #5 

Add explicit lint scope modes so `vaar lint` can target one file with `--target` or recurse within one directory with `--target-dir`, while keeping the existing default repository-wide walk unchanged.

## Why

The linter previously always discovered dotenv files from the current working directory. This change adds opt-in scope flags for workflows that need to lint a single file or a specific subtree without changing the default behavior.

## Type

- [x] Internal refactor
- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [x] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `--target` and `--target-dir` to `vaar lint`.
- Kept the default `vaar lint` discovery flow unchanged.
- Added validation for conflicting or invalid scope paths.
- Updated CLI help, usage docs, and lint guide examples.
- Added tests for the new scope modes and error cases.

## User-visible changes

Before:

```bash
vaar lint
```

Always scanned recursively from the current working directory.

After:

```bash
vaar lint
vaar lint --target=.env.staging
vaar lint --target-dir=src
```

Default behavior is unchanged, but users can now lint one specific file or one specific directory tree.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...`

Additional commands:

```text
make vet
make build
make bench
git log --show-signature -1
```

## Tests

- [x] Added tests
- [x] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Add opt-in `--target` and `--target-dir` lint scope flags while preserving the default repository-wide discovery behavior.

## Reviewer notes

Please pay attention to the following:
- Default `vaar lint` discovery remains unchanged.
- `--target` is file-only and supports explicit non-default dotenv filenames.
- `--target-dir` preserves recursive discovery and ignore behavior.
- `--target` and `--target-dir` are mutually exclusive.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included