### PR TITLE
feat(lint): add constant-case rule

### DIFF
--- a/docs/lint/rules/README.md
+++ b/docs/lint/rules/README.md
@@ -42,6 +42,7 @@ Use the accurate matching evidence level for each rule page:
 | [ending-blank-line](./deterministic/ending-blank-line.md)     | Deterministic  | Flags a file ending that does not match the current policy. |
 | [extra-blank-line](./deterministic/extra-blank-line.md)       | Deterministic  | Flags repeated blank lines.                                 |
 | [invalid-key-name](./deterministic/invalid-key-name.md)       | Deterministic  | Flags non-portable environment variable names.              |
+| [constant-case](./deterministic/constant-case.md)             | Deterministic  | Flags portable keys that are not CONSTANT_CASE.             |
 | [bom-character](./deterministic/bom-character.md)             | Deterministic  | Flags a UTF-8 BOM at the start of a file.                   |
 | [line-ending](./deterministic/line-ending.md)                 | Deterministic  | Flags mixed CRLF and LF line endings.                       |
 

--- a/docs/lint/rules/deterministic/constant-case.md
+++ b/docs/lint/rules/deterministic/constant-case.md
@@ -1,0 +1,44 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
+# constant-case
+
+Warns about portable keys that are not CONSTANT_CASE.
+
+## What it catches
+
+Keys that match the portable env-key pattern but contain lowercase ASCII
+letters. The message suggests the CONSTANT_CASE form, for example
+`database_url should use CONSTANT_CASE: DATABASE_URL`.
+
+> [!NOTE]
+> Keys with structural problems such as hyphens, dots, spaces or leading
+> digits are reported by `invalid-key-name` instead. constant-case only
+> reports otherwise-valid keys whose sole deviation is lowercase letters.
+
+## Why it matters
+
+CONSTANT_CASE is the widely accepted convention for environment variable
+names and keeps keys consistent across files, shells and deployment tools.
+
+## Evidence level
+
+- `Deterministic`: Vaar can prove this from the file contents alone by checking key names for lowercase ASCII letters.
+
+## Fix
+
+Rename the key to its CONSTANT_CASE form. There is no automatic fix: renaming
+a key can break external references, so `vaar lint --fix` leaves these
+findings untouched.
+
+## Bad example
+
+```dotenv
+database_url=value
+```
+
+## Good example
+
+```dotenv
+DATABASE_URL=value
+```

--- a/docs/lint/rules/deterministic/constant-case.md
+++ b/docs/lint/rules/deterministic/constant-case.md
@@ -8,8 +8,13 @@ Warns about portable keys that are not CONSTANT_CASE.
 ## What it catches
 
 Keys that match the portable env-key pattern but contain lowercase ASCII
-letters. The message suggests the CONSTANT_CASE form, for example
+letters. The message suggests an uppercased form of the key, for example
 `database_url should use CONSTANT_CASE: DATABASE_URL`.
+
+The suggestion is the key with its ASCII lowercase letters uppercased, and
+nothing else — word separators are never inserted, so `apiToken` suggests
+`APITOKEN` rather than `API_TOKEN`. Where a key needs new underscores to read
+well, treat the suggestion as a starting point rather than the final name.
 
 > [!NOTE]
 > Keys with structural problems such as hyphens, dots, spaces or leading

--- a/internal/lint/rules/all.go
+++ b/internal/lint/rules/all.go
@@ -26,6 +26,7 @@ func All() []lint.Rule {
 		deterministic.NewEndingBlankLine(),
 		deterministic.NewExtraBlankLine(),
 		deterministic.NewInvalidKeyName(),
+		deterministic.NewConstantCase(),
 		deterministic.NewBOMCharacter(),
 		deterministic.NewLineEnding(),
 	}

--- a/internal/lint/rules/compat.go
+++ b/internal/lint/rules/compat.go
@@ -32,6 +32,8 @@ func NewExtraBlankLine() lint.Rule { return deterministic.NewExtraBlankLine() }
 
 func NewInvalidKeyName() lint.Rule { return deterministic.NewInvalidKeyName() }
 
