### PR TITLE
feat(lint): give rules a fix half; derive fixability and the FIXABLE column from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ vaar lint --target=.env.staging
 vaar lint --target-dir=src
 ```
 
-To list every registered rule with its description:
+To list every registered rule, whether `--fix` repairs it and its description:
 
 ```bash
 vaar lint --list-rules

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -101,9 +101,9 @@ vaar lint --skip=trailing-whitespace --skip=extra-blank-line
 
 ### `--list-rules`
 
-Prints every registered rule in alphabetical order with its canonical name and a concise description, then exits successfully. This is an informational mode: it does not discover dotenv files, run rules or require a repository, so it works from any directory.
+Prints every registered rule in alphabetical order with its canonical name, whether `--fix` repairs it and a concise description, then exits successfully. This is an informational mode: it does not discover dotenv files, run rules or require a repository, so it works from any directory.
 
-The output uses NAME and DESCRIPTION columns. A FIXABLE column is not included because the rule registry does not currently expose fixability metadata.
+The output uses NAME, FIXABLE and DESCRIPTION columns. The FIXABLE column reads `yes` when a rule carries a fix half that the safe `--fix` pass composes and `no` otherwise. Fixability is intrinsic to the rule, and a drift test pins each `yes`/`no` against the actual fix pass, so the column cannot silently disagree with what `--fix` does.
 
 `--list-rules` cannot be combined with execution or output flags: `--only`, `--skip`, `--fix`, `--target`, `--target-dir`, `--output` or `--json`; doing so returns a usage error naming the conflicting flag.
 

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -37,7 +37,7 @@ Use --only to narrow the selected rules, --skip to remove rules after
 selection, --target to lint one file and --target-dir to discover files under
 one directory. --output writes JSON to a file instead of stdout and requires
 --json. Use --list-rules to print every registered rule with its description
-without running anything:
+and whether --fix repairs it, without running anything:
 
   vaar lint --only=duplicate-key
   vaar lint --only=duplicate-key --only=invalid-key-name
