### PR TITLE
fix(lint): confirm successful --output writes on stderr

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -122,6 +122,15 @@ Use either --target or --target-dir, not both.`,
 							return NewToolError(fmt.Sprintf("writing JSON output to %s failed", lintOutput), err)
 						}
 					}
+
+					count := len(result.Findings)
+					if count == 0 {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Successfully flagged no findings and wrote to %s\n", lintOutput)
+					} else if count == 1 {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Successfully flagged 1 finding and wrote to %s\n", lintOutput)
+					} else {
+						fmt.Fprintf(cmd.ErrOrStderr(), "Successfully flagged %d findings and wrote to %s\n", count, lintOutput)
+					}
 				} else {
 					fmt.Fprintln(cmd.OutOrStdout(), string(payload))
 				}

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -149,7 +149,7 @@ func TestLintCommandWritesJSONOutputToFile(t *testing.T) {
 		t.Fatalf("write failed: %v", err)
 	}
 
-	stdout, err := runLintCommand(t, root, "--json", "--output=lint-report.json")
+	stdout, stderr, err := runLintCommandWithStreams(t, root, "--json", "--output=lint-report.json")
 	if err == nil {
 		t.Fatal("expected findings error")
 	}
@@ -158,6 +158,10 @@ func TestLintCommandWritesJSONOutputToFile(t *testing.T) {
 	}
 	if stdout != "" {
 		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	wantStderr := "Successfully flagged 1 finding and wrote to lint-report.json\n"
+	if stderr != wantStderr {
+		t.Fatalf("unexpected stderr: got %q want %q", stderr, wantStderr)
 	}
 
 	data, err := os.ReadFile(filepath.Join(root, "lint-report.json"))
@@ -659,15 +663,23 @@ func withWorkingDir(t *testing.T, dir string) {
 func runLintCommand(t *testing.T, root string, args ...string) (string, error) {
 	t.Helper()
 
+	stdout, _, err := runLintCommandWithStreams(t, root, args...)
+	return stdout, err
+}
+
+func runLintCommandWithStreams(t *testing.T, root string, args ...string) (string, string, error) {
+	t.Helper()
+
 	withWorkingDir(t, root)
 
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd := newRootCmd()
 	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
 	cmd.SetArgs(append([]string{"lint"}, args...))
 
 	err := cmd.Execute()
-	return stdout.String(), err
+	return stdout.String(), stderr.String(), err
 }
 
 func TestLintCommandRejectsOutputOverlappingInput(t *testing.T) {
@@ -759,7 +771,7 @@ func TestLintCommandWritesJSONOutputToDistinctPath(t *testing.T) {
 		t.Fatalf("write failed: %v", err)
 	}
 
-	stdout, err := runLintCommand(t, root, "--json", "--output=lint-report.json")
+	stdout, stderr, err := runLintCommandWithStreams(t, root, "--json", "--output=lint-report.json")
 	if err == nil {
 		t.Fatal("expected findings error")
 	}
@@ -768,6 +780,10 @@ func TestLintCommandWritesJSONOutputToDistinctPath(t *testing.T) {
 	}
 	if stdout != "" {
 		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	wantStderr := "Successfully flagged 1 finding and wrote to lint-report.json\n"
+	if stderr != wantStderr {
+		t.Fatalf("unexpected stderr: got %q want %q", stderr, wantStderr)
 	}
 
 	data, err := os.ReadFile(filepath.Join(root, "lint-report.json"))
@@ -790,5 +806,63 @@ func TestLintCommandWritesJSONOutputToDistinctPath(t *testing.T) {
 	}
 	if string(after) != "KEY=value\nKEY=other\n" {
 		t.Fatalf("input file was modified: %q", after)
+	}
+}
+
+func TestLintCommandConfirmsOutputWriteWithNoFindings(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, stderr, err := runLintCommandWithStreams(t, root, "--json", "--output=lint-report.json")
+	if err != nil {
+		t.Fatalf("expected lint to succeed, got %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	wantStderr := "Successfully flagged no findings and wrote to lint-report.json\n"
+	if stderr != wantStderr {
+		t.Fatalf("unexpected stderr: got %q want %q", stderr, wantStderr)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "lint-report.json"))
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	var payload struct {
+		Findings []lint.Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if got, want := len(payload.Findings), 0; got != want {
+		t.Fatalf("unexpected finding count: got %d want %d", got, want)
+	}
+}
+
+func TestLintCommandReportsOutputWriteFailure(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("KEY=value\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, stderr, err := runLintCommandWithStreams(t, root, "--json", "--output=missing/dir/lint-report.json")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+	if strings.Contains(stderr, "Successfully flagged") {
+		t.Fatalf("expected no success message on write failure, got %q", stderr)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(root, "missing", "dir", "lint-report.json")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected output file not to be created, got stat error %v", statErr)
 	}
 }


### PR DESCRIPTION
Fixes #22.

After the atomic write (temp file + rename) of the `--output` report succeeds, the CLI now prints a confirmation to **stderr** — e.g. `Successfully flagged 7 findings and wrote to temp.json` (with singular/zero-findings variants). Failure paths return before the message, so no success line is ever printed on a failed write; stdout and the report content stay untouched; the exit-code contract (0 no findings / 1 findings / error on write failure) is unchanged.

Per the issue's acceptance criteria, tests cover findings-present, no-findings, and write-failure cases.

**Deliberately no docs in this PR** — documenting `--output` is #23's whole subject, and CONTRIBUTING asks for single-issue PRs; happy to pick #23 up separately.

Note for reviewers: `TestLintCommandTargetFileReportsUnreadablePath` and `TestLintCommandReturnsInternalErrorWhenDiscoveryFails` fail *on clean main* when the suite runs as root (chmod-0 is a no-op for root) — unrelated to this change and invisible to CI.

## AI assistance disclosure

Implemented with AI assistance (Kimi, briefed and verified by Claude); all gates (`make lint/vet/test/build`) were independently re-run before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The lint command now confirms when JSON findings are successfully written to an output file.
  * Success messages clearly indicate whether zero, one, or multiple findings were recorded.

* **Bug Fixes**
  * Failed output-file writes now return an error without displaying a misleading success message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->