### PR TITLE
hotfix: add hotfix as pr type

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,7 @@
 Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 -->
+
 ## Summary
 
 Briefly describe the change.
@@ -21,6 +22,7 @@ Explain why this change is needed. Link an issue or discussion if applicable.
 - [ ] Build
 - [ ] Performance improvement/change
 - [ ] Internal refactor
+- [ ] Hotfix
 
 ## Breaking change
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,14 +30,14 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title.trim();
-            const pattern = /^(feat|fix|docs|test|refactor|chore|ci|build|perf)(\([^)]+\))?(!)?: .+$/;
+            const pattern = /^(feat|fix|docs|test|refactor|chore|ci|build|perf|hotfix)(\([^)]+\))?(!)?: .+$/;
 
             if (!pattern.test(title)) {
               core.setFailed(
                 [
                   'Pull request title must match conventional commit format.',
                   'Use "<type>: <description>" or "<type>(scope)!: <description>".',
-                  'Allowed types: feat, fix, docs, test, refactor, chore, ci, build, perf',
+                  'Allowed types: feat, fix, docs, test, refactor, chore, ci, build, perf, hotfix',
                   `Got: ${title}`,
                 ].join(' ')
               );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Vaar uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 - Use `<type>: <description>` for commits and PR titles.
 - Keep descriptions short, imperative and specific.
 - Use `feat` for new user-visible behavior.
-- Use `fix` for bug fixes.
+- Use `fix` or `hotfix` for bug fixes.
 - Use `docs`, `test`, `refactor`, `chore`, `ci`, `build` or `perf` when necessary.
 - Use `!` only when a [Maintainer](mailto:core@envaar.dev) explicitly approves a breaking change.
 - If you are unsure about your change or need any clarifications, please discuss in the related [Issue](https://github.com/envaar/vaar/issues) or [Discussion](https://github.com/envaar/vaar/discussions).


### PR DESCRIPTION
This pull request updates project documentation and workflow configuration to add support for the new `hotfix` type in conventional commit messages. The main changes ensure that `hotfix` is recognized as a valid commit type across contributing guidelines, pull request templates, and PR title validation.

**Conventional Commit Type Update:**

* Added `hotfix` as an allowed PR type in the PR title validation workflow by updating the regex and error message in `.github/workflows/pr-title.yml`.
* Updated the contributing guidelines in `CONTRIBUTING.md` to mention `hotfix` as an option for bug fixes.
* Added a `Hotfix` checkbox to the PR template in `.github/PULL_REQUEST_TEMPLATE.md` to help categorize PRs.
* Minor formatting improvement in `.github/PULL_REQUEST_TEMPLATE.md` for better clarity. 