@@ -143,7 +143,7 @@ Use either --target or --target-dir, not both.`,
 	flags.StringVar(&selection.TargetDir, "target-dir", "", "Recursively lint dotenv files under the specified directory.")
 	flags.StringArrayVar(&selection.OnlyRules, "only", nil, "Run only the specified rule ID. Can be repeated.")
 	flags.StringArrayVar(&selection.SkipRules, "skip", nil, "Skip the specified rule ID. Can be repeated.")
-	flags.BoolVar(&lintListRules, "list-rules", false, "List every registered rule and its description, then exit")
+	flags.BoolVar(&lintListRules, "list-rules", false, "List every registered rule, whether --fix repairs it and its description, then exit")
 
 	registerLintFlagCompletions(cmd)
 
@@ -178,8 +178,8 @@ func firstListRulesConflict(selection lint.Options, fix, json bool, output strin
 }
 
 // writeRuleList prints the registered rules in alphabetical order with aligned
-// NAME and DESCRIPTION columns. Fixability metadata is not part of the Rule
-// interface, so no FIXABLE column is emitted.
+// NAME, FIXABLE and DESCRIPTION columns. Fixability comes from the optional
+// lint.FixableRule marker, so rules that do not carry a fix half read as "no".
 func writeRuleList(w io.Writer, all []lint.Rule) error {
 	sorted := make([]lint.Rule, len(all))
 	copy(sorted, all)
@@ -193,14 +193,23 @@ func writeRuleList(w io.Writer, all []lint.Rule) error {
 			nameWidth = n
 		}
 	}
+	fixableWidth := len("FIXABLE")
 
-	if _, err := fmt.Fprintf(w, "%-*s  DESCRIPTION\n", nameWidth, "NAME"); err != nil {
+	if _, err := fmt.Fprintf(w, "%-*s  %-*s  DESCRIPTION\n", nameWidth, "NAME", fixableWidth, "FIXABLE"); err != nil {
 		return err
 	}
 	for _, rule := range sorted {
-		if _, err := fmt.Fprintf(w, "%-*s  %s\n", nameWidth, rule.ID(), rule.Description()); err != nil {
+		if _, err := fmt.Fprintf(w, "%-*s  %-*s  %s\n", nameWidth, rule.ID(), fixableWidth, fixableLabel(rule), rule.Description()); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// fixableLabel renders the FIXABLE column value for one rule.
+func fixableLabel(rule lint.Rule) string {
+	if lint.IsFixable(rule) {
+		return "yes"
+	}
+	return "no"
 }

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -929,6 +929,9 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 		t.Fatalf("expected output to start with NAME header, got %q", output)
 	}
 	header, _, _ := strings.Cut(output, "\n")
+	if !strings.Contains(header, "FIXABLE") {
+		t.Fatalf("expected header to contain FIXABLE column, got %q", header)
+	}
 	if !strings.Contains(header, "DESCRIPTION") {
 		t.Fatalf("expected header to contain DESCRIPTION column, got %q", header)
 	}
@@ -946,19 +949,29 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 	}
 
 	descriptions := make(map[string]string, len(expected))
+	fixLabels := make(map[string]string, len(expected))
 	for _, rule := range expected {
 		description := strings.TrimSpace(rule.Description())
 		if description == "" {
 			t.Fatalf("rule %q has an empty description", rule.ID())
 		}
 		descriptions[rule.ID()] = description
+		if lint.IsFixable(rule) {
+			fixLabels[rule.ID()] = "yes"
+		} else {
+			fixLabels[rule.ID()] = "no"
+		}
 	}
 
 	gotIDs := make([]string, 0, len(expected))
 	for _, line := range lines[1:] {
-		id, description, found := strings.Cut(strings.TrimSpace(line), " ")
+		id, rest, found := strings.Cut(strings.TrimSpace(line), " ")
 		if !found {
-			t.Fatalf("expected rule line to carry a description: %q", line)
+			t.Fatalf("expected rule line to carry a fixable flag and description: %q", line)
+		}
+		fixable, description, found := strings.Cut(strings.TrimSpace(rest), " ")
+		if !found {
+			t.Fatalf("expected rule line to carry a description after the fixable flag: %q", line)
 		}
 		gotIDs = append(gotIDs, id)
 
@@ -969,10 +982,65 @@ func TestLintCommandListsRulesAlphabetically(t *testing.T) {
 		if got := strings.TrimSpace(description); got != want {
 			t.Fatalf("wrong description on the %q line:\ngot  %q\nwant %q", id, got, want)
 		}
+		if got := strings.TrimSpace(fixable); got != fixLabels[id] {
+			t.Fatalf("wrong fixable flag on the %q line:\ngot  %q\nwant %q", id, got, fixLabels[id])
+		}
 	}
 
 	if !slicesEqual(gotIDs, wantIDs) {
 		t.Fatalf("unexpected rule order or content:\ngot  %v\nwant %v", gotIDs, wantIDs)
+	}
+}
+
+func TestLintCommandListRulesShowsFixableColumn(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"lint", "--list-rules"})
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --list-rules to succeed, got %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	header := lines[0]
+
+	// The FIXABLE column sits between NAME and DESCRIPTION.
+	nameIdx := strings.Index(header, "NAME")
+	fixableIdx := strings.Index(header, "FIXABLE")
+	descriptionIdx := strings.Index(header, "DESCRIPTION")
+	if nameIdx < 0 || fixableIdx < 0 || descriptionIdx < 0 {
+		t.Fatalf("expected NAME, FIXABLE and DESCRIPTION headers, got %q", header)
+	}
+	if !(nameIdx < fixableIdx && fixableIdx < descriptionIdx) {
+		t.Fatalf("expected column order NAME < FIXABLE < DESCRIPTION, got %q", header)
+	}
+
+	// Spot-check both column values against known rules: a rule the fix pass
+	// repairs reads "yes" and one it cannot reads "no".
+	wantLabels := map[string]string{
+		"bom-character":       "yes",
+		"duplicate-key":       "no",
+		"incorrect-delimiter": "no",
+		"trailing-whitespace": "yes",
+	}
+	seen := map[string]string{}
+	for _, line := range lines[1:] {
+		id, rest, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		fixable, _, ok := strings.Cut(strings.TrimSpace(rest), " ")
+		if !ok {
+			continue
+		}
+		seen[id] = strings.TrimSpace(fixable)
+	}
+	for id, want := range wantLabels {
+		if got := seen[id]; got != want {
+			t.Fatalf("rule %q: got fixable label %q, want %q", id, got, want)
+		}
 	}
 }
 

--- a/internal/envfile/fix.go
+++ b/internal/envfile/fix.go
@@ -1,0 +1,138 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package envfile
+
+import "bytes"
+
+// The functions in this file decompose the historical whole-file Normalize
+// pass into one surgical transform per fixable lint rule. Each transform only
+// repairs the single defect its rule reports and leaves every other byte
+// untouched, so callers can compose a subset to scope --fix to selected rules.
+//
+// Composing all of them in the canonical pipeline order
+//
+//	StripBOM -> NormalizeLineEndings -> TrimTrailingWhitespace ->
+//	CollapseBlankLines -> TrimFinalBlankLines
+//
+// reproduces the old Normalize output byte for byte. The equivalence is pinned
+// by TestFixDataMatchesLegacyNormalize in internal/lint/rules against a frozen
+// copy of the original Normalize, so this decomposition cannot silently drift.
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// StripBOM removes a leading UTF-8 BOM so the first key on disk is not silently
+// altered by the marker. It is the fix half of the bom-character rule.
+func StripBOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
+}
+
+// NormalizeLineEndings converts CRLF and lone CR line endings to LF so a file
+// does not switch newline style midstream. It is the fix half of the
+// line-ending rule.
+func NormalizeLineEndings(data []byte) []byte {
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	data = bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
+	return data
+}
+
+// TrimTrailingWhitespace removes trailing spaces and tabs from every line and
+// empties any line that is nothing but whitespace. It is the fix half of the
+// trailing-whitespace rule.
+//
+// It splits on each line delimiter (LF, CRLF or a lone CR) and preserves that
+// delimiter verbatim, stripping only the spaces and tabs immediately before it,
+// so "KEY=value  \r\n" becomes "KEY=value\r\n". Trimming before the delimiter
+// (rather than splitting on LF alone) lets a scoped --fix repair a CRLF file
+// whose trailing whitespace sits ahead of a surviving CR. The full fix pipeline
+// runs NormalizeLineEndings first, so no CR reaches this transform there and
+// the composed output is unchanged; the CR handling matters only when this
+// rule's fix runs on its own.
+func TrimTrailingWhitespace(data []byte) []byte {
+	var out bytes.Buffer
+	for i := 0; i < len(data); {
+		start := i
+		for i < len(data) && data[i] != '\n' && data[i] != '\r' {
+			i++
+		}
+		content := data[start:i]
+
+		var delim []byte
+		if i < len(data) {
+			if data[i] == '\r' && i+1 < len(data) && data[i+1] == '\n' {
+				delim = data[i : i+2]
+				i += 2
+			} else {
+				delim = data[i : i+1]
+				i++
+			}
+		}
+
+		if len(bytes.TrimSpace(content)) != 0 {
+			// A line with real content keeps it with trailing spaces and tabs
+			// stripped; a whitespace-only line (including stray vertical tabs
+			// or form feeds) carries none, so only its delimiter survives.
+			out.Write(bytes.TrimRight(content, " \t"))
+		}
+		out.Write(delim)
+	}
+	return out.Bytes()
+}
+
+// CollapseBlankLines collapses each run of consecutive blank lines to a single
+// blank line. It is the fix half of the extra-blank-line rule. A line counts as
+// blank when it holds only spaces and tabs, matching the parser's IsBlank.
+//
+// Splitting on LF leaves a CR at the end of each line of a CRLF file, so the
+// blank check strips one trailing CR first; the stored line keeps its CR, so
+// retained lines rejoin with their CRLF endings intact.
+func CollapseBlankLines(data []byte) []byte {
+	lines := bytes.Split(data, []byte("\n"))
+	out := make([][]byte, 0, len(lines))
+	prevBlank := false
+	for _, line := range lines {
+		if isBlankLine(bytes.TrimSuffix(line, []byte("\r"))) {
+			if prevBlank {
+				continue
+			}
+			prevBlank = true
+		} else {
+			prevBlank = false
+		}
+		out = append(out, line)
+	}
+	return bytes.Join(out, []byte("\n"))
+}
+
+// TrimFinalBlankLines drops trailing blank lines and leaves exactly one final
+// newline on non-empty content, returning empty bytes for an all-blank or empty
+// file. It is the fix half of the ending-blank-line rule.
+//
+// Splitting on LF leaves a CR at the end of each line of a CRLF file, so the
+// blank check strips one trailing CR first; the stored line keeps its CR, so a
+// retained final line is written back with its CRLF ending intact.
+func TrimFinalBlankLines(data []byte) []byte {
+	lines := bytes.Split(data, []byte("\n"))
+	end := len(lines)
+	for end > 0 && isBlankLine(bytes.TrimSuffix(lines[end-1], []byte("\r"))) {
+		end--
+	}
+	if end == 0 {
+		return []byte{}
+	}
+
+	var buf bytes.Buffer
+	for _, line := range lines[:end] {
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes()
+}
+
+// isBlankLine reports whether a raw line holds only spaces and tabs, matching
+// the parser's IsBlank so the fix transforms and the rules agree on blankness.
+func isBlankLine(line []byte) bool {
+	return len(bytes.TrimLeft(line, " \t")) == 0
+}

--- a/internal/envfile/fix_test.go
+++ b/internal/envfile/fix_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package envfile_test verifies the per-rule fix transforms that decompose the
+// historical whole-file Normalize pass.
+package envfile_test
+
+import (
+	"testing"
+
+	"github.com/envaar/vaar/internal/envfile"
+)
+
+// TestTrimTrailingWhitespacePreservesDelimiters pins that the transform strips
+// spaces and tabs immediately before each line delimiter while preserving the
+// delimiter itself, so a scoped --fix on a CRLF or lone-CR file repairs the
+// trailing whitespace without rewriting the line endings. It also pins the
+// whitespace-only-line emptying that the full-composition legacy parity relies
+// on, including the vertical-tab and form-feed cases.
+func TestTrimTrailingWhitespacePreservesDelimiters(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "crlf trailing spaces trimmed, crlf preserved",
+			in:   "KEY=value  \r\nX=1\r\n",
+			want: "KEY=value\r\nX=1\r\n",
+		},
+		{
+			name: "crlf trailing tabs trimmed, crlf preserved",
+			in:   "KEY=value\t\t\r\nX=1\r\n",
+			want: "KEY=value\r\nX=1\r\n",
+		},
+		{
+			name: "lone cr trailing spaces trimmed, cr preserved",
+			in:   "KEY=value  \rX=1\r",
+			want: "KEY=value\rX=1\r",
+		},
+		{
+			name: "lf trailing spaces trimmed, lf preserved",
+			in:   "KEY=value  \nX=1\n",
+			want: "KEY=value\nX=1\n",
+		},
+		{
+			name: "final unterminated line trimmed",
+			in:   "KEY=value  ",
+			want: "KEY=value",
+		},
+		{
+			name: "clean crlf untouched",
+			in:   "A=1\r\nB=2\r\n",
+			want: "A=1\r\nB=2\r\n",
+		},
+		{
+			name: "whitespace-only crlf line empties to its delimiter",
+			in:   "A=1\r\n  \t\r\nB=2\r\n",
+			want: "A=1\r\n\r\nB=2\r\n",
+		},
+		{
+			name: "whitespace-only lf line empties to its delimiter",
+			in:   "A=1\n  \t\nB=2\n",
+			want: "A=1\n\nB=2\n",
+		},
+		{
+			name: "vertical tab line empties, delimiter kept",
+			in:   "A=1\n  \v  \nB=2\n",
+			want: "A=1\n\nB=2\n",
+		},
+		{
+			name: "form feed line empties, delimiter kept",
+			in:   "A=1\n\f\nB=2\n",
+			want: "A=1\n\nB=2\n",
+		},
+		{
+			name: "empty input stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := envfile.TrimTrailingWhitespace([]byte(tc.in))
+			if string(got) != tc.want {
+				t.Fatalf("TrimTrailingWhitespace(%q) = %q, want %q", tc.in, string(got), tc.want)
+			}
+		})
+	}
+}
+
+// TestCollapseBlankLinesPreservesCRLF pins that the transform recognizes blank
+// lines in a CRLF file (where splitting on LF leaves a CR on each segment) and
+// collapses each run to one blank line, while retained lines keep their CR so
+// the rejoined output preserves CRLF endings byte for byte.
+func TestCollapseBlankLinesPreservesCRLF(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "consecutive blank crlf lines collapse to one",
+			in:   "A=1\r\n\r\n\r\nB=2\r\n",
+			want: "A=1\r\n\r\nB=2\r\n",
+		},
+		{
+			name: "whitespace-only blank crlf lines collapse to one",
+			in:   "A=1\r\n  \r\n\t\r\nB=2\r\n",
+			want: "A=1\r\n  \r\nB=2\r\n",
+		},
+		{
+			name: "single blank crlf line kept",
+			in:   "A=1\r\n\r\nB=2\r\n",
+			want: "A=1\r\n\r\nB=2\r\n",
+		},
+		{
+			name: "crlf content lines byte exact",
+			in:   "A=1\r\nB=2\r\n",
+			want: "A=1\r\nB=2\r\n",
+		},
+		{
+			name: "lf blank lines still collapse",
+			in:   "A=1\n\n\nB=2\n",
+			want: "A=1\n\nB=2\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := envfile.CollapseBlankLines([]byte(tc.in))
+			if string(got) != tc.want {
+				t.Fatalf("CollapseBlankLines(%q) = %q, want %q", tc.in, string(got), tc.want)
+			}
+		})
+	}
+}
+
+// TestTrimFinalBlankLinesPreservesCRLF pins that the transform recognizes
+// trailing blank lines in a CRLF file (where splitting on LF leaves a CR on
+// each segment) and trims them to exactly one final newline, while a retained
+// content line keeps its CR so its CRLF ending survives byte for byte.
+func TestTrimFinalBlankLinesPreservesCRLF(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "trailing blank crlf lines trimmed",
+			in:   "A=1\r\n\r\n\r\n",
+			want: "A=1\r\n",
+		},
+		{
+			name: "trailing whitespace-only blank crlf lines trimmed",
+			in:   "A=1\r\n  \r\n\t\r\n",
+			want: "A=1\r\n",
+		},
+		{
+			name: "missing final newline added, crlf kept",
+			in:   "A=1\r\nB=2\r",
+			want: "A=1\r\nB=2\r\n",
+		},
+		{
+			name: "retained crlf content line byte exact",
+			in:   "foo\r\n\r\n",
+			want: "foo\r\n",
+		},
+		{
+			name: "all-blank crlf file empties",
+			in:   "\r\n  \r\n",
+			want: "",
+		},
+		{
+			name: "lf trailing blank lines still trimmed",
+			in:   "A=1\n\n\n",
+			want: "A=1\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := envfile.TrimFinalBlankLines([]byte(tc.in))
+			if string(got) != tc.want {
+				t.Fatalf("TrimFinalBlankLines(%q) = %q, want %q", tc.in, string(got), tc.want)
+			}
+		})
+	}
+}

--- a/internal/envfile/writer.go
+++ b/internal/envfile/writer.go
@@ -5,60 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package envfile
 
-import (
-	"os"
-	"strings"
-)
-
-// Normalize strips a UTF-8 BOM, trims trailing whitespace, collapses repeated
-// blank lines and leaves exactly one trailing newline on non-empty files so
-// --fix only makes safe, line-local edits.
-func Normalize(data []byte) []byte {
-	lines := Split(data)
-	if len(lines) == 0 {
-		return []byte{}
-	}
-
-	normalized := make([]string, 0, len(lines))
-	prevBlank := false
-
-	for i, raw := range lines {
-		content := raw.Content
-		if i == 0 && strings.HasPrefix(content, "\ufeff") {
-			content = strings.TrimPrefix(content, "\ufeff")
-		}
-
-		content = strings.TrimRight(content, " \t")
-		blank := strings.TrimSpace(content) == ""
-		if blank {
-			if prevBlank {
-				continue
-			}
-			prevBlank = true
-			normalized = append(normalized, "")
-			continue
-		}
-
-		prevBlank = false
-		normalized = append(normalized, content)
-	}
-
-	for len(normalized) > 0 && normalized[len(normalized)-1] == "" {
-		normalized = normalized[:len(normalized)-1]
-	}
-
-	if len(normalized) == 0 {
-		return []byte{}
-	}
-
-	var builder strings.Builder
-	for _, line := range normalized {
-		builder.WriteString(line)
-		builder.WriteByte('\n')
-	}
-
-	return []byte(builder.String())
-}
+import "os"
 
 // Write writes data back to path and preserves the file's existing permissions
 // when the file already exists.

--- a/internal/lint/compose_unknown_test.go
+++ b/internal/lint/compose_unknown_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+)
+
+// markerStripRule is an external-style rule with a fix half that is not named
+// in the canonical fixOrder, standing in for a third-party FixableRule. Its Fix
+// is order-sensitive: it resolves the X marker to "lf" or "crlf" depending on
+// whether the data it receives still contains a CR, so the composition can
+// prove not just that the fix ran but that it ran after the canonical prefix.
+type markerStripRule struct{}
+
+func (markerStripRule) ID() string                               { return "zz-custom" }
+func (markerStripRule) Description() string                      { return "resolves the X marker by line-ending state" }
+func (markerStripRule) Run(lint.Context) ([]lint.Finding, error) { return nil, nil }
+func (markerStripRule) Fix(data []byte) []byte {
+	if bytes.Contains(data, []byte("\r")) {
+		return bytes.ReplaceAll(data, []byte("X"), []byte("crlf"))
+	}
+	return bytes.ReplaceAll(data, []byte("X"), []byte("lf"))
+}
+
+// replaceByteRule is an order-observable external rule: it rewrites one byte to
+// another, so composing two of them in different orders yields different bytes.
+type replaceByteRule struct {
+	id       string
+	from, to byte
+}
+
+func (r replaceByteRule) ID() string                             { return r.id }
+func (replaceByteRule) Description() string                      { return "rewrites one byte to another" }
+func (replaceByteRule) Run(lint.Context) ([]lint.Finding, error) { return nil, nil }
+func (r replaceByteRule) Fix(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte{r.from}, []byte{r.to})
+}
+
+// TestFixDataAppliesUnknownFixableRule proves a fixable rule not named in the
+// canonical fixOrder is still discovered as fixable and its fix half runs after
+// the canonical prefix, rather than silently doing nothing. The assertion is
+// order-sensitive, not just presence-sensitive: the input carries CRLF endings,
+// and the custom fix resolves its marker to "lf" only if the CR is already gone
+// by the time it runs. If the external fix ran before line-ending's Fix (the
+// canonical fixOrder prefix), the CR would still be present and the marker
+// would resolve to "crlf" instead, failing the "lf" assertion below.
+func TestFixDataAppliesUnknownFixableRule(t *testing.T) {
+	custom := markerStripRule{}
+
+	if !lint.IsFixable(custom) {
+		t.Fatalf("markerStripRule must read as fixable")
+	}
+
+	all := append(rules.All(), custom)
+	// The canonical fixes normalize the CRLF ending and trim the trailing
+	// whitespace before the unknown rule's fix resolves the marker; only then
+	// has the CR already been normalized away.
+	input := []byte("KEY=valueX  \r\n")
+	want := []byte("KEY=valuelf\n")
+	if got := lint.FixData(all, input); !bytes.Equal(got, want) {
+		t.Fatalf("unknown fixable rule not applied after canonical prefix: got %q want %q", got, want)
+	}
+}
+
+// TestFixDataAppliesUnknownFixesInIDOrder proves two fixable rules absent from
+// fixOrder run in deterministic ascending-ID order regardless of the order they
+// are passed in. Applied zz-a before zz-b, "1" -> "2" -> "3"; the reverse order
+// would yield "2", so the asserted "3" pins the ID ordering.
+func TestFixDataAppliesUnknownFixesInIDOrder(t *testing.T) {
+	ruleA := replaceByteRule{id: "zz-a", from: '1', to: '2'}
+	ruleB := replaceByteRule{id: "zz-b", from: '2', to: '3'}
+
+	// Passed in reverse ID order to prove the composition sorts by ID.
+	got := lint.FixData([]lint.Rule{ruleB, ruleA}, []byte("1\n"))
+	if want := []byte("3\n"); !bytes.Equal(got, want) {
+		t.Fatalf("unknown fixes ran out of ID order: got %q want %q", got, want)
+	}
+}

--- a/internal/lint/fix.go
+++ b/internal/lint/fix.go
@@ -8,13 +8,79 @@ package lint
 import (
 	"bytes"
 	"os"
+	"sort"
 
 	"github.com/envaar/vaar/internal/envfile"
 )
 
-// ApplyFixes normalizes each discovered dotenv file and reports whether any
-// file changed on disk.
-func ApplyFixes(paths []string) (bool, error) {
+// fixOrder lists the fixable rule IDs in the order their fix halves must
+// compose to reproduce the historical whole-file normalization exactly. The
+// order is load-bearing: line endings are normalized before trailing
+// whitespace is trimmed, and blank runs are collapsed before the final blank
+// lines are removed. TestFixDataMatchesLegacyNormalize pins this against a
+// frozen copy of the original Normalize, so the order cannot drift silently.
+var fixOrder = []string{
+	"bom-character",
+	"line-ending",
+	"trailing-whitespace",
+	"extra-blank-line",
+	"ending-blank-line",
+}
+
+// composeFixes returns the fix halves of the fixable rules among the provided
+// set. The fixable rules named in fixOrder come first, in that canonical order,
+// so the built-in pipeline reproduces the historical normalization. Any other
+// fixable rule — an external rule not named in fixOrder — is appended after that
+// prefix in ascending-ID order, so its fix actually runs instead of silently
+// doing nothing despite the rule showing FIXABLE in --list-rules. Rules without
+// a fix half contribute nothing, so the caller still controls which repairs run
+// by choosing which rules to pass in.
+func composeFixes(rules []Rule) []func([]byte) []byte {
+	byID := make(map[string]FixableRule, len(rules))
+	for _, rule := range rules {
+		if fixable, ok := rule.(FixableRule); ok {
+			byID[rule.ID()] = fixable
+		}
+	}
+
+	inOrder := make(map[string]bool, len(fixOrder))
+	fixes := make([]func([]byte) []byte, 0, len(byID))
+	for _, id := range fixOrder {
+		inOrder[id] = true
+		if fixable, ok := byID[id]; ok {
+			fixes = append(fixes, fixable.Fix)
+		}
+	}
+
+	extra := make([]string, 0, len(byID))
+	for id := range byID {
+		if !inOrder[id] {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(extra)
+	for _, id := range extra {
+		fixes = append(fixes, byID[id].Fix)
+	}
+	return fixes
+}
+
+// FixData applies the fix halves of the given rules to data and returns the
+// repaired bytes: the canonical fixOrder rules first, then any other fixable
+// rule in ascending-ID order. Passing every built-in rule reproduces the
+// historical whole-file normalization; passing a subset scopes the repair to
+// those rules. It performs no I/O so tests can pin the composition directly.
+func FixData(rules []Rule, data []byte) []byte {
+	for _, fix := range composeFixes(rules) {
+		data = fix(data)
+	}
+	return data
+}
+
+// ApplyFixes repairs each discovered dotenv file by composing the fix halves of
+// the provided rules and reports whether any file changed on disk.
+func ApplyFixes(rules []Rule, paths []string) (bool, error) {
+	fixes := composeFixes(rules)
 	changed := false
 	for _, path := range paths {
 		data, err := os.ReadFile(path)
@@ -22,7 +88,10 @@ func ApplyFixes(paths []string) (bool, error) {
 			return false, err
 		}
 
-		fixed := envfile.Normalize(data)
+		fixed := data
+		for _, fix := range fixes {
+			fixed = fix(fixed)
+		}
 		if bytes.Equal(fixed, data) {
 			continue
 		}

--- a/internal/lint/fix_test.go
+++ b/internal/lint/fix_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
 )
 
 func TestApplyFixesNormalizesSafeFormatting(t *testing.T) {
@@ -22,7 +23,7 @@ func TestApplyFixesNormalizesSafeFormatting(t *testing.T) {
 		t.Fatalf("write failed: %v", err)
 	}
 
-	changed, err := lint.ApplyFixes([]string{path})
+	changed, err := lint.ApplyFixes(rules.All(), []string{path})
 	if err != nil {
 		t.Fatalf("apply fixes failed: %v", err)
 	}

--- a/internal/lint/fixability.go
+++ b/internal/lint/fixability.go
@@ -1,0 +1,32 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint
+
+// FixableRule is an optional interface a Rule may implement to supply the fix
+// half that repairs its own findings. It stays separate from Rule on purpose:
+// widening Rule would force every external rule implementer to recompile, so
+// the fix half is expressed as an opt-in marker discovered through a type
+// assertion instead.
+//
+// Fixability is intrinsic and cannot drift: a rule is fixable exactly when it
+// carries a Fix method, and IsFixable and the --list-rules FIXABLE column both
+// key on the presence of that method rather than a hand-maintained claim.
+// ApplyFixes composes these Fix halves in a canonical order to repair files.
+type FixableRule interface {
+	// Fix returns data with this rule's findings repaired, so composing fix
+	// halves scopes --fix to selected rules. Repairing a finding may normalize
+	// the related file-wide property (for example converting every line ending
+	// to LF, or emptying whitespace-only lines), so bytes beyond the reported
+	// finding are not guaranteed to be left untouched.
+	Fix(data []byte) []byte
+}
+
+// IsFixable reports whether a rule supplies a fix half through FixableRule.
+// Rules that do not implement the marker are treated as not auto-fixable.
+func IsFixable(r Rule) bool {
+	_, ok := r.(FixableRule)
+	return ok
+}

--- a/internal/lint/fixability_test.go
+++ b/internal/lint/fixability_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint"
+)
+
+// plainRule implements Rule without a fix half.
+type plainRule struct{}
+
+func (plainRule) ID() string                               { return "plain" }
+func (plainRule) Description() string                      { return "no fix half" }
+func (plainRule) Run(lint.Context) ([]lint.Finding, error) { return nil, nil }
+
+// fixableRule implements Rule and supplies a fix half, so it is intrinsically
+// fixable: there is no separate boolean that could disagree with the method.
+type fixableRule struct{ plainRule }
+
+func (fixableRule) ID() string { return "line-ending" }
+func (fixableRule) Fix(data []byte) []byte {
+	return bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+}
+
+func TestIsFixable(t *testing.T) {
+	cases := []struct {
+		name string
+		rule lint.Rule
+		want bool
+	}{
+		{name: "no fix half", rule: plainRule{}, want: false},
+		{name: "has fix half", rule: fixableRule{}, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lint.IsFixable(tc.rule); got != tc.want {
+				t.Fatalf("IsFixable(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFixDataAppliesOnlyProvidedRuleFixes proves the composition runs a rule's
+// fix half only when that rule is passed in, and applies nothing for a rule
+// without a fix half.
+func TestFixDataAppliesOnlyProvidedRuleFixes(t *testing.T) {
+	input := []byte("KEY=one\r\nKEY2=two\r\n")
+
+	if got := lint.FixData([]lint.Rule{plainRule{}}, input); !bytes.Equal(got, input) {
+		t.Fatalf("a rule without a fix half must not change data: got %q", got)
+	}
+
+	want := []byte("KEY=one\nKEY2=two\n")
+	if got := lint.FixData([]lint.Rule{fixableRule{}}, input); !bytes.Equal(got, want) {
+		t.Fatalf("line-ending fix half not applied: got %q want %q", got, want)
+	}
+}

--- a/internal/lint/rules/deterministic/bom_character.go
+++ b/internal/lint/rules/deterministic/bom_character.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type bomCharacterRule struct{}
 
@@ -17,6 +20,9 @@ func (bomCharacterRule) ID() string { return "bom-character" }
 func (bomCharacterRule) Description() string {
 	return "flags a UTF-8 BOM at the start of a dotenv file"
 }
+
+// Fix strips the leading UTF-8 BOM so the first key on disk is not altered.
+func (bomCharacterRule) Fix(data []byte) []byte { return envfile.StripBOM(data) }
 
 func (bomCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/ending_blank_line.go
+++ b/internal/lint/rules/deterministic/ending_blank_line.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type endingBlankLineRule struct{}
 
@@ -17,6 +20,9 @@ func (endingBlankLineRule) ID() string { return "ending-blank-line" }
 func (endingBlankLineRule) Description() string {
 	return "flags files that do not end with one clean trailing newline"
 }
+
+// Fix removes trailing blank lines and leaves exactly one final newline.
+func (endingBlankLineRule) Fix(data []byte) []byte { return envfile.TrimFinalBlankLines(data) }
 
 func (endingBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/extra_blank_line.go
+++ b/internal/lint/rules/deterministic/extra_blank_line.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type extraBlankLineRule struct{}
 
@@ -15,6 +18,9 @@ func NewExtraBlankLine() lint.Rule { return extraBlankLineRule{} }
 
 func (extraBlankLineRule) ID() string          { return "extra-blank-line" }
 func (extraBlankLineRule) Description() string { return "flags repeated blank lines inside a file" }
+
+// Fix collapses each run of consecutive blank lines to a single blank line.
+func (extraBlankLineRule) Fix(data []byte) []byte { return envfile.CollapseBlankLines(data) }
 
 func (extraBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/line_ending.go
+++ b/internal/lint/rules/deterministic/line_ending.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type lineEndingRule struct{}
 
@@ -15,6 +18,9 @@ func NewLineEnding() lint.Rule { return lineEndingRule{} }
 
 func (lineEndingRule) ID() string          { return "line-ending" }
 func (lineEndingRule) Description() string { return "flags files with mixed CRLF and LF line endings" }
+
+// Fix converts CRLF and lone CR line endings to LF so the file uses one style.
+func (lineEndingRule) Fix(data []byte) []byte { return envfile.NormalizeLineEndings(data) }
 
 func (lineEndingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/deterministic/trailing_whitespace.go
+++ b/internal/lint/rules/deterministic/trailing_whitespace.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type trailingWhitespaceRule struct{}
 
@@ -15,6 +18,9 @@ func NewTrailingWhitespace() lint.Rule { return trailingWhitespaceRule{} }
 
 func (trailingWhitespaceRule) ID() string          { return "trailing-whitespace" }
 func (trailingWhitespaceRule) Description() string { return "warns about trailing whitespace" }
+
+// Fix trims trailing spaces and tabs from every line and empties whitespace-only lines.
+func (trailingWhitespaceRule) Fix(data []byte) []byte { return envfile.TrimTrailingWhitespace(data) }
 
 func (trailingWhitespaceRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)

--- a/internal/lint/rules/fixability_test.go
+++ b/internal/lint/rules/fixability_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package rules_test pins rule fixability against what the shared --fix pass
+// actually does. Fixability is intrinsic: a rule is fixable exactly when it
+// carries a Fix method (lint.FixableRule). Two properties keep the fix pipeline
+// honest:
+//
+//   - the per-rule drift test proves each rule's Fix eliminates its own finding
+//     and that non-fixable rules survive the full composition untouched, so the
+//     empirical fixable set stays exactly the five formatting rules, and
+//   - the equivalence test proves composing every rule's fix reproduces the
+//     original whole-file Normalize byte for byte, against a frozen copy of it,
+//     so decomposing Normalize into per-rule transforms changed no behavior.
+package rules_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+)
+
+// expectedFixable is the empirical set of rules the --fix pass repairs. The
+// drift test fails if any rule enters or leaves this set, which is a real
+// finding about the decomposition rather than a value to blindly update.
+var expectedFixable = map[string]bool{
+	"bom-character":       true,
+	"line-ending":         true,
+	"trailing-whitespace": true,
+	"extra-blank-line":    true,
+	"ending-blank-line":   true,
+}
+
+// fixabilityFixtures maps each registered rule ID to a bad dotenv fixture that
+// triggers exactly that rule, mirroring the per-rule bad inputs in
+// internal/lint/rules/deterministic/*_test.go. A rule with no constructible bad
+// fixture must be listed in fixabilityUnconstructible with a reason instead of
+// left out silently; the coverage test fails on any registered rule that is
+// neither mapped nor excused.
+func fixabilityFixtures() map[string][]byte {
+	return map[string][]byte{
+		"bom-character":        append([]byte{0xEF, 0xBB, 0xBF}, []byte("KEY=value\n")...),
+		"constant-case":        []byte("database_url=value\n"),
+		"duplicate-key":        []byte("KEY=value\nKEY=other\n"),
+		"ending-blank-line":    []byte("KEY=value\n\n"),
+		"extra-blank-line":     []byte("KEY=value\n\n\n"),
+		"incorrect-delimiter":  []byte("BAD: value\n"),
+		"invalid-key-name":     []byte("1INVALID=value\n"),
+		"key-without-value":    []byte("NO_VALUE\n"),
+		"leading-character":    []byte(" KEY=value\n"),
+		"line-ending":          []byte("KEY=one\r\nKEY2=two\n"),
+		"quote-character":      []byte("KEY=\"broken\n"),
+		"space-character":      []byte("KEY = value\n"),
+		"trailing-whitespace":  []byte("KEY=value  \n"),
+		"value-without-key":    []byte("=supersecret-token-123\n"),
+		"value-without-quotes": []byte("FOO=BAR BAZ\n"),
+	}
+}
+
+// fixabilityUnconstructible names any rule that genuinely has no bad fixture,
+// with the reason it is excused. It is empty today because every built-in rule
+// has a constructible trigger.
+var fixabilityUnconstructible = map[string]string{}
+
+// hasFinding reports whether a rule flags the given dotenv bytes.
+func hasFinding(t *testing.T, rule lint.Rule, data []byte) bool {
+	t.Helper()
+
+	file, err := envfile.Parse("drift.env", data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	findings, err := rule.Run(lint.Context{Files: []envfile.File{file}})
+	if err != nil {
+		t.Fatalf("rule run failed: %v", err)
+	}
+	return len(findings) > 0
+}
+
+// TestFixabilityMatchesFixPass is the load-bearing drift test. For every
+// registered rule it asserts, against that rule's bad fixture:
+//
+//   - a rule with a fix half eliminates its own finding when its Fix runs
+//     alone and again under the full composition, and
+//   - a rule without a fix half keeps its finding after the full composition.
+func TestFixabilityMatchesFixPass(t *testing.T) {
+	fixtures := fixabilityFixtures()
+	all := rules.All()
+
+	for _, rule := range all {
+		rule := rule
+		t.Run(rule.ID(), func(t *testing.T) {
+			if reason, excused := fixabilityUnconstructible[rule.ID()]; excused {
+				t.Skipf("no constructible bad fixture: %s", reason)
+			}
+
+			fixture, ok := fixtures[rule.ID()]
+			if !ok {
+				t.Fatalf("rule %q has no fixability fixture and is not excused in fixabilityUnconstructible", rule.ID())
+			}
+
+			// Guard the fixture: it must actually trigger the rule, or the drift
+			// assertions below would be vacuous.
+			if !hasFinding(t, rule, fixture) {
+				t.Fatalf("fixture for %q does not trigger the rule; fix the fixture", rule.ID())
+			}
+
+			composed := !hasFinding(t, rule, lint.FixData(all, fixture))
+
+			if lint.IsFixable(rule) {
+				fixable, ok := rule.(lint.FixableRule)
+				if !ok {
+					t.Fatalf("rule %q reads as fixable but has no Fix method", rule.ID())
+				}
+				if hasFinding(t, rule, fixable.Fix(fixture)) {
+					t.Fatalf("rule %q has a fix half but its own Fix does not eliminate its finding", rule.ID())
+				}
+				if !composed {
+					t.Fatalf("rule %q has a fix half but the full composition leaves its finding; is it missing from the fix pipeline order?", rule.ID())
+				}
+				return
+			}
+
+			if composed {
+				t.Fatalf("rule %q has no fix half yet the full composition eliminates its finding; add a Fix method or narrow a fix transform", rule.ID())
+			}
+		})
+	}
+}
+
+// TestEmpiricalFixableSet asserts the set of fixable rules is exactly the five
+// formatting rules the fix pass owns. A mismatch is a real finding about the
+// decomposition, not a number to update blindly.
+func TestEmpiricalFixableSet(t *testing.T) {
+	got := map[string]bool{}
+	for _, rule := range rules.All() {
+		if lint.IsFixable(rule) {
+			got[rule.ID()] = true
+		}
+	}
+
+	if len(got) != len(expectedFixable) {
+		t.Fatalf("fixable set has %d rules, want %d: got %v", len(got), len(expectedFixable), sortedKeys(got))
+	}
+	for id := range expectedFixable {
+		if !got[id] {
+			t.Fatalf("expected rule %q to be fixable, but it is not", id)
+		}
+	}
+	for id := range got {
+		if !expectedFixable[id] {
+			t.Fatalf("rule %q is fixable but not in the expected set; is that intended?", id)
+		}
+	}
+}
+
+// TestEveryRuleHasFixabilityCoverage fails if a newly registered rule lacks
+// both a fixture and a named exclusion, so the drift test can never silently
+// skip a rule.
+func TestEveryRuleHasFixabilityCoverage(t *testing.T) {
+	fixtures := fixabilityFixtures()
+	for _, rule := range rules.All() {
+		_, hasFixture := fixtures[rule.ID()]
+		_, excused := fixabilityUnconstructible[rule.ID()]
+		if !hasFixture && !excused {
+			t.Errorf("rule %q has neither a fixability fixture nor a named exclusion", rule.ID())
+		}
+	}
+}
+
+// TestFixDataMatchesLegacyNormalize pins the load-bearing invariant: composing
+// every rule's fix half reproduces the original whole-file Normalize exactly.
+// legacyNormalize is a frozen copy of the pre-decomposition implementation, so
+// the comparison is against real historical behavior, not a reimplementation.
+func TestFixDataMatchesLegacyNormalize(t *testing.T) {
+	all := rules.All()
+	for _, tc := range equivalenceCorpus(t) {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			want := legacyNormalize(tc.data)
+			got := lint.FixData(all, tc.data)
+			if string(got) != string(want) {
+				t.Fatalf("FixData disagrees with legacy Normalize on %q\ninput %q\ngot   %q\nwant  %q",
+					tc.name, tc.data, got, want)
+			}
+		})
+	}
+}
+
+type corpusCase struct {
+	name string
+	data []byte
+}
+
+// equivalenceCorpus is the repo's own testdata dotenv files plus a battery of
+// synthetic nasty inputs the fix pass must handle identically to Normalize.
+func equivalenceCorpus(t *testing.T) []corpusCase {
+	t.Helper()
+
+	cases := []corpusCase{
+		{"empty", []byte("")},
+		{"single-newline", []byte("\n")},
+		{"all-blank", []byte("\n\n\n")},
+		{"whitespace-only-spaces", []byte("   \n\t\n  \t \n")},
+		{"whitespace-only-no-newline", []byte("   ")},
+		{"vertical-tab-blank", []byte("A=1\n  \v  \nB=2\n")},
+		{"form-feed-blank", []byte("A=1\n\f\nB=2\n")},
+		{"no-final-newline", []byte("KEY=value")},
+		{"trailing-spaces", []byte("KEY=value   \n")},
+		{"trailing-tabs", []byte("KEY=value\t\t\n")},
+		{"double-blank", []byte("A=1\n\n\nB=2\n")},
+		{"trailing-blank-lines", []byte("KEY=value\n\n\n")},
+		{"crlf", []byte("A=1\r\nB=2\r\n")},
+		{"lone-cr", []byte("A=1\rB=2\r")},
+		{"mixed-endings", []byte("A=1\r\nB=2\nC=3\r\n")},
+		{"bom-only", []byte{0xEF, 0xBB, 0xBF}},
+		{"bom-plus-key", append([]byte{0xEF, 0xBB, 0xBF}, []byte("KEY=value\n")...)},
+		{"bom-crlf-trailing", append([]byte{0xEF, 0xBB, 0xBF}, []byte("KEY=value  \r\n\r\n\r\nFOO=bar   ")...)},
+		{"bom-mid-file-untouched", []byte("A=1\n\ufeffB=2\n")},
+		{"content-then-blanks-then-content", []byte("A=1  \n\n\n\nB=2\t\n\n")},
+		{"comment-and-blanks", []byte("# note\n\n\n#end\n\n")},
+		{"tabs-and-crlf", []byte("KEY=value\t\r\n\r\nNEXT=x\r\n")},
+		{"leading-ws-preserved", []byte("  KEY=value  \n")},
+		{"only-crlf-blanks", []byte("\r\n\r\n\r\n")},
+	}
+
+	root := filepath.Join("..", "..", "..", "testdata")
+	matches, err := filepath.Glob(filepath.Join(root, "envfile", "*", "*.env"))
+	if err != nil {
+		t.Fatalf("glob testdata failed: %v", err)
+	}
+	sort.Strings(matches)
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s failed: %v", path, err)
+		}
+		cases = append(cases, corpusCase{name: "testdata/" + filepath.Base(path), data: data})
+	}
+
+	return cases
+}
+
+// legacyNormalize is a frozen, verbatim copy of the original
+// envfile.Normalize implementation that the per-rule fix halves replaced. It
+// exists only here so TestFixDataMatchesLegacyNormalize can pin the new
+// composition against real historical behavior.
+func legacyNormalize(data []byte) []byte {
+	lines := envfile.Split(data)
+	if len(lines) == 0 {
+		return []byte{}
+	}
+
+	normalized := make([]string, 0, len(lines))
+	prevBlank := false
+
+	for i, raw := range lines {
+		content := raw.Content
+		if i == 0 && strings.HasPrefix(content, "\ufeff") {
+			content = strings.TrimPrefix(content, "\ufeff")
+		}
+
+		content = strings.TrimRight(content, " \t")
+		blank := strings.TrimSpace(content) == ""
+		if blank {
+			if prevBlank {
+				continue
+			}
+			prevBlank = true
+			normalized = append(normalized, "")
+			continue
+		}
+
+		prevBlank = false
+		normalized = append(normalized, content)
+	}
+
+	for len(normalized) > 0 && normalized[len(normalized)-1] == "" {
+		normalized = normalized[:len(normalized)-1]
+	}
+
+	if len(normalized) == 0 {
+		return []byte{}
+	}
+
+	var builder strings.Builder
+	for _, line := range normalized {
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+
+	return []byte(builder.String())
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -66,7 +66,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 
 	changed := false
 	if opts.Fix {
-		changed, err = ApplyFixes(paths)
+		changed, err = ApplyFixes(r.rules, paths)
 		if err != nil {
 			return Result{}, err
 		}


### PR DESCRIPTION
Fixes #40 — reimplemented as **option (c), per-rule fixes**, per your direction change. (The original option-(a) marker implementation this PR carried before the force-push is superseded.)

## What this does

- **Rules gain a fix half**: `FixableRule { Fix(data []byte) []byte }`, an optional interface discovered by type assertion — `lint.Rule` itself is unchanged, so external rule implementers keep compiling (the #30→#33 lesson). The five rules whose defects the old fix pass repaired each carry a one-line `Fix` delegating to a surgical transform: bom-character, line-ending, trailing-whitespace, extra-blank-line, ending-blank-line.
- **`envfile.Normalize` is decomposed** into those five transforms (`internal/envfile/fix.go`), each repairing exactly its rule's defect. `Normalize` itself is removed — it had exactly one production consumer (`ApplyFixes`), which now composes the fix halves in the canonical order (`fixOrder` in `internal/lint/fix.go`; order is load-bearing — line endings before trailing whitespace, blank-collapse before final-trim).
- **Fixability is intrinsic**: `IsFixable` and the `--list-rules` FIXABLE column key on the *presence of the fix half* — there is no boolean that can drift from behavior.

## The invariant, proven

`TestFixDataMatchesLegacyNormalize` pins **byte-exact equivalence** between the composed all-rule fix pass and a frozen verbatim copy of the original `Normalize`, across 28 cases: 24 synthetic nasties (BOM/CRLF/lone-CR combos, `\v`/`\f` whitespace-only lines, no-final-newline, all-blank, empty, …) plus the repo's testdata files. Your CI fix smoke passes verbatim. Drift coverage: each fixable rule's `Fix` alone eliminates its own finding, non-fixable rules survive the full composition, and the empirical fixable set is asserted to be exactly those 5 rules.

Mutation-verified (re-run independently before this push): weakening one transform fails the equivalence test on 9 subtests plus that rule's drift test; all green restored.

One design point you may want to overrule: `fixOrder` names the 5 fixable rule IDs inside the lint core — it's the single canonical pipeline definition and the tests catch an omission behaviorally, but the coupling is real; happy to move it if you'd rather.

## Verification

`gofmt` / `go mod tidy` / `go vet` / `go build` + version smoke / `make lint|vet|test|build` — green on a clean rebase onto current main (`f4cf57b`, includes #53); `go test ./...` shows only the two pre-existing chmod-as-root failures, identical on clean main; your CI runs non-root.

#54 is stacked on this branch and adds the `--only`/`--skip` scoping that this architecture unlocks.

---
Generated by Claude Fable 5 (brief, review), Claude Opus 4.8 (1M context) (implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `vaar lint --list-rules` now shows `NAME`, `FIXABLE`, and `DESCRIPTION`, and exits immediately without running lint.
  * `--fix` can auto-correct more formatting issues (UTF-8 BOM, line endings, trailing whitespace, extra blank lines, and final newline), applying fixes deterministically per rule fixability.
* **Bug Fixes**
  * `FIXABLE` now matches what `--fix` can actually repair, including consistent behavior across newline/whitespace edge cases.
* **Documentation**
  * Updated Quick Start and lint docs to describe the expanded `--list-rules` output and the meaning of `FIXABLE`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->