+func NewConstantCase() lint.Rule { return deterministic.NewConstantCase() }
+
 func NewBOMCharacter() lint.Rule { return deterministic.NewBOMCharacter() }
 
 func NewLineEnding() lint.Rule { return deterministic.NewLineEnding() }

--- a/internal/lint/rules/deterministic/constant_case.go
+++ b/internal/lint/rules/deterministic/constant_case.go
@@ -19,6 +19,9 @@ type constantCaseRule struct{}
 func NewConstantCase() lint.Rule { return constantCaseRule{} }
 
 func (constantCaseRule) ID() string { return "constant-case" }
+func (constantCaseRule) Description() string {
+	return "warns about portable keys that are not CONSTANT_CASE"
+}
 
 func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/constant_case.go
+++ b/internal/lint/rules/deterministic/constant_case.go
@@ -47,7 +47,7 @@ func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 }
 
 // constantCaseKey uppercases ASCII lowercase letters and leaves every other
-// byte untouched.
+// rune untouched.
 func constantCaseKey(key string) string {
 	return strings.Map(func(r rune) rune {
 		if r >= 'a' && r <= 'z' {

--- a/internal/lint/rules/deterministic/constant_case.go
+++ b/internal/lint/rules/deterministic/constant_case.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deterministic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/envaar/vaar/internal/lint"
+)
+
+type constantCaseRule struct{}
+
+// NewConstantCase returns a rule that warns about portable keys that are not
+// CONSTANT_CASE.
+func NewConstantCase() lint.Rule { return constantCaseRule{} }
+
+func (constantCaseRule) ID() string { return "constant-case" }
+
+func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
+	findings := make([]lint.Finding, 0)
+	for _, file := range ctx.Files {
+		for _, line := range file.Lines {
+			// Structurally invalid keys belong to invalid-key-name; this
+			// rule only reports otherwise-valid keys whose sole deviation
+			// is lowercase letters.
+			if !line.HasKey || !validKeyName(line.Key) {
+				continue
+			}
+			upper := constantCaseKey(line.Key)
+			if upper == line.Key {
+				continue
+			}
+			findings = append(findings, finding(
+				constantCaseRule{}.ID(),
+				lint.SeverityWarn,
+				file.Path,
+				line.Number,
+				fmt.Sprintf("%s should use CONSTANT_CASE: %s", line.Key, upper),
+			))
+		}
+	}
+	return findings, nil
+}
+
+// constantCaseKey uppercases ASCII lowercase letters and leaves every other
+// byte untouched.
+func constantCaseKey(key string) string {
+	return strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' {
+			return r - ('a' - 'A')
+		}
+		return r
+	}, key)
+}

--- a/internal/lint/rules/deterministic/constant_case_test.go
+++ b/internal/lint/rules/deterministic/constant_case_test.go
@@ -64,11 +64,26 @@ func TestConstantCaseAllowsDigitUnderscoreKey(t *testing.T) {
 }
 
 // Structurally invalid keys are reported by invalid-key-name, not by
-// constant-case: each rule stays in its own lane.
+// constant-case: each rule stays in its own lane. Asserting only that
+// constant-case stays silent would also pass if nothing flagged these keys at
+// all, so pin both halves of the boundary: constant-case ignores them AND
+// invalid-key-name reports them.
 func TestConstantCaseLeavesInvalidKeysToInvalidKeyName(t *testing.T) {
+	invalidKeys := []byte("api-key=value\n1api=value\n")
+
 	runRuleTest(t, ruleTestCase{
 		rule:      deterministic.NewConstantCase(),
-		input:     []byte("api-key=value\n1api=value\n"),
+		input:     invalidKeys,
 		wantCount: 0,
+	})
+
+	runRuleTest(t, ruleTestCase{
+		rule:            deterministic.NewInvalidKeyName(),
+		input:           invalidKeys,
+		wantCount:       2,
+		wantLine:        1,
+		wantRule:        "invalid-key-name",
+		wantSeverity:    "error",
+		wantMessagePart: "api-key is not a portable env key name",
 	})
 }

