### PR TITLE
feat: allow JSON lint output to be written to a file

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -76,8 +76,42 @@ Use either --target or --target-dir, not both.`,
 					return NewToolError("rendering JSON output failed", err)
 				}
 				if lintOutput != "" {
-					if err := os.WriteFile(lintOutput, payload, 0644); err != nil {
+					data := append(payload, '\n')
+					dir := "."
+					for i := len(lintOutput) - 1; i >= 0; i-- {
+						if lintOutput[i] == '/' || lintOutput[i] == '\\' {
+							if i == 0 {
+								dir = lintOutput[:1]
+							} else {
+								dir = lintOutput[:i]
+							}
+							break
+						}
+					}
+
+					tmp, err := os.CreateTemp(dir, "vaar-lint-*.json")
+					if err != nil {
+						return NewToolError("creating JSON output file failed", err)
+					}
+					tmpName := tmp.Name()
+					defer os.Remove(tmpName)
+
+					if _, err := tmp.Write(data); err != nil {
+						_ = tmp.Close()
 						return NewToolError(fmt.Sprintf("writing JSON output to %s failed", lintOutput), err)
+					}
+					if err := tmp.Close(); err != nil {
+						return NewToolError(fmt.Sprintf("writing JSON output to %s failed", lintOutput), err)
+					}
+
+					if err := os.Rename(tmpName, lintOutput); err != nil {
+						// Windows rename does not replace existing files.
+						if removeErr := os.Remove(lintOutput); removeErr == nil {
+							err = os.Rename(tmpName, lintOutput)
+						}
+						if err != nil {
+							return NewToolError(fmt.Sprintf("writing JSON output to %s failed", lintOutput), err)
+						}
 					}
 				} else {
 					fmt.Fprintln(cmd.OutOrStdout(), string(payload))
@@ -100,7 +134,7 @@ Use either --target or --target-dir, not both.`,
 	flags := cmd.Flags()
 	flags.BoolVar(&lintFix, "fix", false, "Apply safe formatting fixes before reporting")
 	flags.BoolVar(&lintJSON, "json", false, "Render findings as JSON")
-	flags.StringVarP(&lintOutput, "output", "o", "", "Write JSON output to a file instead of stdout")
+	flags.StringVarP(&lintOutput, "output", "o", "", "Write JSON output to a file instead of stdout (requires --json)")
 	flags.StringVar(&selection.Target, "target", "", "Lint only the specified file path.")
 	flags.StringVar(&selection.TargetDir, "target-dir", "", "Recursively lint dotenv files under the specified directory.")
 	flags.StringArrayVar(&selection.OnlyRules, "only", nil, "Run only the specified rule ID. Can be repeated.")

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/envaar/vaar/internal/lint"
 	"github.com/envaar/vaar/internal/lint/rules"
@@ -21,6 +22,7 @@ func newLintCmd() *cobra.Command {
 	var selection lint.Options
 	var lintFix bool
 	var lintJSON bool
+	var lintOutput string
 
 	cmd := &cobra.Command{
 		Use:   "lint",
@@ -49,6 +51,9 @@ Use either --target or --target-dir, not both.`,
   vaar lint --target-dir=src`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if lintOutput != "" && !lintJSON {
+				return NewToolError("--output requires --json", nil)
+			}
 			runner := lint.NewRunner(rules.All()...)
 			result, err := runner.Run(cmd.Context(), lint.Options{
 				Root:      ".",
@@ -70,7 +75,13 @@ Use either --target or --target-dir, not both.`,
 				if err != nil {
 					return NewToolError("rendering JSON output failed", err)
 				}
-				fmt.Fprintln(cmd.OutOrStdout(), string(payload))
+				if lintOutput != "" {
+					if err := os.WriteFile(lintOutput, payload, 0644); err != nil {
+						return NewToolError(fmt.Sprintf("writing JSON output to %s failed", lintOutput), err)
+					}
+				} else {
+					fmt.Fprintln(cmd.OutOrStdout(), string(payload))
+				}
 			default:
 				text := report.Text(result.Findings)
 				if text != "" {
@@ -89,6 +100,7 @@ Use either --target or --target-dir, not both.`,
 	flags := cmd.Flags()
 	flags.BoolVar(&lintFix, "fix", false, "Apply safe formatting fixes before reporting")
 	flags.BoolVar(&lintJSON, "json", false, "Render findings as JSON")
+	flags.StringVarP(&lintOutput, "output", "o", "", "Write JSON output to a file instead of stdout")
 	flags.StringVar(&selection.Target, "target", "", "Lint only the specified file path.")
 	flags.StringVar(&selection.TargetDir, "target-dir", "", "Recursively lint dotenv files under the specified directory.")
 	flags.StringArrayVar(&selection.OnlyRules, "only", nil, "Run only the specified rule ID. Can be repeated.")


### PR DESCRIPTION
Fixes #10. Adds an \--output\ (or \-o\) argument that writes the JSON lint report to the specified file instead of stdout. Requires \--json\ to be active.