### PR TITLE
docs: add a developer primer

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Those boundaries are intentional. Vaar should stay focused before it grows broad
 
 ## Documentation
 
-Please refer to [/docs](/docs/) for all necessary documentation. If you are unsure where to start, try reading [Usage](/docs/usage.md).
+Please refer to [/docs](/docs/) for all necessary documentation. If you are unsure where to start, try reading [Usage](/docs/usage.md). New developers can take the [Primer](/docs/primer/README.md) for a fast, hands-on tour of how Vaar works.
 
 ## System Overview and Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Those boundaries are intentional. Vaar should stay focused before it grows broad
 
 ## Documentation
 
-Please refer to [/docs](/docs/) for all necessary documentation. If you are unsure where to start, try reading [Usage](/docs/usage.md). New developers can take the [Primer](/docs/primer/README.md) for a fast, hands-on tour of how Vaar works.
+Please refer to [/docs](/docs/) for all necessary documentation. If you are unsure where to start, try reading [Usage](/docs/usage.md). New developers can read the [Primer](/docs/primer/README.md) for a fast, hands-on tour of how Vaar works.
 
 ## System Overview and Repository Layout
 

--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -1,0 +1,205 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
+# Vaar Primer
+
+A fast, hands-on tour of Vaar for new developers. Read this end to end and you
+will know what Vaar is, how a lint run flows through the codebase and how to run
+it yourself. It should take about ten minutes.
+
+This primer complements the reference docs: [System Overview](../system-overview.md)
+for package boundaries, [Usage](../usage.md) for the command map and
+[Lint Guide](../lint/README.md) for the full flag and exit-code reference.
+
+## Foundations
+
+### What Vaar Is
+
+Vaar is a repo-aware linter for environment variables, shipped as a single Go
+binary (`cmd/vaar`). The current release focuses on **deterministic dotenv
+hygiene**: it discovers `.env` files in a repository, checks each one against a
+built-in rule set, reports findings with file and line numbers and can apply
+safe formatting fixes.
+
+### The Problem It Solves
+
+`.env` files are rarely reviewed with the same rigor as code. Because they are
+sensitive, they are awkward to share and diff, so duplicate keys, wrong
+delimiters, stray whitespace and non-portable key names slip through unnoticed.
+Vaar makes that drift visible and, where a fix is unambiguous, repairs it.
+
+### Design Principles
+
+These principles come straight from the [System Overview](../system-overview.md)
+and are visible in the package layout:
+
+- **Deterministic first.** Every shipped rule reports an exact finding proven
+  from the file's own bytes. Rules live under `internal/lint/rules/deterministic/`.
+- **Stable ordering and output.** Findings are sorted by file, line, severity,
+  rule and message so scripts and CI can rely on the result (`sortFindings` in
+  `internal/lint/runner.go`).
+- **Preserve original state.** The parser keeps original bytes, line numbers,
+  BOM state and line-ending information; a file is only rewritten when a safe
+  fix intentionally changes it (`internal/envfile/`, `internal/lint/fix.go`).
+- **Thin command layer.** `internal/cli/` only wires flags, exit codes and
+  output; the real logic lives in focused packages.
+- **Local and self-contained.** Vaar reads files from the working tree and
+  nothing else — no network calls, no API keys, no daemon.
+
+## Components
+
+A lint run flows through a small set of packages. Each one owns a single
+responsibility, which keeps them easy to test and extend.
+
+| Stage | Package | Responsibility |
+| ----- | ------- | -------------- |
+| Entrypoint | `cmd/vaar/` | Starts the binary and hands control to `internal/cli`. |
+| CLI layer | `internal/cli/` | Cobra command wiring, flag translation, exit codes and user-facing errors. |
+| Discovery / walk | `internal/fs/` | Walks the tree, matches known dotenv filenames and skips build, VCS and vendored directories (`Discover`). |
+| Envfile parser | `internal/envfile/` | Parses bytes into a line-aware model and provides `Normalize`/`Write` for safe rewrites. |
+| Rule engine | `internal/lint/` | Selects rules with `--only`/`--skip`, runs them, sorts findings and drives the fix pass (`Runner`). |
+| Rule registry | `internal/lint/rules/` | `All()` returns the built-in rule set in a stable order over the category packages. |
+| Report / output | `internal/report/` | Renders findings as plain text or JSON. |
+
+### How A Lint Run Works
+
+The `Runner` in `internal/lint/runner.go` ties these together:
+
+1. Select the active rules (apply `--only`, then `--skip`).
+2. Resolve the scope: the whole repo, one `--target` file or one `--target-dir`
+   tree.
+3. Discover dotenv files and parse each into an in-memory snapshot.
+4. Run every selected rule against the snapshots to produce findings.
+5. If `--fix` is set, apply safe fixes, re-parse, re-run the rules and mark
+   findings that disappeared as `[fixed]`.
+6. Sort the findings into a stable order.
+7. Render text or JSON and choose the exit code from the remaining findings.
+
+Each finding carries a severity (`warn` or `error`), a rule ID, the file, a line
+number and a message. The built-in rules are catalogued in
+[docs/lint/rules/README.md](../lint/rules/README.md).
+
+## Getting Started
+
+### Build And Verify
+
+For install-from-release and `go install` paths, see the
+[README Installation section](../../README.md#installation). To build from a
+clone:
+
+```bash
+make build
+./bin/vaar --version
+```
+
+```text
+vaar version dev
+```
+
+A source build reports the version as `dev`; release binaries report their tag.
+
+### Your First Lint Run
+
+Run Vaar from the repository you want to check. Against the
+[broken example](../../examples/broken/README.md) it reports:
+
+```text
+warn space-character .env:2 line has spaces around the key, delimiter or value
+warn trailing-whitespace .env:2 line has trailing whitespace
+error duplicate-key .env:4 APP_ENV is defined more than once
+error incorrect-delimiter .env:5 DATABASE_URL uses ':' instead of '='
+error invalid-key-name .env:6 api-key is not a portable env key name
+warn ending-blank-line .env:8 file must end with exactly one final newline
+warn extra-blank-line .env:8 repeated blank line
+```
+
+### Reading The Output
+
+Every line follows `<severity> <rule> <file>:<line> <message>`. A clean run
+prints nothing. Exit codes are script-friendly:
+
+- `0` — no findings remain (fixes made during `--fix` are still reported).
+- `1` — findings remain.
+- `2` — the command failed before producing results (for example, an unknown
+  rule name).
+
+### JSON Output
+
+Use `--json` when a CI job or wrapper needs structured findings. Add
+`--output`/`-o` to write the JSON to a file instead of stdout (it requires
+`--json`):
+
+```bash
+vaar lint --json
+vaar lint --json --output=findings.json
+```
+
+```json
+{
+  "findings": [
+    {
+      "rule": "duplicate-key",
+      "severity": "error",
+      "file": ".env",
+      "line": 4,
+      "message": "APP_ENV is defined more than once"
+    }
+  ]
+}
+```
+
+### Applying Safe Fixes
+
+`--fix` normalizes what can be repaired deterministically, then re-checks the
+file. Repaired findings are prefixed with `[fixed]`; anything that still needs a
+human decision (such as a duplicate key or a wrong delimiter) remains:
+
+```bash
+vaar lint --fix
+```
+
+```text
+warn space-character .env:2 line has spaces around the key, delimiter or value
+[fixed] warn trailing-whitespace .env:2 line has trailing whitespace
+error duplicate-key .env:4 APP_ENV is defined more than once
+error incorrect-delimiter .env:5 DATABASE_URL uses ':' instead of '='
+error invalid-key-name .env:6 api-key is not a portable env key name
+[fixed] warn ending-blank-line .env:8 file must end with exactly one final newline
+[fixed] warn extra-blank-line .env:8 repeated blank line
+```
+
+### Selecting Rules
+
+`--only` runs just the named rules; `--skip` removes rules after selection. Both
+flags are repeatable, and an unknown rule name fails the run before linting
+starts:
+
+```bash
+vaar lint --only=duplicate-key
+vaar lint --skip=trailing-whitespace --skip=extra-blank-line
+```
+
+```text
+error duplicate-key .env:4 APP_ENV is defined more than once
+```
+
+### Choosing A Scope
+
+By default Vaar walks the whole repository. Narrow the scope with `--target` for
+one file or `--target-dir` for one tree; the two are mutually exclusive:
+
+```bash
+vaar lint --target=.env.staging
+vaar lint --target-dir=src
+```
+
+## Where To Go Next
+
+- **Every flag, output detail and exit code:** [Lint Guide](../lint/README.md).
+- **The full command map:** [Usage](../usage.md).
+- **What each rule catches, with good and bad examples:**
+  [Rule Reference](../lint/rules/README.md).
+- **Package boundaries and where new code belongs:**
+  [System Overview](../system-overview.md).
+- **Contributing a change or a new rule:**
+  [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -97,6 +97,8 @@ vaar version dev
 ```
 
 A source build reports the version as `dev`; release binaries report their tag.
+The examples below invoke `vaar` directly — put `./bin/vaar` on your `PATH` (or
+use an installed release) and run them from the repository you want to check.
 
 ### Your First Lint Run
 
@@ -115,8 +117,9 @@ warn extra-blank-line .env:8 repeated blank line
 
 ### Reading The Output
 
-Every line follows `<severity> <rule> <file>:<line> <message>`. A clean run
-prints nothing. Exit codes are script-friendly:
+Every line follows `<severity> <rule> <file>:<line> <message>`; during `--fix`
+runs, repaired findings additionally carry a `[fixed]` prefix (see below). A
+clean run prints nothing. Exit codes are script-friendly:
 
 - `0` — no findings remain (fixes made during `--fix` are still reported).
 - `1` — findings remain.

--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -97,8 +97,10 @@ vaar version dev
 ```
 
 A source build reports the version as `dev`; release binaries report their tag.
-The examples below invoke `vaar` directly — put `./bin/vaar` on your `PATH` (or
-use an installed release) and run them from the repository you want to check.
+The examples below invoke `vaar` directly — add the Vaar clone's `bin`
+directory to your `PATH` (for example, run `export PATH="$PWD/bin:$PATH"` from
+the Vaar clone) or use an installed release, then run them from the repository
+you want to check.
 
 ### Your First Lint Run
 

--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -3,9 +3,7 @@ SPDX-License-Identifier: Apache-2.0 -->
 
 # Vaar Primer
 
-A fast, hands-on tour of Vaar for new developers. Read this end-to-end and you
-will know what Vaar is, how a lint run flows through the codebase and how to run
-it yourself. It should take about ten minutes.
+This page is a short introduction to Vaar for new developers. It explains what the project does, how a lint execution moves through the codebase and how to run the tool locally.
 
 This primer complements the reference docs: [System Overview](../system-overview.md)
 for package boundaries, [Usage](../usage.md) for the command map and
@@ -15,47 +13,44 @@ for package boundaries, [Usage](../usage.md) for the command map and
 
 ### What Vaar Is
 
-Vaar is a repo-aware linter for environment variables, shipped as a single Go
-binary built from the `cmd/vaar` entrypoint. The current release focuses on **deterministic dotenv
-hygiene**: it discovers `.env` files in a repository, checks each one against a
-built-in rule set, reports findings with file and line numbers and can apply
-safe formatting fixes.
+Vaar is a Go command-line tool for checking environment configuration. It discovers dotenv files in a repository, runs the built-in rule set, reports findings with file and line numbers and applies safe formatting fixes with `--fix`.
 
 ### The Problem It Solves
 
-`.env` files are rarely reviewed with the same rigor as code. Because they are
-sensitive, they are awkward to share and diff, so duplicate keys, wrong
-delimiters, stray whitespace and non-portable key names slip through unnoticed.
-Vaar makes that drift visible and, where a fix is unambiguous, repairs it.
+`.env` files are rarely reviewed with the same rigor as code. Because they are sensitive, they are difficult to share and diff. So duplicate keys, wrong delimiters, stray whitespaces, non-portable key names and other such issues slip through unnoticed. Vaar makes that drift visible and, where a fix is unambiguous, repairs it.
+
+### What Vaar Checks 
+
+By default Vaar discovers these filenames:
+
+- `.env`
+- `.env.example`
+- `.env.local`
+- `.env.development`
+- `.env.test`
+- `.env.production`
+
+Discovery is recursive and stays deterministic. The repository walk skips generated, vendored, fixture and VCS directories, as implemented in `internal/fs/`.
 
 ### Design Principles
 
-These principles come straight from the [System Overview](../system-overview.md)
-and are visible in the package layout:
+These principles detailed in the [System Overview](../system-overview.md) and are visible in the package layout:
 
-- **Deterministic first.** Every shipped rule reports an exact finding proven
-  from the file's own bytes. Rules live under `internal/lint/rules/deterministic/`.
-- **Stable ordering and output.** Findings are sorted by file, line, severity,
-  rule and message so scripts and CI can rely on the result (`sortFindings` in
-  `internal/lint/runner.go`).
-- **Preserve original state.** The parser keeps original bytes, line numbers,
-  BOM state and line-ending information; a file is only rewritten when a safe
-  fix intentionally changes it (`internal/envfile/`, `internal/lint/fix.go`).
-- **Thin command layer.** `internal/cli/` only wires flags, exit codes and
-  output; the real logic lives in focused packages.
-- **Local and self-contained.** Vaar reads files from the working tree and
-  nothing else — no network calls, no API keys, no daemon.
+- Deterministic first. Every rule is currently under `internal/lint/rules/deterministic/` and reports an exact finding from file content.
+- Stable ordering and output. Findings are sorted by file, line, severity, rule and message so scripts and CI can rely on the result.
+- Preserve original file state where possible. Parsing keeps original bytes, line numbers, BOM state and line-ending information available to later stages.
+- Keep the command layer thin. `internal/cli/` handles command wiring, flags and exit codes while the main logic stays in focused packages.
 
 ## Components
 
-A lint run flows through a small set of packages. Each one owns a single
-responsibility, which keeps them easy to test and extend.
+A lint run passes through a small set of packages. Each package has one main
+responsibility.
 
 | Stage | Package | Responsibility |
 | ----- | ------- | -------------- |
 | Entrypoint | `cmd/vaar/` | Starts the binary and hands control to `internal/cli`. |
 | CLI layer | `internal/cli/` | Cobra command wiring, flag translation, exit codes and user-facing errors. |
-| Discovery / walk | `internal/fs/` | Walks the tree, matches known dotenv filenames and skips build, VCS and vendored directories (`Discover`). |
+| Discovery / walk | `internal/fs/` | Walks the tree, matches known dotenv filenames and skips ignored directories such as `.git`, `build`, `dist`, `node_modules`, `testdata` and `vendor` (`Discover`). |
 | Envfile parser | `internal/envfile/` | Parses bytes into a line-aware model and provides `Normalize`/`Write` for safe rewrites. |
 | Rule engine | `internal/lint/` | Selects rules with `--only`/`--skip`, runs them, sorts findings and drives the fix pass (`Runner`). |
 | Rule registry | `internal/lint/rules/` | `All()` returns the built-in rule set in a stable order over the category packages. |
@@ -63,29 +58,24 @@ responsibility, which keeps them easy to test and extend.
 
 ### How A Lint Run Works
 
-The `Runner` in `internal/lint/runner.go` ties these together:
+The `Runner` in `internal/lint/runner.go` ties these packages together:
 
-1. Select the active rules (apply `--only`, then `--skip`).
-2. Resolve the scope: the whole repo, one `--target` file or one `--target-dir`
-   tree.
-3. Discover dotenv files and parse each into an in-memory snapshot.
-4. Run every selected rule against the snapshots to produce findings.
-5. If `--fix` is set, apply safe fixes, re-parse, re-run the rules and mark
-   findings that disappeared as `[fixed]`.
+1. Select the active rules after applying `--only` and `--skip`.
+2. Resolve the lint scope: the whole repository, one `--target` file or one `--target-dir` tree.
+3. Discover dotenv files and load them into in-memory snapshots.
+4. Run the selected rules against those snapshots.
+5. If `--fix` is enabled, apply safe fixes, re-parse the changed files, re-run the rules and mark findings that disappeared as `[fixed]`.
 6. Sort the findings into a stable order.
-7. Render text or JSON and choose the exit code from the remaining findings.
+7. Render text or JSON output.
+8. Exit based on the findings that remain after fixing.
 
-Each finding carries a severity (`warn` or `error`), a rule ID, the file, a line
-number and a message. The built-in rules are catalogued in
-[docs/lint/rules/README.md](../lint/rules/README.md).
+Each finding carries a severity (`warn` or `error`), a rule name, the file, a line number and a message. The built-in rules are catalogued in [docs/lint/rules/README.md](../lint/rules/README.md).
 
 ## Getting Started
 
 ### Build And Verify
 
-For install-from-release and `go install` paths, see the
-[README Installation section](../../README.md#installation). To build from a
-clone:
+For install-from-release and `go install` paths, see the [README Installation section](../../README.md#installation). To build from a clone:
 
 ```bash
 make build
@@ -96,47 +86,45 @@ make build
 vaar version dev
 ```
 
-A source build reports the version as `dev`; release binaries report their tag.
-The examples below invoke `vaar` directly — add the Vaar clone's `bin`
-directory to your `PATH` (for example, run `export PATH="$PWD/bin:$PATH"` from
-the Vaar clone) or use an installed release, then run them from the repository
-you want to check.
+A source build reports the version as `dev`. Release binaries report the release tag.
 
-### Your First Lint Run
+The examples below use `./bin/vaar` from a local clone. If `vaar` is already on your `PATH`, use the same commands without the `./bin/` prefix.
 
-Run Vaar from the repository you want to check. Against the
-[broken example](../../examples/broken/README.md) it reports:
+### First Lint Run
+
+From the Vaar repository, run the linter against the [broken example](../../examples/broken/README.md):
+
+```bash
+./bin/vaar lint --target=examples/broken/.env.example
+```
+
+It reports:
 
 ```text
-warn space-character .env:2 line has spaces around the key, delimiter or value
-warn trailing-whitespace .env:2 line has trailing whitespace
-error duplicate-key .env:4 APP_ENV is defined more than once
-error incorrect-delimiter .env:5 DATABASE_URL uses ':' instead of '='
-error invalid-key-name .env:6 api-key is not a portable env key name
-warn ending-blank-line .env:8 file must end with exactly one final newline
-warn extra-blank-line .env:8 repeated blank line
+warn space-character examples/broken/.env.example:2 line has spaces around the key, delimiter or value
+warn trailing-whitespace examples/broken/.env.example:2 line has trailing whitespace
+error duplicate-key examples/broken/.env.example:4 APP_ENV is defined more than once
+error incorrect-delimiter examples/broken/.env.example:5 DATABASE_URL uses ':' instead of '='
+error invalid-key-name examples/broken/.env.example:6 api-key is not a portable env key name
+warn ending-blank-line examples/broken/.env.example:8 file must end with exactly one final newline
+warn extra-blank-line examples/broken/.env.example:8 repeated blank line
 ```
 
 ### Reading The Output
 
-Every line follows `<severity> <rule> <file>:<line> <message>`; during `--fix`
-runs, repaired findings additionally carry a `[fixed]` prefix (see below). A
-clean run prints nothing. Exit codes are script-friendly:
+Every line follows `<severity> <rule> <file>:<line> <message>`; during `--fix` runs, repaired findings additionally carry a `[fixed]` prefix (see below). A clean run prints nothing. Exit codes are script-friendly:
 
-- `0` — no findings remain (fixes made during `--fix` are still reported).
-- `1` — findings remain.
-- `2` — the command failed before producing results (for example, an unknown
-  rule name).
+- `0` - no findings remain (fixes made during `--fix` are still reported).
+- `1` - findings remain.
+- `2` - the command failed before producing results (for example, an unknown rule name).
 
 ### JSON Output
 
-Use `--json` when a CI job or wrapper needs structured findings. Add
-`--output`/`-o` to write the JSON to a file instead of stdout (it requires
-`--json`):
+Use `--json` when you need structured findings. Add `--output`/`-o` to write the JSON to a file instead of stdout (it requires `--json`):
 
 ```bash
-vaar lint --json
-vaar lint --json --output=findings.json
+./bin/vaar lint --target=examples/broken/.env.example --json
+./bin/vaar lint --target=examples/broken/.env.example --json --output=findings.json
 ```
 
 ```json
@@ -145,7 +133,7 @@ vaar lint --json --output=findings.json
     {
       "rule": "duplicate-key",
       "severity": "error",
-      "file": ".env",
+      "file": "examples/broken/.env.example",
       "line": 4,
       "message": "APP_ENV is defined more than once"
     }
@@ -155,43 +143,38 @@ vaar lint --json --output=findings.json
 
 ### Applying Safe Fixes
 
-`--fix` normalizes what can be repaired deterministically, then re-checks the
-file. Repaired findings are prefixed with `[fixed]`; anything that still needs a
-human decision (such as a duplicate key or a wrong delimiter) remains:
+`--fix` normalizes any findings that can be repaired safely, then re-checks the file. Repaired findings are prefixed with `[fixed]`; anything that still needs human intervention (such as a duplicate key or a wrong delimiter) remains:
 
 ```bash
-vaar lint --fix
+./bin/vaar lint --target=examples/broken/.env.example --fix
 ```
 
 ```text
-warn space-character .env:2 line has spaces around the key, delimiter or value
-[fixed] warn trailing-whitespace .env:2 line has trailing whitespace
-error duplicate-key .env:4 APP_ENV is defined more than once
-error incorrect-delimiter .env:5 DATABASE_URL uses ':' instead of '='
-error invalid-key-name .env:6 api-key is not a portable env key name
-[fixed] warn ending-blank-line .env:8 file must end with exactly one final newline
-[fixed] warn extra-blank-line .env:8 repeated blank line
+warn space-character examples/broken/.env.example:2 line has spaces around the key, delimiter or value
+[fixed] warn trailing-whitespace examples/broken/.env.example:2 line has trailing whitespace
+error duplicate-key examples/broken/.env.example:4 APP_ENV is defined more than once
+error incorrect-delimiter examples/broken/.env.example:5 DATABASE_URL uses ':' instead of '='
+error invalid-key-name examples/broken/.env.example:6 api-key is not a portable env key name
+[fixed] warn ending-blank-line examples/broken/.env.example:8 file must end with exactly one final newline
+[fixed] warn extra-blank-line examples/broken/.env.example:8 repeated blank line
 ```
 
 ### Selecting Rules
 
-`--only` runs just the named rules; `--skip` removes rules after selection. Both
-flags are repeatable, and an unknown rule name fails the run before linting
-starts:
+`--only` runs just the chosen rules; `--skip` removes rules specific rules. Both flags are repeatable and an unknown rule name fails the run before linting starts:
 
 ```bash
-vaar lint --only=duplicate-key
-vaar lint --skip=trailing-whitespace --skip=extra-blank-line
+./bin/vaar lint --target=examples/broken/.env.example --only=duplicate-key
+./bin/vaar lint --target=examples/broken/.env.example --skip=trailing-whitespace --skip=extra-blank-line
 ```
 
 ```text
-error duplicate-key .env:4 APP_ENV is defined more than once
+error duplicate-key examples/broken/.env.example:4 APP_ENV is defined more than once
 ```
 
-### Choosing A Scope
+### Choosing Search Scope
 
-By default Vaar walks the whole repository. Narrow the scope with `--target` for
-one file or `--target-dir` for one tree; the two are mutually exclusive:
+By default, Vaar walks the whole repository. Narrow the scope with `--target` for one file or `--target-dir` for one tree; the two are mutually exclusive:
 
 ```bash
 vaar lint --target=.env.staging
@@ -200,11 +183,8 @@ vaar lint --target-dir=src
 
 ## Where To Go Next
 
-- **Every flag, output detail and exit code:** [Lint Guide](../lint/README.md).
-- **The full command map:** [Usage](../usage.md).
-- **What each rule catches, with good and bad examples:**
-  [Rule Reference](../lint/rules/README.md).
-- **Package boundaries and where new code belongs:**
-  [System Overview](../system-overview.md).
-- **Contributing a change or a new rule:**
-  [CONTRIBUTING.md](../../CONTRIBUTING.md).
+- Every flag, output detail and exit code: [Lint Guide](../lint/README.md).
+- The full command map: [Usage](../usage.md).
+- What each rule catches, with good and bad examples: [Rule Reference](../lint/rules/README.md).
+- Package boundaries and where new code belongs: [System Overview](../system-overview.md).
+- Contributing a change or a new rule: [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/docs/primer/README.md
+++ b/docs/primer/README.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 -->
 
 # Vaar Primer
 
-A fast, hands-on tour of Vaar for new developers. Read this end to end and you
+A fast, hands-on tour of Vaar for new developers. Read this end-to-end and you
 will know what Vaar is, how a lint run flows through the codebase and how to run
 it yourself. It should take about ten minutes.
 
@@ -16,7 +16,7 @@ for package boundaries, [Usage](../usage.md) for the command map and
 ### What Vaar Is
 
 Vaar is a repo-aware linter for environment variables, shipped as a single Go
-binary (`cmd/vaar`). The current release focuses on **deterministic dotenv
+binary built from the `cmd/vaar` entrypoint. The current release focuses on **deterministic dotenv
 hygiene**: it discovers `.env` files in a repository, checks each one against a
 built-in rule set, reports findings with file and line numbers and can apply
 safe formatting fixes.


### PR DESCRIPTION
Fixes #9.

Adds `docs/primer/README.md` — a ~10-minute hands-on tour with the issue's requested sections (Foundations, Components, Getting Started, plus Where To Go Next), following the structure of the GitHub CLI primer the issue references (kept as one well-organized file since the content fits; happy to split into per-section files if you prefer that shape). One link line added to the README's Documentation paragraph.

Truthfulness bar: **every command shown was executed against a locally built `./bin/vaar`** and every output block is real (trimmed) output from those runs against the repo's broken example; every flag mentioned exists in `lint --help` on current main. Notably the primer documents `-o/--output` (present and working, though absent from the lint guide — #23/#31 territory) and deliberately omits `--list-rules` (only exists in the open #30, not on main yet).

Components are mapped to their actual packages (`cmd/vaar`, `internal/cli|fs|envfile|lint|lint/rules|report`) and the run-flow description follows `Runner` in `internal/lint/runner.go`.

Gates: `make lint`/`vet`/`build` green (docs-only; the two chmod-0-as-root cli tests fail on clean main too, invisible to CI).

## AI assistance disclosure

Written with AI assistance (Claude); all commands, outputs, and flags were verified against the real binary before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Vaar Primer” for new developers, covering Vaar’s purpose (repo-aware `.env` linting), core principles, the full `vaar lint` workflow (rule selection, scoping, findings, optional `--fix` with re-check), and guidance on interpreting text/JSON output and exit codes.
  * Updated the main documentation to point new developers to the primer after the existing usage entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->