--- a/internal/lint/rules/deterministic/constant_case_test.go
+++ b/internal/lint/rules/deterministic/constant_case_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deterministic_test
+
+import (
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint/rules/deterministic"
+)
+
+func TestConstantCaseFlagsLowercaseKey(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:            deterministic.NewConstantCase(),
+		input:           []byte("database_url=value\n"),
+		wantCount:       1,
+		wantLine:        1,
+		wantRule:        "constant-case",
+		wantSeverity:    "warn",
+		wantMessagePart: "database_url should use CONSTANT_CASE: DATABASE_URL",
+	})
+}
+
+func TestConstantCaseFlagsMixedCaseKey(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:            deterministic.NewConstantCase(),
+		input:           []byte("Database_URL=value\n"),
+		wantCount:       1,
+		wantLine:        1,
+		wantRule:        "constant-case",
+		wantSeverity:    "warn",
+		wantMessagePart: "Database_URL should use CONSTANT_CASE: DATABASE_URL",
+	})
+}
+
+func TestConstantCaseFlagsCamelCaseKey(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:            deterministic.NewConstantCase(),
+		input:           []byte("apiToken=value\n"),
+		wantCount:       1,
+		wantLine:        1,
+		wantRule:        "constant-case",
+		wantSeverity:    "warn",
+		wantMessagePart: "apiToken should use CONSTANT_CASE: APITOKEN",
+	})
+}
+
+func TestConstantCaseAllowsUppercaseKeys(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:      deterministic.NewConstantCase(),
+		input:     []byte("DATABASE_URL=value\nAPI_TOKEN=value\nAPI_V2_URL=value\n"),
+		wantCount: 0,
+	})
+}
+
+func TestConstantCaseAllowsDigitUnderscoreKey(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:      deterministic.NewConstantCase(),
+		input:     []byte("_2=value\n"),
+		wantCount: 0,
+	})
+}
+
+// Structurally invalid keys are reported by invalid-key-name, not by
+// constant-case: each rule stays in its own lane.
+func TestConstantCaseLeavesInvalidKeysToInvalidKeyName(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:      deterministic.NewConstantCase(),
+		input:     []byte("api-key=value\n1api=value\n"),
+		wantCount: 0,
+	})
+}


### PR DESCRIPTION
Fixes #6.

New warn-severity deterministic rule `constant-case`: reports otherwise-valid keys containing lowercase ASCII letters as `<key> should use CONSTANT_CASE: <UPPER>` (uppercasing ASCII a–z only for the suggestion). **No autofix**, per the issue — renames break external references.

**Division with `invalid-key-name`** follows the codebase convention of exclusive lanes (the way `duplicate-key` skips `incorrect-delimiter`'s lines): the rule reuses the shared `validKeyName` guard, so hyphens/dots/spaces/leading digits stay `invalid-key-name`'s business — `api-key` yields only the invalid-key-name error. A test documents the division.

Scaffolding matches existing rules everywhere they appear (impl, tests in the `runRuleTest` style, `rules.All()` registry, `compat.go` constructor, `docs/lint/rules/deterministic/constant-case.md` page, Rule Catalog row); CLI completions pick the name up automatically from the registry. Six tests cover the issue's bad/good examples verbatim plus the division case.

One deliberate divergence: the issue's sample shows a `[warn]` badge, but vaar's reporter renders `warn constant-case file:line message` — the message body matches the issue verbatim and the line format follows the existing reporter (no reporter changes).

Coordination note: #30 (open) adds `Description()` to the `Rule` interface — whichever PR lands second needs a one-line addition on the other's shape; happy to rebase either way.

Gates: `make lint`/`vet`/`build` clean; `make test` green except the two known root-environment chmod-0 tests (fail on clean main too, invisible to CI). Rule behavior verified live against a demo dotenv with the built binary.

## AI assistance disclosure

Implemented with AI assistance (Kimi K3, briefed and verified by Claude); gates, tests, and live rule output were independently re-verified before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the deterministic `constant-case` lint rule to the built-in rule set.
  - Emits warnings when portable env-key casing includes lowercase ASCII letters and suggests the `CONSTANT_CASE` equivalent (manual rename).

- **Documentation**
  - Added a `constant-case` rule page and updated the rule catalog, including its `Deterministic` evidence level and examples.

- **Tests**
  - Added test coverage for lowercase, mixed-case, and camelCase warnings, while allowing already-constant uppercase keys and digit+underscore keys.
  - Verified structurally invalid keys are handled by the existing `invalid-key-name` rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->