### PR TITLE
perf(lint): skip the second pass when no fixes were applied

### DIFF
--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -71,18 +71,20 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 			return Result{}, err
 		}
 
-		fixedFiles, err := loadFiles(absRoot, paths)
-		if err != nil {
-			return Result{}, err
-		}
+		if changed {
+			fixedFiles, err := loadFiles(absRoot, paths)
+			if err != nil {
+				return Result{}, err
+			}
 
-		remaining, err := r.runRules(ctx, absRoot, selected, fixedFiles, opts)
-		if err != nil {
-			return Result{}, err
-		}
+			remaining, err := r.runRules(ctx, absRoot, selected, fixedFiles, opts)
+			if err != nil {
+				return Result{}, err
+			}
 
-		findings = markFixedFindings(findings, remaining)
-		files = fixedFiles
+			findings = markFixedFindings(findings, remaining)
+			files = fixedFiles
+		}
 	}
 
 	sortFindings(findings)

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -288,6 +289,112 @@ func TestRunnerTargetDirModeRecursesAndSkipsIgnoredDirs(t *testing.T) {
 		if got, want := result.Findings[i].File, wantPath; got != want {
 			t.Fatalf("unexpected finding file at %d: got %q want %q", i, got, want)
 		}
+	}
+}
+
+func TestRunnerFixWithChangesRunsSecondPass(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("TRAIL=one  \n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	calls := new(int)
+	runner := lint.NewRunner(append([]lint.Rule{
+		countingRule{id: "pass-counter", calls: calls},
+	}, rules.All()...)...)
+
+	result, err := runner.Run(context.Background(), lint.Options{
+		Root:      root,
+		Fix:       true,
+		OnlyRules: []string{"pass-counter", "trailing-whitespace"},
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if got, want := *calls, 2; got != want {
+		t.Fatalf("unexpected rule run count: got %d want %d", got, want)
+	}
+	if !result.Changed {
+		t.Fatalf("expected the run to report a change")
+	}
+
+	if got, want := len(result.Findings), 1; got != want {
+		t.Fatalf("unexpected findings count: got %d want %d", got, want)
+	}
+	if got, want := result.Findings[0].Rule, "trailing-whitespace"; got != want {
+		t.Fatalf("unexpected rule: got %q want %q", got, want)
+	}
+	if !result.Findings[0].Fixed {
+		t.Fatalf("expected the fixed finding to be marked as fixed")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if got, want := string(content), "TRAIL=one\n"; got != want {
+		t.Fatalf("unexpected file content: got %q want %q", got, want)
+	}
+}
+
+func TestRunnerFixWithoutChangesSkipsSecondPass(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=one\nKEY=two\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	calls := new(int)
+	runner := lint.NewRunner(append([]lint.Rule{
+		countingRule{id: "pass-counter", calls: calls},
+	}, rules.All()...)...)
+
+	baseline, err := runner.Run(context.Background(), lint.Options{
+		Root:      root,
+		OnlyRules: []string{"pass-counter", "duplicate-key"},
+	})
+	if err != nil {
+		t.Fatalf("baseline run failed: %v", err)
+	}
+	if got, want := len(baseline.Findings), 1; got != want {
+		t.Fatalf("unexpected baseline findings count: got %d want %d", got, want)
+	}
+
+	*calls = 0
+
+	result, err := runner.Run(context.Background(), lint.Options{
+		Root:      root,
+		Fix:       true,
+		OnlyRules: []string{"pass-counter", "duplicate-key"},
+	})
+	if err != nil {
+		t.Fatalf("fix run failed: %v", err)
+	}
+
+	if got, want := *calls, 1; got != want {
+		t.Fatalf("unexpected rule run count: got %d want %d", got, want)
+	}
+	if result.Changed {
+		t.Fatalf("expected the run to report no change")
+	}
+
+	if !reflect.DeepEqual(result.Findings, baseline.Findings) {
+		t.Fatalf("unexpected findings: got %#v want %#v", result.Findings, baseline.Findings)
+	}
+	for _, finding := range result.Findings {
+		if finding.Fixed {
+			t.Fatalf("expected no finding to be marked fixed, got %#v", finding)
+		}
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if got, want := string(content), "KEY=one\nKEY=two\n"; got != want {
+		t.Fatalf("unexpected file content: got %q want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Fixes #24.

The `opts.Fix` branch now gates the file reload, second `runRules`, and `markFixedFindings` behind `ApplyFixes` reporting `changed == true` — exactly the issue's sketch, with error handling untouched (`ApplyFixes`'s error stays outside the gate, the inner returns keep their shape) and `Result.Changed` populated either way. When nothing changed, findings and files keep the first-pass values, which a second pass over identical bytes would only have reproduced.

Tests assert the skip **directly** via the existing `countingRule`: the counter runs twice when a fix is applied (plus fixed-finding marking and on-disk normalization asserted) and once when `ApplyFixes` reports no change (plus `DeepEqual`-identical findings vs a no-fix baseline and untouched file bytes).

Gates: `make lint` / `make vet` / `make build` clean; `make test` green except the two known root-environment `internal/cli` chmod-0 tests (verified failing on the clean tree too — invisible to CI). Since this touches rule runtime, `make bench` was also run per CONTRIBUTING: `BenchmarkRunnerSmoke-5 31766 39338 ns/op`.

## AI assistance disclosure

Implemented with AI assistance (Kimi K3, briefed and verified by Claude); all gates and both tests were independently re-run before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic-fix processing so files are rechecked only when changes are made.
  * Preserved original findings when no fixes are applied.
  * Ensured fixed findings are accurately reported after successful changes.
* **Tests**
  * Added coverage for fix workflows with and without file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->