### PR TITLE
feat(lint): add value-without-quotes lint rule

### DIFF
--- a/docs/lint/rules/README.md
+++ b/docs/lint/rules/README.md
@@ -37,6 +37,7 @@ Use the accurate matching evidence level for each rule page:
 | [value-without-key](./deterministic/value-without-key.md)     | Deterministic  | Flags a value-like line that does not have a valid key.     |
 | [leading-character](./deterministic/leading-character.md)     | Deterministic  | Flags leading whitespace before content.                    |
 | [quote-character](./deterministic/quote-character.md)         | Deterministic  | Flags unbalanced quote usage.                               |
+| [value-without-quotes](./deterministic/value-without-quotes.md) | Deterministic  | Flags unquoted values containing whitespace.                |
 | [space-character](./deterministic/space-character.md)         | Deterministic  | Flags spaces around the key, delimiter or value.            |
 | [trailing-whitespace](./deterministic/trailing-whitespace.md) | Deterministic  | Flags trailing spaces or tabs.                              |
 | [ending-blank-line](./deterministic/ending-blank-line.md)     | Deterministic  | Flags a file ending that does not match the current policy. |

--- a/docs/lint/rules/deterministic/value-without-quotes.md
+++ b/docs/lint/rules/deterministic/value-without-quotes.md
@@ -1,8 +1,29 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
 # value-without-quotes
 
-Reports unquoted values containing whitespace.
+Flags unquoted values containing whitespace.
 
-## Bad
+## What it catches
+
+Values that contain spaces or tabs but are not enclosed in matching single or double quotes.
+
+## Why it matters
+
+Unquoted whitespace can be parsed inconsistently across dotenv tooling and can make the intended value ambiguous.
+
+## Evidence level
+
+- `Deterministic`: Vaar can prove this from the parsed file contents alone by checking whether an assigned value contains whitespace outside matching quotes.
+
+## Fix
+
+Wrap the full value in matching single or double quotes.
+
+Automatic fixing is not currently provided because Vaar must avoid changing interpolation behavior, escapes, embedded quotes or inline comment parsing.
+
+## Bad example
 
 ```dotenv
 FOO=BAR BAZ
@@ -10,13 +31,12 @@ WELCOME_MESSAGE=Hello world
 DATABASE_LABEL=Primary database
 ```
 
-## Good
+## Good example
 
 ```dotenv
 FOO="BAR BAZ"
 WELCOME_MESSAGE='Hello world'
 DATABASE_LABEL="Primary database"
-
 FOO=BAR
 PORT=3000
 DEBUG=true
@@ -27,7 +47,3 @@ DEBUG=true
 ```text
 .env:1 value-without-quotes: value containing whitespace should be enclosed in quotes
 ```
-
-## Evidence level
-
-Deterministic

--- a/docs/lint/rules/deterministic/value-without-quotes.md
+++ b/docs/lint/rules/deterministic/value-without-quotes.md
@@ -1,0 +1,33 @@
+# value-without-quotes
+
+Reports unquoted values containing whitespace.
+
+## Bad
+
+```dotenv
+FOO=BAR BAZ
+WELCOME_MESSAGE=Hello world
+DATABASE_LABEL=Primary database
+```
+
+## Good
+
+```dotenv
+FOO="BAR BAZ"
+WELCOME_MESSAGE='Hello world'
+DATABASE_LABEL="Primary database"
+
+FOO=BAR
+PORT=3000
+DEBUG=true
+```
+
+## Example output
+
+```text
+.env:1 value-without-quotes: value containing whitespace should be enclosed in quotes
+```
+
+## Evidence level
+
+Deterministic

--- a/docs/lint/rules/deterministic/value-without-quotes.md
+++ b/docs/lint/rules/deterministic/value-without-quotes.md
@@ -45,5 +45,5 @@ DEBUG=true
 ## Example output
 
 ```text
