### PR TITLE
docs: document vaar lint --output file export behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Use the `--json` flag output for a portable export in the form of a JSON:
 vaar lint --json
 ```
 
+To write that JSON report to a file instead of `stdout`, use:
+
+```bash
+vaar lint --json --output=report.json
+```
+
+This writes the JSON report to a file. For the full file-output behavior, see [docs/lint/README.md](./docs/lint/README.md).
+
 To apply safe, non destructive formatting fixes, use:
 
 ```bash

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -7,7 +7,7 @@ This page contains the lint-specific command reference for Vaar. Refer to [READM
 
 ## Description of the Command
 
-`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json`, explicit rule selection or exclusion with `--only` and `--skip` and explicit scope selection with either `--target` or `--target-dir`.
+`vaar lint` is the primary command for checking a repository for environment configuration issues. It reports findings with line numbers, supports deterministic fixes with `--fix`, machine-readable output with `--json`, JSON file export with `--output` or `-o`, explicit rule selection or exclusion with `--only` and `--skip` and explicit scope selection with either `--target` or `--target-dir`.
 
 To use lint, run the command:
 
@@ -17,6 +17,8 @@ Lint also comes with additional flags such as:
 
 - `vaar lint --fix`
 - `vaar lint --json`
+- `vaar lint --json --output=lint-report.json`
+- `vaar lint --json -o lint-report.json`
 - `vaar lint --only=[rule-name]`
 - `vaar lint --skip=[rule-name]`
 - `vaar lint --target=.env.staging`
@@ -31,6 +33,29 @@ Applies only the safe formatting fixes that can be made deterministically. Vaar 
 ### `--json`
 
 Renders findings as a JSON output. To be used when a CI job, editor integration or wrapper script needs structured output instead of text.
+
+### `--output`, `-o`
+
+Writes the JSON report to a destination file path instead of `stdout`. This flag requires `--json`.
+
+- Relative and absolute destination paths are both supported.
+- The parent directory must already exist; `vaar lint` does not create missing directories.
+- Existing destination files are replaced.
+- The filename extension does not control the reporter; `--output=report.txt` still writes JSON.
+- Exit codes continue to report the lint result, not just whether the file write succeeded.
+- If the resolved output path matches a lint input file, `vaar lint` fails before writing output.
+
+Examples:
+
+```bash
+vaar lint --json --output=lint-report.json
+vaar lint --json -o lint-report.json
+vaar lint --json --output=reports/lint-report.json
+vaar lint \
+  --target=.env.staging \
+  --json \
+  --output=reports/staging-lint.json
+```
 
 ### `--target`
 
@@ -82,6 +107,14 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 - `2` means the command failed before producing results.
 
 The default output of `vaar lint` is plain text. Repaired findings are prefixed with `[fixed]`. Use `--json` when you want machine-readable findings for automation purposes; repaired findings include `"fixed": true`.
+
+When `--output` is not used, JSON is written to `stdout`. When `--output` or `-o` is used, the JSON report is written to the destination file instead and is not printed to `stdout`.
+
+Producing a report file and passing lint are separate outcomes:
+
+- If lint finds no issues, `vaar lint --json --output=report.json` writes the JSON report and exits with code `0`.
+- If lint finds issues, `vaar lint --json --output=report.json` still writes the JSON report and exits with code `1`.
+- If `--output` is used without `--json`, if the destination cannot be written, if the parent directory does not exist or if the output path resolves to a lint input file, `vaar lint` fails before producing the report and exits with code `2`.
 
 ## Rule Reference
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ For installation, verification and the fastest first run, start with [README](..
 | Command                                                                          | What it does                            | Read more                                          |
 | -------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------- |
 | `vaar lint`                                                                      | Runs the repository lint checks.        | [Lint guide](./lint/README.md)                     |
-| `vaar lint --fix` / `vaar lint --json` / `vaar lint --output` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, file export, rule selection and scope. | [Lint guide](./lint/README.md)                     |
+| `vaar lint --fix` / `vaar lint --json` / `vaar lint --output` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, JSON file export, rule selection and scope. | [Lint guide](./lint/README.md)                     |
 | `vaar --help` / `vaar help`                                                      | Shows the root help screen.             | [Help guide](./help/README.md)                     |
 | `vaar lint --help` / `vaar help lint`                                            | Shows the lint help screen.             | [Lint help guide](./help/help-lint.md)             |
 | `vaar completion <shell>`                                                        | Prints a shell completion script.       | [Completion guide](./completion/README.md)         |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ For installation, verification and the fastest first run, start with [README](..
 | Command                                                                          | What it does                            | Read more                                          |
 | -------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------- |
 | `vaar lint`                                                                      | Runs the repository lint checks.        | [Lint guide](./lint/README.md)                     |
-| `vaar lint --fix` / `vaar lint --json` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, rule selection and scope. | [Lint guide](./lint/README.md)                     |
+| `vaar lint --fix` / `vaar lint --json` / `vaar lint --output` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, file export, rule selection and scope. | [Lint guide](./lint/README.md)                     |
 | `vaar --help` / `vaar help`                                                      | Shows the root help screen.             | [Help guide](./help/README.md)                     |
 | `vaar lint --help` / `vaar help lint`                                            | Shows the lint help screen.             | [Lint help guide](./help/help-lint.md)             |
 | `vaar completion <shell>`                                                        | Prints a shell completion script.       | [Completion guide](./completion/README.md)         |
@@ -29,4 +29,5 @@ For installation, verification and the fastest first run, start with [README](..
 
 1. Install Vaar and verify the binary from [README](../README.md).
 2. Run `vaar lint` in the repository you want to check.
-3. Open [docs/lint/README.md](./lint/README.md) when you need to use/exclude specific rules, use `--json` or understand exit codes.
+3. Use `vaar lint --json --output=lint-report.json` when you want to export the JSON report to a file instead of `stdout`.
+4. Open [docs/lint/README.md](./lint/README.md) when you need to use/exclude specific rules or need the detailed exit-code behavior.

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -16,8 +16,8 @@ import (
 )
 
 // newLintCmd builds the lint subcommand, wires the built-in rule set and
-// exposes the flag surface for safe fixes, JSON output, rule selection and
-// explicit discovery scopes.
+// exposes the flag surface for safe fixes, JSON output, JSON file export,
+// rule selection and explicit discovery scopes.
 func newLintCmd() *cobra.Command {
 	var selection lint.Options
 	var lintFix bool
@@ -29,13 +29,16 @@ func newLintCmd() *cobra.Command {
 		Short: "Run environment lint checks",
 		Long: `Run Vaar's lint rules against discovered dotenv files in the current repository.
 
-The command supports safe fixes, JSON output, repeatable rule selection flags
-and explicit target scopes. Use --only to narrow the selected rules, --skip to
-remove rules after selection, --target to lint one file and --target-dir to
-discover files under one directory:
+The command supports safe fixes, JSON output, JSON file export through
+--output or -o, repeatable rule selection flags and explicit target scopes.
+Use --only to narrow the selected rules, --skip to remove rules after
+selection, --target to lint one file and --target-dir to discover files under
+one directory. --output writes JSON to a file instead of stdout and requires
+--json:
 
   vaar lint --only=duplicate-key
   vaar lint --only=duplicate-key --only=invalid-key-name
+  vaar lint --json --output=lint-report.json
   vaar lint --skip=trailing-whitespace
   vaar lint --skip=trailing-whitespace --skip=extra-blank-line
   vaar lint --target=.env.staging
@@ -44,6 +47,8 @@ discover files under one directory:
 Use either --target or --target-dir, not both.`,
 		Example: `  vaar lint
   vaar lint --json
+  vaar lint --json --output=lint-report.json
+  vaar lint --json -o lint-report.json
   vaar lint --fix
   vaar lint --only=duplicate-key --only=invalid-key-name
   vaar lint --skip=trailing-whitespace --skip=extra-blank-line

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -37,7 +37,7 @@ The command supports safe fixes, JSON output, JSON file export through
 Use --only to narrow the selected rules, --skip to remove rules after
 selection, --target to lint one file and --target-dir to discover files under
 one directory. --output writes JSON to a file instead of stdout and requires
---json. Use --list-rules to print every registered rule with its description 
+--json. Use --list-rules to print every registered rule with its description
 without running anything:
 
   vaar lint --only=duplicate-key


### PR DESCRIPTION
## Summary

Closes #23 

Document `vaar lint --output` / `-o` file export behavior across the top-level README, lint docs, usage guide, and `vaar lint` help text.

## Why

`vaar lint --output` already supports writing JSON reports to a file, but that behavior was not consistently documented or easy to discover. This change makes the flag more visible and explains how it interacts with `--json`, `stdout`, exit codes, destination paths, and overwrite safeguards.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [x] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Add a top-level README example for writing JSON lint output to a file.
- Expand the lint command docs with `--output` / `-o` usage, examples, and behavior details.
- Update the usage guide to call out JSON file export explicitly.
- Refresh `vaar lint` CLI help text and examples so they match the documented `--output` behavior.

## User-visible changes

Before, the docs primarily showed:

```bash
vaar lint --json
```

After, the docs and `vaar lint --help` also show:

```bash
vaar lint --json --output=lint-report.json
```

They now clarify that `--output` requires `--json`, writes the JSON report to a file instead of `stdout`, replaces existing destination files, requires the parent directory to already exist, and still returns lint exit code `1` when findings are present even though the report file is written successfully.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...`

Additional commands:

```text
env GOCACHE=/tmp/go-build-cache make lint
env GOCACHE=/tmp/go-build-cache go test ./...
env GOCACHE=/tmp/go-build-cache go run ./cmd/vaar lint --json --output=/tmp/vaar-lint-report.json --target=examples/basic/.env.example
env GOCACHE=/tmp/go-build-cache go run ./cmd/vaar lint --json --output=/tmp/vaar-lint-report-broken.json --target=examples/broken/.env.example
```

## Tests

- [ ] Added tests
- [ ] Updated existing tests
- [x] No tests needed (documentation and help text only; no runtime behavior change)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Document `vaar lint --output` file export usage and clarify its JSON-only, stdout/file, and exit-code behavior in the docs and CLI help.

## Reviewer notes

Please sanity-check that the documented `--output` behavior matches the current CLI implementation, especially:

- `--output` requiring `--json`
- file output replacing `stdout`
- exit code `1` still writing the report when findings exist
- the guard that prevents writing output over a lint input file

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Added and updated guidance for exporting `vaar lint` JSON reports to a file using `--output`/`-o`.
  - Documented destination path behavior (relative/absolute), overwrite handling, and directory requirements.
  - Clarified default behavior (JSON to `stdout`) vs `--output` (writes to the destination) and explained exit-code outcomes, including pre-report failure scenarios.
  - Refreshed quick-start, usage examples, and command help text to reflect the new flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->