### PR TITLE
feat(lint): add --list-rules for rule discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ vaar lint --target=.env.staging
 vaar lint --target-dir=src
 ```
 
+To list every registered rule with its description:
+
+```bash
+vaar lint --list-rules
+```
+
 For the lint-specific command reference and rule catalog, see [docs/lint/README.md](./docs/lint/README.md).
 
 ### Examples

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -21,6 +21,7 @@ Lint also comes with additional flags such as:
 - `vaar lint --skip=[rule-name]`
 - `vaar lint --target=.env.staging`
 - `vaar lint --target-dir=src`
+- `vaar lint --list-rules`
 
 ## Lint Flags
 
@@ -71,6 +72,20 @@ Examples:
 ```bash
 vaar lint --skip=trailing-whitespace
 vaar lint --skip=trailing-whitespace --skip=extra-blank-line
+```
+
+### `--list-rules`
+
+Prints every registered rule in alphabetical order with its canonical name and a concise description, then exits successfully. This is an informational mode: it does not discover dotenv files, run rules or require a repository, so it works from any directory.
+
+The output uses NAME and DESCRIPTION columns. A FIXABLE column is not included because the rule registry does not currently expose fixability metadata.
+
+`--list-rules` cannot be combined with execution flags such as `--only`, `--skip`, `--fix`, `--target`, `--target-dir` or `--output`; doing so returns a usage error naming the conflicting flag.
+
+Example:
+
+```bash
+vaar lint --list-rules
 ```
 
 ## Output and Exit Codes

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -80,7 +80,7 @@ Prints every registered rule in alphabetical order with its canonical name and a
 
 The output uses NAME and DESCRIPTION columns. A FIXABLE column is not included because the rule registry does not currently expose fixability metadata.
 
-`--list-rules` cannot be combined with execution flags such as `--only`, `--skip`, `--fix`, `--target`, `--target-dir` or `--output`; doing so returns a usage error naming the conflicting flag.
+`--list-rules` cannot be combined with execution or output flags: `--only`, `--skip`, `--fix`, `--target`, `--target-dir`, `--output` or `--json`; doing so returns a usage error naming the conflicting flag.
 
 Example:
 

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -7,7 +7,9 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"sort"
 
 	"github.com/envaar/vaar/internal/lint"
 	"github.com/envaar/vaar/internal/lint/rules"
@@ -23,6 +25,7 @@ func newLintCmd() *cobra.Command {
 	var lintFix bool
 	var lintJSON bool
 	var lintOutput string
+	var lintListRules bool
 
 	cmd := &cobra.Command{
 		Use:   "lint",
@@ -32,7 +35,8 @@ func newLintCmd() *cobra.Command {
 The command supports safe fixes, JSON output, repeatable rule selection flags
 and explicit target scopes. Use --only to narrow the selected rules, --skip to
 remove rules after selection, --target to lint one file and --target-dir to
-discover files under one directory:
+discover files under one directory. Use --list-rules to print every registered
+rule with its description without running anything:
 
   vaar lint --only=duplicate-key
   vaar lint --only=duplicate-key --only=invalid-key-name
@@ -40,6 +44,7 @@ discover files under one directory:
   vaar lint --skip=trailing-whitespace --skip=extra-blank-line
   vaar lint --target=.env.staging
   vaar lint --target-dir=src
+  vaar lint --list-rules
 
 Use either --target or --target-dir, not both.`,
 		Example: `  vaar lint
@@ -48,11 +53,19 @@ Use either --target or --target-dir, not both.`,
   vaar lint --only=duplicate-key --only=invalid-key-name
   vaar lint --skip=trailing-whitespace --skip=extra-blank-line
   vaar lint --target=.env.staging
