### PR TITLE
fix(lint): reject --output that would overwrite a lint input

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -54,15 +54,24 @@ Use either --target or --target-dir, not both.`,
 			if lintOutput != "" && !lintJSON {
 				return NewToolError("--output requires --json", nil)
 			}
-			runner := lint.NewRunner(rules.All()...)
-			result, err := runner.Run(cmd.Context(), lint.Options{
+
+			opts := lint.Options{
 				Root:      ".",
 				Target:    selection.Target,
 				TargetDir: selection.TargetDir,
 				OnlyRules: selection.OnlyRules,
 				SkipRules: selection.SkipRules,
 				Fix:       lintFix,
-			})
+			}
+
+			if lintOutput != "" {
+				if err := lint.ValidateOutputPath(opts, lintOutput); err != nil {
+					return NewToolError(err.Error(), nil)
+				}
+			}
+
+			runner := lint.NewRunner(rules.All()...)
+			result, err := runner.Run(cmd.Context(), opts)
 			if err != nil {
 				return NewToolError("lint failed", err)
 			}

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -10,6 +10,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -667,4 +668,127 @@ func runLintCommand(t *testing.T, root string, args ...string) (string, error) {
 
 	err := cmd.Execute()
 	return stdout.String(), err
+}
+
+func TestLintCommandRejectsOutputOverlappingInput(t *testing.T) {
+	root := t.TempDir()
+	envPath := filepath.Join(root, ".env")
+	if err := os.WriteFile(envPath, []byte("KEY=value\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	srcAppPath := filepath.Join(root, "src", "app", ".env")
+	if err := os.MkdirAll(filepath.Dir(srcAppPath), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(srcAppPath, []byte("APP=value\nAPP=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		args     []string
+		wantPath string
+	}{
+		{
+			name:     "output equals explicit target",
+			args:     []string{"--target=.env", "--json", "--output=.env"},
+			wantPath: ".env",
+		},
+		{
+			name:     "output equals discovered file",
+			args:     []string{"--json", "--output=.env"},
+			wantPath: ".env",
+		},
+		{
+			name:     "output equals file under target-dir",
+			args:     []string{"--target-dir=src", "--json", "--output=src/app/.env"},
+			wantPath: "src/app/.env",
+		},
+		{
+			name:     "relative output matches absolute target",
+			args:     []string{"--target=" + envPath, "--json", "--output=.env"},
+			wantPath: ".env",
+		},
+		{
+			name:     "output via parent traversal matches discovered file",
+			args:     []string{"--json", "--output=src/../.env"},
+			wantPath: "src/../.env",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original, err := os.ReadFile(envPath)
+			if err != nil {
+				t.Fatalf("read failed: %v", err)
+			}
+
+			stdout, err := runLintCommand(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("cannot write lint output to %q", tc.wantPath)) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "the path is also a lint input file") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout output, got %q", stdout)
+			}
+
+			after, err := os.ReadFile(envPath)
+			if err != nil {
+				t.Fatalf("read failed: %v", err)
+			}
+			if !bytes.Equal(after, original) {
+				t.Fatalf("input file was modified: got %q want %q", after, original)
+			}
+		})
+	}
+}
+
+func TestLintCommandWritesJSONOutputToDistinctPath(t *testing.T) {
+	root := t.TempDir()
+	envPath := filepath.Join(root, ".env")
+	if err := os.WriteFile(envPath, []byte("KEY=value\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--json", "--output=lint-report.json")
+	if err == nil {
+		t.Fatal("expected findings error")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "lint-report.json"))
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	var payload struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got, want := len(payload.Findings), 1; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+
+	after, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(after) != "KEY=value\nKEY=other\n" {
+		t.Fatalf("input file was modified: %q", after)
+	}
 }

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -210,6 +210,65 @@ func scopePathError(flag, path string, err error) error {
 	return fmt.Errorf("%s path cannot be read: %s: %w", flag, path, err)
 }
 
+// ValidateOutputPath reports an error if outputPath resolves to the same file
+// as any input path that would be linted with opts. The comparison uses
+// canonical absolute paths so relative, cleaned and symlink-equivalent forms
+// are detected.
+func ValidateOutputPath(opts Options, outputPath string) error {
+	if opts.Root == "" {
+		opts.Root = "."
+	}
+
+	absRoot, err := filepath.Abs(opts.Root)
+	if err != nil {
+		return fmt.Errorf("resolve root %q: %w", opts.Root, err)
+	}
+
+	inputs, err := discoverPaths(absRoot, opts.Root, opts.Target, opts.TargetDir)
+	if err != nil {
+		return err
+	}
+
+	out, err := canonicalPath(outputPath)
+	if err != nil {
+		return fmt.Errorf("resolve output path %q: %w", outputPath, err)
+	}
+
+	for _, input := range inputs {
+		in, err := canonicalPath(input)
+		if err != nil {
+			return fmt.Errorf("resolve input path %q: %w", input, err)
+		}
+		if out == in {
+			return fmt.Errorf("cannot write lint output to %q: the path is also a lint input file", outputPath)
+		}
+	}
+
+	return nil
+}
+
+// canonicalPath returns a stable absolute form of path. It resolves symlinks
+// and cleans . and .. segments. If path does not exist yet (typical for an
+// --output destination), the parent directory is canonicalized and the base
+// name is rejoined so the result can still be compared with existing files.
+func canonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+
+	dir := filepath.Dir(abs)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedDir, filepath.Base(abs)), nil
+}
+
 // loadFiles reads each discovered path and parses it relative to the configured
 // repository root.
 func loadFiles(root string, paths []string) ([]envfile.File, error) {


### PR DESCRIPTION
## Problem

`vaar lint --output` could overwrite a file that was also being linted. For example:

```sh
vaar lint --target .env --json --output .env
vaar lint --json --output .env
```

The file was read and linted first, then replaced with the JSON report, destroying the original dotenv contents.

## Fix

The command now rejects `--output` when it resolves to the same path as any lint input file. The check fires **before linting or writing begins**, so:

- the input file is never modified,
- no output file is created or truncated,
- the command exits with the operational-error code (`2`).

## Path canonicalization

A naive string comparison misses realistic equivalent paths such as:

- `.env` vs `/abs/path/.env`,
- `src/../.env` vs `.env`,
- symlinked directories.

Both the output path and each discovered input path are resolved with `filepath.Abs` + `filepath.EvalSymlinks` before comparison. Because `--output` may point to a file that does not exist yet, `EvalSymlinks` is applied to the output's parent directory and the base name is rejoined. This makes relative, cleaned, and symlink-equivalent forms detectable.

## Coverage

The validation covers both input sources named in the issue:

- the explicit file passed via `--target`,
- every dotenv file discovered during a normal run or a `--target-dir` run.

## Tests

Added table-driven tests that verify:

- `--output` equal to `--target` is rejected,
- `--output` matching a file under `--target-dir` is rejected,
- relative vs absolute forms and `..` traversal are still rejected,
- a genuinely distinct `--output` path still works,
- after a rejected run the input file contents are unchanged.

## Gates

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go build ./...` — clean
- `make lint` — clean
- `make test` — passes; two pre-existing permission-denied fixture tests fail when run as root and also fail on clean `upstream/main`

Closes #27

Prepared with AI assistance (Kimi K2.7 Code), human-reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented lint reports from overwriting files that are also being analyzed.
  - Added reliable validation for output paths, including relative paths and symbolic links.
  - Preserved source files when writing lint results.

- **New Features**
  - Added support for writing JSON lint reports to a separate output file while returning the expected lint status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->