### PR TITLE
fix: report repaired findings with --fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Please read [Development Workflow](./CONTRIBUTING.md) to understand the typical 
 
 - If nothing was flagged, Vaar scanned the current working tree and did not find anything to report. Confirm you are in the repository/root you meant to scan.
 - To verify a downloaded binary, compare it against `vaar_checksums.txt` and then run `vaar --version` after extraction.
-- Exit codes are intentionally simple: `0` means no findings reported, `1` means findings were reported and `2` means the command failed before producing results.
+- Exit codes are intentionally simple: `0` means no findings remain after an optional `--fix` pass, `1` means findings remain and `2` means the command failed before producing results.
 
 ## Contributing
 

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -26,11 +26,7 @@ Lint also comes with additional flags such as:
 
 ### `--fix`
 
-Applies only the safe formatting fixes that can be made deterministically. Vaar
-reports the findings from the original file and marks findings that disappeared
-after the fix with `[fixed]`. It then reports any findings that remain in the
-post-fix file. The exit code is based on the remaining findings, so a file with
-only repaired findings exits successfully.
+Applies only the safe formatting fixes that can be made deterministically. Vaar reports the findings from the original file and marks findings that disappeared after the fix with `[fixed]`. It then reports any findings that remain in the post-fix file. The exit code is based on the remaining findings, so a file with only repaired findings exits successfully.
 
 ### `--json`
 
@@ -81,8 +77,8 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 
 `vaar lint` uses simple exit codes that are useful for scripting:
 
-- `0` means no findings remain after an optional `--fix` pass.
-- `1` means one or more findings remain after an optional `--fix` pass.
+- `0` means no lint findings were reported.
+- `1` means lint findings were reported.
 - `2` means the command failed before producing results.
 
 The default output of `vaar lint` is plain text. Repaired findings are prefixed

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -26,7 +26,11 @@ Lint also comes with additional flags such as:
 
 ### `--fix`
 
-Applies only the safe formatting fixes that can be made deterministically.
+Applies only the safe formatting fixes that can be made deterministically. Vaar
+reports the findings from the original file and marks findings that disappeared
+after the fix with `[fixed]`. It then reports any findings that remain in the
+post-fix file. The exit code is based on the remaining findings, so a file with
+only repaired findings exits successfully.
 
 ### `--json`
 
@@ -77,11 +81,13 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 
 `vaar lint` uses simple exit codes that are useful for scripting:
 
-- `0` means no lint findings were reported.
-- `1` means lint findings were reported.
+- `0` means no findings remain after an optional `--fix` pass.
+- `1` means one or more findings remain after an optional `--fix` pass.
 - `2` means the command failed before producing results.
 
-The default output of `vaar lint` is plain text. Use `--json` when you want machine-readable findings for automation purposes.
+The default output of `vaar lint` is plain text. Repaired findings are prefixed
+with `[fixed]`. Use `--json` when you want machine-readable findings for
+automation purposes; repaired findings include `"fixed": true`.
 
 ## Rule Reference
 

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -77,7 +77,7 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 
 `vaar lint` uses simple exit codes that are useful for scripting:
 
-- `0` means no lint findings were reported (or some issues were fixed automatically and reported).
+- `0` means no lint findings were reported (if `--fix` made any fixes, they are reported)
 - `1` means lint findings were reported.
 - `2` means the command failed before producing results.
 

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -77,13 +77,11 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 
 `vaar lint` uses simple exit codes that are useful for scripting:
 
-- `0` means no lint findings were reported.
+- `0` means no lint findings were reported (or some issues were fixed automatically and reported).
 - `1` means lint findings were reported.
 - `2` means the command failed before producing results.
 
-The default output of `vaar lint` is plain text. Repaired findings are prefixed
-with `[fixed]`. Use `--json` when you want machine-readable findings for
-automation purposes; repaired findings include `"fixed": true`.
+The default output of `vaar lint` is plain text. Repaired findings are prefixed with `[fixed]`. Use `--json` when you want machine-readable findings for automation purposes; repaired findings include `"fixed": true`.
 
 ## Rule Reference
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -31,13 +31,14 @@ Vaar keeps the command layer thin and pushes the real logic into a few focused p
 
 1. Resolve the repository root.
 2. Discover dotenv files in the tree.