-  vaar lint --target-dir=src`,
+  vaar lint --target-dir=src
+  vaar lint --list-rules`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if lintOutput != "" && !lintJSON {
 				return NewToolError("--output requires --json", nil)
+			}
+
+			if lintListRules {
+				if conflict := firstListRulesConflict(selection, lintFix, lintJSON, lintOutput); conflict != "" {
+					return NewToolError(fmt.Sprintf("--list-rules cannot be combined with %s", conflict), nil)
+				}
+				return writeRuleList(cmd.OutOrStdout(), rules.All())
 			}
 
 			opts := lint.Options{
@@ -148,8 +161,60 @@ Use either --target or --target-dir, not both.`,
 	flags.StringVar(&selection.TargetDir, "target-dir", "", "Recursively lint dotenv files under the specified directory.")
 	flags.StringArrayVar(&selection.OnlyRules, "only", nil, "Run only the specified rule ID. Can be repeated.")
 	flags.StringArrayVar(&selection.SkipRules, "skip", nil, "Skip the specified rule ID. Can be repeated.")
+	flags.BoolVar(&lintListRules, "list-rules", false, "List every registered rule and its description, then exit")
 
 	registerLintFlagCompletions(cmd)
 
 	return cmd
+}
+
+// firstListRulesConflict returns the first execution flag that conflicts with
+// --list-rules, or an empty string when there is no conflict.
+func firstListRulesConflict(selection lint.Options, fix, json bool, output string) string {
+	if len(selection.OnlyRules) > 0 {
+		return "--only"
+	}
+	if len(selection.SkipRules) > 0 {
+		return "--skip"
+	}
+	if fix {
+		return "--fix"
+	}
+	if output != "" {
+		return "--output"
+	}
+	if json {
+		return "--json"
+	}
+	if selection.Target != "" {
+		return "--target"
+	}
+	if selection.TargetDir != "" {
+		return "--target-dir"
+	}
+	return ""
+}
+
+// writeRuleList prints the registered rules in alphabetical order with aligned
+// NAME and DESCRIPTION columns. Fixability metadata is not part of the Rule
+// interface, so no FIXABLE column is emitted.
+func writeRuleList(w io.Writer, all []lint.Rule) error {
+	sorted := make([]lint.Rule, len(all))
+	copy(sorted, all)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].ID() < sorted[j].ID()
+	})
+
+	nameWidth := len("NAME")
+	for _, rule := range sorted {
+		if n := len(rule.ID()); n > nameWidth {
+			nameWidth = n
+		}
+	}
+
+	fmt.Fprintf(w, "%-*s  DESCRIPTION\n", nameWidth, "NAME")
+	for _, rule := range sorted {
+		fmt.Fprintf(w, "%-*s  %s\n", nameWidth, rule.ID(), rule.Description())
+	}
+	return nil
 }

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -57,15 +57,15 @@ Use either --target or --target-dir, not both.`,
   vaar lint --list-rules`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if lintOutput != "" && !lintJSON {
-				return NewToolError("--output requires --json", nil)
-			}
-
 			if lintListRules {
 				if conflict := firstListRulesConflict(selection, lintFix, lintJSON, lintOutput); conflict != "" {
 					return NewToolError(fmt.Sprintf("--list-rules cannot be combined with %s", conflict), nil)
 				}
 				return writeRuleList(cmd.OutOrStdout(), rules.All())
+			}
+
+			if lintOutput != "" && !lintJSON {
+				return NewToolError("--output requires --json", nil)
 			}
 
 			opts := lint.Options{
@@ -212,9 +212,13 @@ func writeRuleList(w io.Writer, all []lint.Rule) error {
 		}
 	}
 
-	fmt.Fprintf(w, "%-*s  DESCRIPTION\n", nameWidth, "NAME")
+	if _, err := fmt.Fprintf(w, "%-*s  DESCRIPTION\n", nameWidth, "NAME"); err != nil {
+		return err
+	}
 	for _, rule := range sorted {
-		fmt.Fprintf(w, "%-*s  %s\n", nameWidth, rule.ID(), rule.Description())
+		if _, err := fmt.Fprintf(w, "%-*s  %s\n", nameWidth, rule.ID(), rule.Description()); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -961,7 +961,8 @@ func slicesEqual(a, b []string) bool {
 		}
 	}
 	return true
-  
+}
+
 func TestLintCommandConfirmsOutputWriteWithNoFindings(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("KEY=value\n"), 0o644); err != nil {

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -842,8 +842,12 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 	}
 
 	for _, rule := range expected {
-		if !strings.Contains(output, rule.Description()) {
-			t.Fatalf("expected description for %q to appear in output: %q", rule.ID(), rule.Description())
+		description := strings.TrimSpace(rule.Description())
+		if description == "" {
+			t.Fatalf("rule %q has an empty description", rule.ID())
+		}
+		if !strings.Contains(output, description) {
+			t.Fatalf("expected description for %q to appear in output: %q", rule.ID(), description)
 		}
 	}
 }

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -828,27 +828,34 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 		t.Fatalf("expected %d lines (header + %d rules), got %d", len(expected)+1, len(expected), len(lines))
 	}
 
-	gotIDs := make([]string, 0, len(expected))
-	for _, line := range lines[1:] {
-		fields := strings.Fields(line)
-		if len(fields) < 1 {
-			t.Fatalf("unexpected empty rule line: %q", line)
-		}
-		gotIDs = append(gotIDs, fields[0])
-	}
-
-	if !slicesEqual(gotIDs, wantIDs) {
-		t.Fatalf("unexpected rule order or content:\ngot  %v\nwant %v", gotIDs, wantIDs)
-	}
-
+	descriptions := make(map[string]string, len(expected))
 	for _, rule := range expected {
 		description := strings.TrimSpace(rule.Description())
 		if description == "" {
 			t.Fatalf("rule %q has an empty description", rule.ID())
 		}
-		if !strings.Contains(output, description) {
-			t.Fatalf("expected description for %q to appear in output: %q", rule.ID(), description)
+		descriptions[rule.ID()] = description
+	}
+
+	gotIDs := make([]string, 0, len(expected))
+	for _, line := range lines[1:] {
+		id, description, found := strings.Cut(strings.TrimSpace(line), " ")
+		if !found {
+			t.Fatalf("expected rule line to carry a description: %q", line)
 		}
+		gotIDs = append(gotIDs, id)
+
+		want, known := descriptions[id]
+		if !known {
+			t.Fatalf("unexpected rule %q in output", id)
+		}
+		if got := strings.TrimSpace(description); got != want {
+			t.Fatalf("wrong description on the %q line:\ngot  %q\nwant %q", id, got, want)
+		}
+	}
+
+	if !slicesEqual(gotIDs, wantIDs) {
+		t.Fatalf("unexpected rule order or content:\ngot  %v\nwant %v", gotIDs, wantIDs)
 	}
 }
 

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -811,6 +811,10 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 	if !strings.HasPrefix(output, "NAME") {
 		t.Fatalf("expected output to start with NAME header, got %q", output)
 	}
+	header, _, _ := strings.Cut(output, "\n")
+	if !strings.Contains(header, "DESCRIPTION") {
+		t.Fatalf("expected header to contain DESCRIPTION column, got %q", header)
+	}
 
 	expected := rules.All()
 	wantIDs := make([]string, len(expected))
@@ -885,7 +889,7 @@ func TestLintCommandListRulesRejectsExecutionFlags(t *testing.T) {
 		},
 		{
 			name: "output",
-			args: []string{"--list-rules", "--json", "--output=rules.json"},
+			args: []string{"--list-rules", "--output=rules.json"},
 			want: "--list-rules cannot be combined with --output",
 		},
 		{

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -14,10 +14,12 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
 )
 
 func TestLintCommandUnknownRuleReturnsExitCode2(t *testing.T) {
@@ -791,4 +793,141 @@ func TestLintCommandWritesJSONOutputToDistinctPath(t *testing.T) {
 	if string(after) != "KEY=value\nKEY=other\n" {
 		t.Fatalf("input file was modified: %q", after)
 	}
+}
+
+func TestLintCommandListsRulesAlphabetically(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"lint", "--list-rules"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected --list-rules to succeed, got %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.HasPrefix(output, "NAME") {
+		t.Fatalf("expected output to start with NAME header, got %q", output)
+	}
+
+	expected := rules.All()
+	wantIDs := make([]string, len(expected))
+	for i, rule := range expected {
+		wantIDs[i] = rule.ID()
+	}
+	sort.Strings(wantIDs)
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != len(expected)+1 {
+		t.Fatalf("expected %d lines (header + %d rules), got %d", len(expected)+1, len(expected), len(lines))
+	}
+
+	gotIDs := make([]string, 0, len(expected))
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			t.Fatalf("unexpected empty rule line: %q", line)
+		}
+		gotIDs = append(gotIDs, fields[0])
+	}
+
+	if !slicesEqual(gotIDs, wantIDs) {
+		t.Fatalf("unexpected rule order or content:\ngot  %v\nwant %v", gotIDs, wantIDs)
+	}
+
+	for _, rule := range expected {
+		if !strings.Contains(output, rule.Description()) {
+			t.Fatalf("expected description for %q to appear in output: %q", rule.ID(), rule.Description())
+		}
+	}
+}
+
+func TestLintCommandListRulesWorksOutsideRepository(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	stdout, err := runLintCommand(t, root, "--list-rules")
+	if err != nil {
+		t.Fatalf("expected --list-rules to succeed outside a repository, got %v", err)
+	}
+	if !strings.Contains(stdout, "duplicate-key") {
+		t.Fatalf("expected rule list to contain duplicate-key, got %q", stdout)
+	}
+}
+
+func TestLintCommandListRulesRejectsExecutionFlags(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "only",
+			args: []string{"--list-rules", "--only=duplicate-key"},
+			want: "--list-rules cannot be combined with --only",
+		},
+		{
+			name: "skip",
+			args: []string{"--list-rules", "--skip=trailing-whitespace"},
+			want: "--list-rules cannot be combined with --skip",
+		},
+		{
+			name: "fix",
+			args: []string{"--list-rules", "--fix"},
+			want: "--list-rules cannot be combined with --fix",
+		},
+		{
+			name: "json",
+			args: []string{"--list-rules", "--json"},
+			want: "--list-rules cannot be combined with --json",
+		},
+		{
+			name: "output",
+			args: []string{"--list-rules", "--json", "--output=rules.json"},
+			want: "--list-rules cannot be combined with --output",
+		},
+		{
+			name: "target",
+			args: []string{"--list-rules", "--target=.env"},
+			want: "--list-rules cannot be combined with --target",
+		},
+		{
+			name: "target-dir",
+			args: []string{"--list-rules", "--target-dir=src"},
+			want: "--list-rules cannot be combined with --target-dir",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			stdout, err := runLintCommand(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("unexpected error: got %v, want to contain %q", err, tc.want)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout output, got %q", stdout)
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/lint/rule.go
+++ b/internal/lint/rule.go
@@ -41,6 +41,7 @@ type Context struct {
 // mutating shared state.
 type Rule interface {
 	ID() string
+	Description() string
 	Run(Context) ([]Finding, error)
 }
 

--- a/internal/lint/rules/deterministic/bom_character.go
+++ b/internal/lint/rules/deterministic/bom_character.go
@@ -14,6 +14,9 @@ type bomCharacterRule struct{}
 func NewBOMCharacter() lint.Rule { return bomCharacterRule{} }
 
 func (bomCharacterRule) ID() string { return "bom-character" }
+func (bomCharacterRule) Description() string {
+	return "flags a UTF-8 BOM at the start of a dotenv file"
+}
 
 func (bomCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/duplicate_key.go
+++ b/internal/lint/rules/deterministic/duplicate_key.go
@@ -19,6 +19,9 @@ type duplicateKeyRule struct{}
 func NewDuplicateKey() lint.Rule { return duplicateKeyRule{} }
 
 func (duplicateKeyRule) ID() string { return "duplicate-key" }
+func (duplicateKeyRule) Description() string {
+	return "flags the second and later assignment of the same key in one file"
+}
 
 func (duplicateKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/ending_blank_line.go
+++ b/internal/lint/rules/deterministic/ending_blank_line.go
@@ -14,6 +14,9 @@ type endingBlankLineRule struct{}
 func NewEndingBlankLine() lint.Rule { return endingBlankLineRule{} }
 
 func (endingBlankLineRule) ID() string { return "ending-blank-line" }
+func (endingBlankLineRule) Description() string {
+	return "flags files that do not end with one clean trailing newline"
+}
 
 func (endingBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/extra_blank_line.go
+++ b/internal/lint/rules/deterministic/extra_blank_line.go
@@ -13,7 +13,8 @@ type extraBlankLineRule struct{}
 // file because they add vertical noise without changing meaning.
 func NewExtraBlankLine() lint.Rule { return extraBlankLineRule{} }
 
-func (extraBlankLineRule) ID() string { return "extra-blank-line" }
+func (extraBlankLineRule) ID() string          { return "extra-blank-line" }
+func (extraBlankLineRule) Description() string { return "flags repeated blank lines inside a file" }
 
 func (extraBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/incorrect_delimiter.go
+++ b/internal/lint/rules/deterministic/incorrect_delimiter.go
@@ -19,6 +19,9 @@ type incorrectDelimiterRule struct{}
 func NewIncorrectDelimiter() lint.Rule { return incorrectDelimiterRule{} }
 
 func (incorrectDelimiterRule) ID() string { return "incorrect-delimiter" }
+func (incorrectDelimiterRule) Description() string {
+	return "flags ':' where dotenv assignments should use '='"
+}
 
 func (incorrectDelimiterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/invalid_key_name.go
+++ b/internal/lint/rules/deterministic/invalid_key_name.go
@@ -18,6 +18,9 @@ type invalidKeyNameRule struct{}
 func NewInvalidKeyName() lint.Rule { return invalidKeyNameRule{} }
 
 func (invalidKeyNameRule) ID() string { return "invalid-key-name" }
+func (invalidKeyNameRule) Description() string {
+	return "flags keys outside the portable env-var format"
+}
 
 func (invalidKeyNameRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/key_without_value.go
+++ b/internal/lint/rules/deterministic/key_without_value.go
@@ -19,6 +19,9 @@ type keyWithoutValueRule struct{}
 func NewKeyWithoutValue() lint.Rule { return keyWithoutValueRule{} }
 
 func (keyWithoutValueRule) ID() string { return "key-without-value" }
+func (keyWithoutValueRule) Description() string {
+	return "flags bare keys and empty assignments that leave a variable unset"
+}
 
 func (keyWithoutValueRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/leading_character.go
+++ b/internal/lint/rules/deterministic/leading_character.go
@@ -13,7 +13,8 @@ type leadingCharacterRule struct{}
 // indentation, which often hides accidental formatting drift.
 func NewLeadingCharacter() lint.Rule { return leadingCharacterRule{} }
 
-func (leadingCharacterRule) ID() string { return "leading-character" }
+func (leadingCharacterRule) ID() string          { return "leading-character" }
+func (leadingCharacterRule) Description() string { return "warns when a line starts with indentation" }
 
 func (leadingCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/line_ending.go
+++ b/internal/lint/rules/deterministic/line_ending.go
@@ -13,7 +13,8 @@ type lineEndingRule struct{}
 // endings because the same file should not switch newline style midstream.
 func NewLineEnding() lint.Rule { return lineEndingRule{} }
 
-func (lineEndingRule) ID() string { return "line-ending" }
+func (lineEndingRule) ID() string          { return "line-ending" }
+func (lineEndingRule) Description() string { return "flags files with mixed CRLF and LF line endings" }
 
 func (lineEndingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/quote_character.go
+++ b/internal/lint/rules/deterministic/quote_character.go
@@ -17,6 +17,9 @@ type quoteCharacterRule struct{}
 func NewQuoteCharacter() lint.Rule { return quoteCharacterRule{} }
 
 func (quoteCharacterRule) ID() string { return "quote-character" }
+func (quoteCharacterRule) Description() string {
+	return "flags values with unbalanced quotes or stray text after a closing quote"
+}
 
 func (quoteCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/space_character.go
+++ b/internal/lint/rules/deterministic/space_character.go
@@ -14,6 +14,9 @@ type spaceCharacterRule struct{}
 func NewSpaceCharacter() lint.Rule { return spaceCharacterRule{} }
 
 func (spaceCharacterRule) ID() string { return "space-character" }
+func (spaceCharacterRule) Description() string {
+	return "warns about spaces around the key, delimiter or value"
+}
 
 func (spaceCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/trailing_whitespace.go
+++ b/internal/lint/rules/deterministic/trailing_whitespace.go
@@ -13,7 +13,8 @@ type trailingWhitespaceRule struct{}
 // which tends to sneak into review diffs unnoticed.
 func NewTrailingWhitespace() lint.Rule { return trailingWhitespaceRule{} }
 
-func (trailingWhitespaceRule) ID() string { return "trailing-whitespace" }
+func (trailingWhitespaceRule) ID() string          { return "trailing-whitespace" }
+func (trailingWhitespaceRule) Description() string { return "warns about trailing whitespace" }
 
 func (trailingWhitespaceRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/value_without_key.go
+++ b/internal/lint/rules/deterministic/value_without_key.go
@@ -17,6 +17,9 @@ type valueWithoutKeyRule struct{}
 func NewValueWithoutKey() lint.Rule { return valueWithoutKeyRule{} }
 
 func (valueWithoutKeyRule) ID() string { return "value-without-key" }
+func (valueWithoutKeyRule) Description() string {
+	return "flags values or delimiters that appear without a key"
+}
 
 func (valueWithoutKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -24,7 +24,8 @@ type countingRule struct {
 	calls *int
 }
 
-func (r countingRule) ID() string { return r.id }
+func (r countingRule) ID() string          { return r.id }
+func (r countingRule) Description() string { return "counting rule for tests" }
 
 func (r countingRule) Run(lint.Context) ([]lint.Finding, error) {
 	*r.calls++


### PR DESCRIPTION
Fixes #26.

`vaar lint --list-rules` prints a deterministic, alphabetically-sorted NAME/DESCRIPTION table of every registered rule, sourced from the canonical registry (`rules.All()`) — the `lint.Rule` interface gains `Description() string` and each built-in rule implements it, so the CLI cannot drift from the implemented set. Informational mode: no file discovery, no rule execution, works outside a repository, exits 0.

Two judgment calls surfaced for your veto:
- **No FIXABLE column** — the registry exposes no fixability metadata today; inventing it in the CLI layer is exactly the duplication the issue forbids. Easy follow-up if a `Fixable()` method lands on the interface.
- **`--json` is also rejected** alongside the issue's listed execution flags (`--only --skip --fix --target --target-dir --output`) — it's meaningless in list mode; documented and tested. Say the word if you'd rather it emit a JSON listing instead.

Docs per the issue: README example, `docs/lint/README.md` full behavior, `--help` text. Tests cover output, ordering, registry-derived completeness, and every incompatible-flag error.

Note: the two chmod-0 tests fail on clean main when run as root (no-op for root) — unrelated, invisible to CI.

## AI assistance disclosure

Implemented with AI assistance (Kimi, briefed and verified by Claude); the flag was exercised live and all gates re-run before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vaar lint --list-rules` to print all registered lint rules (sorted alphabetically) with `NAME`/`DESCRIPTION`, then exit without running lint checks.
  * Works outside a repository.
* **Documentation**
  * Updated Quick Start and lint command reference with `--list-rules`, including what it prints and an example.
* **Bug Fixes**
  * `--list-rules` is now rejected when combined with selection/execution, scoping/targeting, or output-related flags.
* **Tests**
  * Added end-to-end coverage for output ordering, outside-repo behavior, and invalid flag combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->