### PR TITLE
docs: add example output to deterministic rule pages

### DIFF
--- a/docs/lint/rules/deterministic/bom-character.md
+++ b/docs/lint/rules/deterministic/bom-character.md
@@ -35,3 +35,22 @@ Remove the BOM.
 ```text
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=bom-character
+```
+
+Bad Example Produces:
+
+```text
+warn bom-character .env:1 file starts with a UTF-8 BOM
+```
+
+> [!NOTE]
+> `\ufeff` above stands for the actual BOM bytes (`EF BB BF`) at the start of the
+> file. A file containing the literal six characters `\ufeff` is not a BOM and
+> does not produce this finding.

--- a/docs/lint/rules/deterministic/duplicate-key.md
+++ b/docs/lint/rules/deterministic/duplicate-key.md
@@ -33,3 +33,17 @@ KEY=other
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=duplicate-key
+```
+
+Bad Example Produces:
+
+```text
+error duplicate-key .env:2 KEY is defined more than once
+```

--- a/docs/lint/rules/deterministic/ending-blank-line.md
+++ b/docs/lint/rules/deterministic/ending-blank-line.md
@@ -36,3 +36,17 @@ KEY=value
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=ending-blank-line
+```
+
+Bad Example Produces:
+
+```text
+warn ending-blank-line .env:2 file must end with exactly one final newline
+```

--- a/docs/lint/rules/deterministic/extra-blank-line.md
+++ b/docs/lint/rules/deterministic/extra-blank-line.md
@@ -40,3 +40,17 @@ KEY=value
 
 OTHER=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=extra-blank-line
+```
+
+Bad Example Produces:
+
+```text
+warn extra-blank-line .env:3 repeated blank line
+```

--- a/docs/lint/rules/deterministic/incorrect-delimiter.md
+++ b/docs/lint/rules/deterministic/incorrect-delimiter.md
@@ -32,3 +32,17 @@ KEY:value
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=incorrect-delimiter
+```
+
+Bad Example Produces:
+
+```text
+error incorrect-delimiter .env:1 KEY uses ':' instead of '='
+```

--- a/docs/lint/rules/deterministic/invalid-key-name.md
+++ b/docs/lint/rules/deterministic/invalid-key-name.md
@@ -36,3 +36,17 @@ bad-key=value
 ```dotenv
 BAD_KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=invalid-key-name
+```
+
+Bad Example Produces:
+
+```text
+error invalid-key-name .env:1 bad-key is not a portable env key name
+```

--- a/docs/lint/rules/deterministic/key-without-value.md
+++ b/docs/lint/rules/deterministic/key-without-value.md
@@ -32,3 +32,17 @@ KEY=
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=key-without-value
+```
+
+Bad Example Produces:
+
+```text
+error key-without-value .env:1 KEY is missing a value
+```

--- a/docs/lint/rules/deterministic/leading-character.md
+++ b/docs/lint/rules/deterministic/leading-character.md
@@ -32,3 +32,17 @@ Remove the leading indentation.
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=leading-character
+```
+
+Bad Example Produces:
+
+```text
+warn leading-character .env:1 line starts with leading whitespace
+```

--- a/docs/lint/rules/deterministic/line-ending.md
+++ b/docs/lint/rules/deterministic/line-ending.md
@@ -35,3 +35,22 @@ KEY=value\r\nOTHER=value\n
 ```text
 KEY=value\nOTHER=value\n
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=line-ending
+```
+
+Bad Example Produces:
+
+```text
+warn line-ending .env:1 file uses mixed CRLF and LF line endings
+```
+
+> [!NOTE]
+> `\r\n` and `\n` above stand for the actual line-ending bytes, so the bad
+> example is a two-line file whose first line ends with CRLF and whose second
+> line ends with LF.

--- a/docs/lint/rules/deterministic/quote-character.md
+++ b/docs/lint/rules/deterministic/quote-character.md
@@ -32,3 +32,17 @@ KEY="value
 ```dotenv
 KEY="value"
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=quote-character
+```
+
+Bad Example Produces:
+
+```text
+error quote-character .env:1 value has unbalanced quotes
+```