-3. Parse each file
-4. Select the requested rules.
-5. Run each rule against the parsed snapshot.
-6. Sort findings into a stable order.
-7. Render text or JSON output.
-8. Apply safe formatting fixes when `--fix` is set and report the same.
-9. Exit with the required code.
+3. Select the requested rules.
+4. Parse each file and run the rules against the original snapshot.
+5. Apply safe formatting fixes when `--fix` is set.
+6. Re-parse and re-run the rules after fixing, marking disappeared findings as
+   fixed while retaining findings that remain.
+7. Sort findings into a stable order.
+8. Render text or JSON output.
+9. Exit based on the post-fix findings.
 
 The parser keeps the original bytes, line numbers, BOM state and line-ending information available to later stages. This ensures safe rewrites.
 

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -31,14 +31,15 @@ Vaar keeps the command layer thin and pushes the real logic into a few focused p
 
 1. Resolve the repository root.
 2. Discover dotenv files in the tree.
-3. Select the requested rules.
-4. Parse each file and run the rules against the original snapshot.
-5. Apply safe formatting fixes when `--fix` is set.
-6. Re-parse and re-run the rules after fixing, marking disappeared findings as
-   fixed while retaining findings that remain.
-7. Sort findings into a stable order.
-8. Render text or JSON output.
-9. Exit based on the post-fix findings.
+3. Create an in-memory snapshot of each discovered `.env` file.
+4. Select the rules to apply.
+5. Parse each file and run the rules against the original snapshot.
+   1. If automatic safe fixing is enabled with `--fix`:
+      1. Apply the safe fixes.
+      2. Re-parse the files and re-run the rules after fixing, marking disappeared findings as fixed while retaining findings that remain.
+6. Sort findings into a stable order.
+7. Render text or JSON output.
+8. Exit based on the post-fix findings.
 
 The parser keeps the original bytes, line numbers, BOM state and line-ending information available to later stages. This ensures safe rewrites.
 

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -78,7 +78,7 @@ Use either --target or --target-dir, not both.`,
 				}
 			}
 
-			if len(result.Findings) > 0 {
+			if result.HasUnfixedFindings() {
 				return ExitError{Code: ExitFindings}
 			}
 

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -175,6 +175,36 @@ func TestLintCommandFixUsesRemainingFindingsForExitStatus(t *testing.T) {
 	}
 }
 
+func TestLintCommandFixKeepsShiftedFindingsVisible(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=value  \n\n\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--fix")
+	if err == nil {
+		t.Fatal("expected the remaining duplicate-key finding to fail the command")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	wantOutput := "[fixed] warn trailing-whitespace .env:1 line has trailing whitespace\n" +
+		"error duplicate-key .env:3 KEY is defined more than once\n" +
+		"[fixed] warn extra-blank-line .env:3 repeated blank line\n"
+	if stdout != wantOutput {
+		t.Fatalf("unexpected fix report: got %q want %q", stdout, wantOutput)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(got) != "KEY=value\n\nKEY=other\n" {
+		t.Fatalf("unexpected fixed content: got %q", string(got))
+	}
+}
+
 func TestLintCommandFixMarksFindingsInJSON(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")
@@ -320,9 +350,10 @@ func TestLintCommandTargetDirModeSupportsFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected lint --fix to succeed, got %v", err)
 	}
-	wantOutput := "[fixed] warn trailing-whitespace src/app/.env.example:1 line has trailing whitespace\n" +
-		"[fixed] warn ending-blank-line src/app/.env.example:3 file must end with exactly one final newline\n" +
-		"[fixed] warn extra-blank-line src/app/.env.example:3 repeated blank line\n"
+	expectedPath := filepath.Join("src", "app", ".env.example")
+	wantOutput := "[fixed] warn trailing-whitespace " + expectedPath + ":1 line has trailing whitespace\n" +
+		"[fixed] warn ending-blank-line " + expectedPath + ":3 file must end with exactly one final newline\n" +
+		"[fixed] warn extra-blank-line " + expectedPath + ":3 repeated blank line\n"
 	if stdout != wantOutput {
 		t.Fatalf("unexpected fix report: got %q want %q", stdout, wantOutput)
 	}

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -130,8 +130,11 @@ func TestLintCommandFixesSafeFormatting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected lint --fix to succeed, got %v", err)
 	}
-	if stdout != "" {
-		t.Fatalf("expected no output after fixing, got %q", stdout)
+	wantOutput := "[fixed] warn trailing-whitespace .env:1 line has trailing whitespace\n" +
+		"[fixed] warn ending-blank-line .env:3 file must end with exactly one final newline\n" +
+		"[fixed] warn extra-blank-line .env:3 repeated blank line\n"
+	if stdout != wantOutput {
+		t.Fatalf("unexpected fix report: got %q want %q", stdout, wantOutput)
 	}
 
 	got, err := os.ReadFile(path)
@@ -140,6 +143,67 @@ func TestLintCommandFixesSafeFormatting(t *testing.T) {
 	}
 	if string(got) != "KEY=value\n" {
 		t.Fatalf("unexpected fixed content: got %q want %q", string(got), "KEY=value\n")
+	}
+}
+
+func TestLintCommandFixUsesRemainingFindingsForExitStatus(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=value  \nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--fix")
+	if err == nil {
+		t.Fatal("expected the remaining duplicate-key finding to fail the command")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	wantOutput := "[fixed] warn trailing-whitespace .env:1 line has trailing whitespace\n" +
+		"error duplicate-key .env:2 KEY is defined more than once\n"
+	if stdout != wantOutput {
+		t.Fatalf("unexpected fix report: got %q want %q", stdout, wantOutput)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(got) != "KEY=value\nKEY=other\n" {
+		t.Fatalf("unexpected fixed content: got %q", string(got))
+	}
+}
+
+func TestLintCommandFixMarksFindingsInJSON(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=value  \nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--fix", "--json")
+	if err == nil {
+		t.Fatal("expected the remaining duplicate-key finding to fail the command")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	var payload struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got, want := len(payload.Findings), 2; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+	if !payload.Findings[0].Fixed {
+		t.Fatalf("expected first finding to be marked fixed: %#v", payload.Findings[0])
+	}
+	if payload.Findings[1].Fixed {
+		t.Fatalf("expected remaining finding not to be marked fixed: %#v", payload.Findings[1])
 	}
 }
 
@@ -256,8 +320,11 @@ func TestLintCommandTargetDirModeSupportsFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected lint --fix to succeed, got %v", err)
 	}
-	if stdout != "" {
-		t.Fatalf("expected no output after fixing, got %q", stdout)
+	wantOutput := "[fixed] warn trailing-whitespace src/app/.env.example:1 line has trailing whitespace\n" +
+		"[fixed] warn ending-blank-line src/app/.env.example:3 file must end with exactly one final newline\n" +
+		"[fixed] warn extra-blank-line src/app/.env.example:3 repeated blank line\n"
+	if stdout != wantOutput {
+		t.Fatalf("unexpected fix report: got %q want %q", stdout, wantOutput)
 	}
 
 	got, err := os.ReadFile(path)

--- a/internal/lint/finding.go
+++ b/internal/lint/finding.go
@@ -17,4 +17,6 @@ type Finding struct {
 	Line int `json:"line"`
 	// Message explains the issue in user-facing language.
 	Message string `json:"message"`
+	// Fixed reports that --fix repaired this finding and it is no longer present.
+	Fixed bool `json:"fixed,omitempty"`
 }

--- a/internal/lint/rule.go
+++ b/internal/lint/rule.go
@@ -22,7 +22,7 @@ type Options struct {
 	OnlyRules []string
 	// SkipRules removes the named rule IDs after selection.
 	SkipRules []string
-	// Fix enables the safe formatting pass before linting.
+	// Fix enables the safe formatting pass and reports findings repaired by it.
 	Fix bool
 }
 
@@ -52,4 +52,15 @@ type Result struct {
 	Files []envfile.File
 	// Changed reports whether ApplyFixes rewrote any file on disk.
 	Changed bool
+}
+
+// HasUnfixedFindings reports whether the final lint snapshot still contains
+// any findings after an optional fix pass.
+func (r Result) HasUnfixedFindings() bool {
+	for _, finding := range r.Findings {
+		if !finding.Fixed {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -116,7 +116,6 @@ type findingKey struct {
 	rule     string
 	severity Severity
 	file     string
-	line     int
 	message  string
 }
 
@@ -125,7 +124,6 @@ func keyForFinding(finding Finding) findingKey {
 		rule:     finding.Rule,
 		severity: finding.Severity,
 		file:     finding.File,
-		line:     finding.Line,
 		message:  finding.Message,
 	}
 }

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -31,9 +31,9 @@ func NewRunner(rules ...Rule) *Runner {
 	return &Runner{rules: copied}
 }
 
-// Run resolves the root, discovers dotenv files, applies safe fixes when
-// requested, parses the files and executes the selected rules in declaration
-// order.
+// Run resolves the root, discovers dotenv files and executes the selected
+// rules in declaration order. When fixes are requested, it reports the
+// original findings that disappeared as fixed and keeps the post-fix findings.
 func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
 	if err != nil {
@@ -54,36 +54,35 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
+	files, err := loadFiles(absRoot, paths)
+	if err != nil {
+		return Result{}, err
+	}
+
+	findings, err := r.runRules(ctx, absRoot, selected, files, opts)
+	if err != nil {
+		return Result{}, err
+	}
+
 	changed := false
 	if opts.Fix {
 		changed, err = ApplyFixes(paths)
 		if err != nil {
 			return Result{}, err
 		}
-	}
 
-	files, err := loadFiles(absRoot, paths)
-	if err != nil {
-		return Result{}, err
-	}
-
-	runCtx := Context{
-		Root:    absRoot,
-		Files:   files,
-		Options: opts,
-	}
-
-	findings := make([]Finding, 0, 16)
-	for _, rule := range selected {
-		if err := ctx.Err(); err != nil {
+		fixedFiles, err := loadFiles(absRoot, paths)
+		if err != nil {
 			return Result{}, err
 		}
 
-		ruleFindings, err := rule.Run(runCtx)
+		remaining, err := r.runRules(ctx, absRoot, selected, fixedFiles, opts)
 		if err != nil {
-			return Result{}, fmt.Errorf("%s: %w", rule.ID(), err)
+			return Result{}, err
 		}
-		findings = append(findings, ruleFindings...)
+
+		findings = markFixedFindings(findings, remaining)
+		files = fixedFiles
 	}
 
 	sortFindings(findings)
@@ -93,6 +92,63 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 		Files:    files,
 		Changed:  changed,
 	}, nil
+}
+
+func (r *Runner) runRules(ctx context.Context, root string, selected []Rule, files []envfile.File, opts Options) ([]Finding, error) {
+	runCtx := Context{Root: root, Files: files, Options: opts}
+	findings := make([]Finding, 0, 16)
+	for _, rule := range selected {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		ruleFindings, err := rule.Run(runCtx)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", rule.ID(), err)
+		}
+		findings = append(findings, ruleFindings...)
+	}
+
+	return findings, nil
+}
+
+type findingKey struct {
+	rule     string
+	severity Severity
+	file     string
+	line     int
+	message  string
+}
+
+func keyForFinding(finding Finding) findingKey {
+	return findingKey{
+		rule:     finding.Rule,
+		severity: finding.Severity,
+		file:     finding.File,
+		line:     finding.Line,
+		message:  finding.Message,
+	}
+}
+
+func markFixedFindings(original, remaining []Finding) []Finding {
+	remainingCounts := make(map[findingKey]int, len(remaining))
+	for _, finding := range remaining {
+		remainingCounts[keyForFinding(finding)]++
+	}
+
+	findings := make([]Finding, 0, len(original)+len(remaining))
+	for _, finding := range original {
+		key := keyForFinding(finding)
+		if remainingCounts[key] > 0 {
+			remainingCounts[key]--
+			continue
+		}
+
+		finding.Fixed = true
+		findings = append(findings, finding)
+	}
+
+	return append(findings, remaining...)
 }
 
 // discoverPaths resolves the active lint scope and keeps the default recursive

--- a/internal/lint/runner_internal_test.go
+++ b/internal/lint/runner_internal_test.go
@@ -1,0 +1,34 @@
+package lint
+
+import "testing"
+
+func TestMarkFixedFindingsIgnoresLineChangesForMatching(t *testing.T) {
+	original := []Finding{{
+		Rule:     "trailing-whitespace",
+		Severity: SeverityWarn,
+		File:     ".env",
+		Line:     1,
+		Message:  "line has trailing whitespace",
+	}}
+
+	remaining := []Finding{{
+		Rule:     "trailing-whitespace",
+		Severity: SeverityWarn,
+		File:     ".env",
+		Line:     2,
+		Message:  "line has trailing whitespace",
+	}}
+
+	got := markFixedFindings(original, remaining)
+	if len(got) != 1 {
+		t.Fatalf("expected one retained finding, got %d", len(got))
+	}
+
+	if got[0].Fixed {
+		t.Fatalf("expected remaining finding to stay present, but it was marked fixed")
+	}
+
+	if got[0].Line != 2 {
+		t.Fatalf("expected remaining finding at line 2, got line %d", got[0].Line)
+	}
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -30,6 +30,23 @@ func TestTextRender(t *testing.T) {
 	}
 }
 
+func TestTextRenderMarksFixedFindings(t *testing.T) {
+	findings := []lint.Finding{{
+		Rule:     "trailing-whitespace",
+		Severity: lint.SeverityWarn,
+		File:     ".env",
+		Line:     1,
+		Message:  "line has trailing whitespace",
+		Fixed:    true,
+	}}
+
+	got := report.Text(findings)
+	want := "[fixed] warn trailing-whitespace .env:1 line has trailing whitespace\n"
+	if got != want {
+		t.Fatalf("unexpected fixed text output: got %q want %q", got, want)
+	}
+}
+
 func TestJSONRender(t *testing.T) {
 	findings := []lint.Finding{{
 		Rule:     "duplicate-key",

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -24,6 +24,9 @@ func Text(findings []lint.Finding) string {
 		if i > 0 {
 			builder.WriteByte('\n')
 		}
+		if finding.Fixed {
+			builder.WriteString("[fixed] ")
+		}
 		builder.WriteString(fmt.Sprintf("%s %s %s:%d %s", finding.Severity, finding.Rule, finding.File, finding.Line, finding.Message))
 	}
 	builder.WriteByte('\n')


### PR DESCRIPTION
Fixes #13

## Summary
- lint the original file before applying `--fix` so fixable findings are not lost
- re-lint the post-fix snapshot, mark disappeared findings as `fixed`, and keep remaining findings visible
- prefix repaired text findings with `[fixed]`, expose `fixed: true` in JSON, and base exit status on post-fix findings
- document the behavior and add end-to-end regression coverage

## Testing
- `go test ./...`
- `make vet`
- `make lint`
- `make build`
- CLI smoke test with a temporary trailing-whitespace `.env` confirmed `[fixed]` output and exit code 0

All commits were authored and committed as `hkJerryLeung <hkjerryleung@gmail.com>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated FAQ/Troubleshooting and lint docs to clarify exit codes for `vaar` with `--fix`: `0` when no findings remain, `1` when findings remain, `2` on command failure.
  * Refreshed system overview and reporting docs to describe the post-fix recheck flow and how repaired findings are labeled (`[fixed]` / `fixed: true`).

* **Bug Fixes**
  * Adjusted `lint --fix` so the command’s success/failure depends only on remaining (unfixed) findings.

* **Tests**
  * Expanded deterministic `--fix` and `--json` coverage, including fixed markers in text/JSON and visibility of shifted line numbers for remaining findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->