-.env:1 value-without-quotes: value containing whitespace should be enclosed in quotes
+error value-without-quotes .env:1 value containing whitespace should be enclosed in quotes
 ```

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -122,6 +122,27 @@ func TestLintCommandReportsFindingsInTextAndJSON(t *testing.T) {
 	})
 }
 
+func TestLintCommandOnlyValueWithoutQuotesReportsOnlyThatRule(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=hello world\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--only=value-without-quotes")
+	if err == nil {
+		t.Fatal("expected findings")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	want := "error value-without-quotes .env:1 value containing whitespace should be enclosed in quotes\n"
+	if stdout != want {
+		t.Fatalf("unexpected output: got %q want %q", stdout, want)
+	}
+}
+
 func TestLintCommandRejectsOutputWithoutJSON(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -146,16 +146,21 @@ func TestLintCommandOnlyValueWithoutQuotesReportsOnlyThatRule(t *testing.T) {
 func TestLintCommandSkipValueWithoutQuotesSuppressesThatRule(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")
-	if err := os.WriteFile(path, []byte("KEY=hello world\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("KEY=hello world\nKEY=other\n"), 0o644); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
 
 	stdout, err := runLintCommand(t, root, "--skip=value-without-quotes")
-	if err != nil {
-		t.Fatalf("expected skip run to succeed, got %v", err)
+	if err == nil {
+		t.Fatal("expected remaining findings")
 	}
-	if stdout != "" {
-		t.Fatalf("expected no stdout output, got %q", stdout)
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	want := "error duplicate-key .env:2 KEY is defined more than once\n"
+	if stdout != want {
+		t.Fatalf("unexpected output: got %q want %q", stdout, want)
 	}
 }
 

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -143,6 +143,22 @@ func TestLintCommandOnlyValueWithoutQuotesReportsOnlyThatRule(t *testing.T) {
 	}
 }
 
+func TestLintCommandSkipValueWithoutQuotesSuppressesThatRule(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=hello world\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--skip=value-without-quotes")
+	if err != nil {
+		t.Fatalf("expected skip run to succeed, got %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout output, got %q", stdout)
+	}
+}
+
 func TestLintCommandRejectsOutputWithoutJSON(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")

--- a/internal/lint/rules/all.go
+++ b/internal/lint/rules/all.go
@@ -21,6 +21,7 @@ func All() []lint.Rule {
 		deterministic.NewValueWithoutKey(),
 		deterministic.NewLeadingCharacter(),
 		deterministic.NewQuoteCharacter(),
+		deterministic.NewValueWithoutQuotes(),
 		deterministic.NewSpaceCharacter(),
 		deterministic.NewTrailingWhitespace(),
 		deterministic.NewEndingBlankLine(),

--- a/internal/lint/rules/compat.go
+++ b/internal/lint/rules/compat.go
@@ -22,6 +22,8 @@ func NewLeadingCharacter() lint.Rule { return deterministic.NewLeadingCharacter(
 
 func NewQuoteCharacter() lint.Rule { return deterministic.NewQuoteCharacter() }
 
+func NewValueWithoutQuotes() lint.Rule { return deterministic.NewValueWithoutQuotes() }
+
 func NewSpaceCharacter() lint.Rule { return deterministic.NewSpaceCharacter() }
 
 func NewTrailingWhitespace() lint.Rule { return deterministic.NewTrailingWhitespace() }

--- a/internal/lint/rules/deterministic/value_without_quotes.go
+++ b/internal/lint/rules/deterministic/value_without_quotes.go
@@ -1,0 +1,56 @@
+package deterministic
+
+import (
+	"strings"
+
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
+
+type valueWithoutQuotesRule struct{}
+
+// NewValueWithoutQuotes returns a rule that flags unquoted values
+// containing whitespace.
+func NewValueWithoutQuotes() lint.Rule { return valueWithoutQuotesRule{} }
+
+func (valueWithoutQuotesRule) ID() string { return "value-without-quotes" }
+
+func (valueWithoutQuotesRule) Description() string {
+	return "flags unquoted values containing whitespace"
+}
+
+func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
+	findings := make([]lint.Finding, 0)
+
+	for _, file := range ctx.Files {
+		for _, line := range file.Lines {
+
+			if !line.HasAssignment || !line.HasValue {
+				continue
+			}
+
+			if line.Value == "" {
+				continue
+			}
+
+			if line.QuoteState == envfile.QuoteSingle ||
+				line.QuoteState == envfile.QuoteDouble {
+				continue
+			}
+
+			if strings.ContainsRune(line.Value, ' ') ||
+				strings.ContainsRune(line.Value, '\t') {
+
+				findings = append(findings, finding(
+					valueWithoutQuotesRule{}.ID(),
+					lint.SeverityError,
+					file.Path,
+					line.Number,
+					"value containing whitespace should be enclosed in quotes",
+				))
+			}
+		}
+	}
+
+	return findings, nil
+}

--- a/internal/lint/rules/deterministic/value_without_quotes.go
+++ b/internal/lint/rules/deterministic/value_without_quotes.go
@@ -1,3 +1,8 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package deterministic
 
 import (
@@ -24,7 +29,6 @@ func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 
 	for _, file := range ctx.Files {
 		for _, line := range file.Lines {
-
 			if !line.HasAssignment || !line.HasValue {
 				continue
 			}
@@ -33,14 +37,12 @@ func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				continue
 			}
 
-			if line.QuoteState == envfile.QuoteSingle ||
-				line.QuoteState == envfile.QuoteDouble {
+			if line.QuoteState != envfile.QuoteNone {
 				continue
 			}
 
 			if strings.ContainsRune(line.Value, ' ') ||
 				strings.ContainsRune(line.Value, '\t') {
-
 				findings = append(findings, finding(
 					valueWithoutQuotesRule{}.ID(),
 					lint.SeverityError,

--- a/internal/lint/rules/deterministic/value_without_quotes_test.go
+++ b/internal/lint/rules/deterministic/value_without_quotes_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deterministic_test
+
+import (
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint/rules/deterministic"
+)
+
+func TestValueWithoutQuotes(t *testing.T) {
+	tests := []ruleTestCase{
+		{
+			rule:            deterministic.NewValueWithoutQuotes(),
+			input:           []byte("FOO=BAR BAZ\n"),
+			wantCount:       1,
+			wantLine:        1,
+			wantRule:        "value-without-quotes",
+			wantSeverity:    "error",
+			wantMessagePart: "value containing whitespace should be enclosed in quotes",
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("WELCOME_MESSAGE='Hello world'\n"),
+			wantCount: 0,
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("DATABASE_LABEL=\"Primary database\"\n"),
+			wantCount: 0,
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("FOO=BAR\n"),
+			wantCount: 0,
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("EMPTY=\n"),
+			wantCount: 0,
+		},
+		{
+			rule:            deterministic.NewValueWithoutQuotes(),
+			input:           []byte("TAB_VALUE=hello\tworld\n"),
+			wantCount:       1,
+			wantLine:        1,
+			wantRule:        "value-without-quotes",
+			wantSeverity:    "error",
+			wantMessagePart: "value containing whitespace should be enclosed in quotes",
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("INLINE_COMMENT=value # comment\n"),
+			wantCount: 0,
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("HASH_IN_QUOTES=\"value # not a comment\"\n"),
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		runRuleTest(t, tc)
+	}
+}

--- a/internal/lint/rules/deterministic/value_without_quotes_test.go
+++ b/internal/lint/rules/deterministic/value_without_quotes_test.go
@@ -44,6 +44,15 @@ func TestValueWithoutQuotes(t *testing.T) {
 		},
 		{
 			rule:            deterministic.NewValueWithoutQuotes(),
+			input:           []byte("MULTIPLE_SPACES=hello   world\n"),
+			wantCount:       1,
+			wantLine:        1,
+			wantRule:        "value-without-quotes",
+			wantSeverity:    "error",
+			wantMessagePart: "value containing whitespace should be enclosed in quotes",
+		},
+		{
+			rule:            deterministic.NewValueWithoutQuotes(),
 			input:           []byte("TAB_VALUE=hello\tworld\n"),
 			wantCount:       1,
 			wantLine:        1,
@@ -59,6 +68,11 @@ func TestValueWithoutQuotes(t *testing.T) {
 		{
 			rule:      deterministic.NewValueWithoutQuotes(),
 			input:     []byte("HASH_IN_QUOTES=\"value # not a comment\"\n"),
+			wantCount: 0,
+		},
+		{
+			rule:      deterministic.NewValueWithoutQuotes(),
+			input:     []byte("BROKEN=\"hello world\n"),
 			wantCount: 0,
 		},
 	}


### PR DESCRIPTION
## Summary

Closes  #43

Adds the `value-without-quotes` deterministic lint rule.

### Changes

- Adds the `value-without-quotes` rule.
- Detects unquoted values containing spaces or tabs.
- Ignores quoted values.
- Uses the parsed value to avoid false positives from inline comments.
- Adds unit tests.
- Adds rule documentation.
- Registers the rule in the built-in rule set.

## Testing

- [x] go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

- **New Features**
  - Added deterministic lint rule `value-without-quotes` to flag unquoted `.env` values containing spaces or tabs (no automatic fix).
  - Enabled in the default rule set, so it respects selection and suppression flags.

- **Documentation**
  - Added a new rule page and updated the rule catalog with evidence level and “Bad/Good” diagnostic examples.

- **Tests**
  - Added unit and CLI end-to-end coverage to verify reporting and correct `--only` / `--skip` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->