--- a/docs/lint/rules/deterministic/space-character.md
+++ b/docs/lint/rules/deterministic/space-character.md
@@ -32,3 +32,17 @@ KEY = value
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=space-character
+```
+
+Bad Example Produces:
+
+```text
+warn space-character .env:1 line has spaces around the key, delimiter or value
+```

--- a/docs/lint/rules/deterministic/value-without-key.md
+++ b/docs/lint/rules/deterministic/value-without-key.md
@@ -32,3 +32,17 @@ just some text
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=value-without-key
+```
+
+Bad Example Produces:
+
+```text
+error value-without-key .env:1 value appears without a valid key
+```


### PR DESCRIPTION
Fixes #8.

Adds an `## Example output` section to 12 of the 13 deterministic rule pages, each showing the command and the finding the bad example actually produces. The section reuses the page's existing `## Bad example` block rather than restating it, and sits after `## Good example` uniformly, keeping the Bad/Good pair contiguous as the template orders them.

**Every pasted output came from running the real binary, and was verified byte-exact afterwards** — a script re-extracts each page's command and expected block, runs it in a temp dir, and diffs. 12/12 match.

### Two things in the issue that turned out to be stale

The issue's sample is `[error] duplicate-key .env:2 KEY is defined more than once`. Real output differs in two ways, both verified against the binary:

1. **No brackets** — the format is `<severity> <rule-id> <file>:<line> <message>`, e.g. `error duplicate-key .env:2 KEY is defined more than once`.
2. **Severity isn't always `error`** — 6 of the 12 rules emit `warn` (`bom-character`, `ending-blank-line`, `extra-blank-line`, `leading-character`, `line-ending`, `space-character`); the other 6 emit `error`. The issue only ever shows `error`, so a contributor copying its format would get the severity wrong on half the pages.

I followed the binary, not the issue. The `Bad Example Produces:` label the issue asks for is preserved verbatim.

### `--only`, and one page deliberately left alone

- **Command shown is `vaar lint --only=<rule-id>`.** Full disclosure: I expected bad examples to incidentally trip other rules, and they don't — **plain `vaar lint` output is byte-identical on all 12 pages**. So `--only` isn't load-bearing today; its remaining value is pinning the pasted output regardless of what else sits in the reader's repo. Trivial to drop if you'd rather the pages show the plain command.
- **`trailing-whitespace.md` has no `Example output` and is untouched.** Its bad example contains no trailing whitespace — it's byte-identical to its good example and produces no finding. Rather than invent output or quietly edit the example, I filed **#39**: Markdown can't render trailing whitespace and editors strip it, so it needs the same "notation stands for real bytes" treatment its neighbours use, and which notation is your call.
- **`bom-character.md` and `line-ending.md`** have the mirror wrinkle — their bad examples use `﻿` / `\r\n` *notation*, which taken literally doesn't trigger their rules (a literal `﻿` string trips `invalid-key-name` instead). Their documented output is from the real bytes, and I added a short note to each page saying the notation stands for actual bytes.

### Also worth flagging
`RULE_TEMPLATE.md` has no `Example output` section, so a rule added from the template won't carry one and the structure will drift immediately — CONTRIBUTING points contributors straight at that template. Left out to keep this PR to one concern; happy to send it. Relatedly, these outputs are now a hand-maintained snapshot with nothing enforcing them, so a reworded rule message would silently stale 12 pages — a golden test would fix that if you want one.

### Gates
`make lint`, `make vet`, `make build` all clean. `make test` passes except the two known environment failures (`TestLintCommandTargetFileReportsUnreadablePath`, `TestLintCommandReturnsInternalErrorWhenDiscoveryFails`), which fail identically on clean `main` here because I run as uid 0 — `chmod 0` is a no-op for root, so the deliberately-unreadable file stays readable. They'd pass in CI.

Disclosure: implemented with AI assistance (Claude Opus), specified, reviewed and independently re-verified by a human-supervised lead — including re-running all 12 documented outputs byte-exact and auditing every touched file for stray control characters (the BOM page is an easy place to leak real bytes; it's clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added example CLI output for deterministic lint rules.
  * Documented expected warnings and errors for malformed `.env` files, including duplicate keys, invalid names, spacing, delimiters, line endings, and missing keys or values.
  * Clarified how special characters and line-ending representations appear in lint output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->