### PR TITLE
feat: add vaar diff command with text output

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/envaar/vaar/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+func newDiffCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "diff",
+		Short: "Compare dotenv key presence",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return NewToolError("diff requires exactly two dotenv files", nil)
+			}
+
+			leftPath := args[0]
+			rightPath := args[1]
+
+			leftData, err := os.ReadFile(leftPath)
+			if err != nil {
+				return NewToolError(
+					fmt.Sprintf("reading %s", leftPath),
+					err,
+				)
+			}
+
+			rightData, err := os.ReadFile(rightPath)
+			if err != nil {
+				return NewToolError(
+					fmt.Sprintf("reading %s", rightPath),
+					err,
+				)
+			}
+
+			// === MODIFIED SECTION START ===
+			res, err := diff.Compare(leftPath, leftData, rightPath, rightData)
+			if err != nil {
+				return NewToolError("comparing dotenv files", err)
+			}
+
+			// If both lists are empty, the files match structurally
+			if len(res.MissingFromLeft) == 0 && len(res.MissingFromRight) == 0 {
+				fmt.Println("Files are structurally identical.")
+				return nil
+			}
+
+			// Helper to get correct singular/plural text
+			pluralize := func(count int) string {
+				if count == 1 {
+					return "key"
+				}
+				return "keys"
+			}
+
+			// Print findings for the left file
+			if len(res.MissingFromLeft) > 0 {
+				fmt.Printf("%s is missing %d %s:\n", leftPath, len(res.MissingFromLeft), pluralize(len(res.MissingFromLeft)))
+				for _, k := range res.MissingFromLeft {
+					fmt.Printf("  - %s\n", k)
+				}
+			}
+
+			// Print findings for the right file
+			if len(res.MissingFromRight) > 0 {
+				fmt.Printf("%s is missing %d %s:\n", rightPath, len(res.MissingFromRight), pluralize(len(res.MissingFromRight)))
+				for _, k := range res.MissingFromRight {
+					fmt.Printf("  - %s\n", k)
+				}
+			}
+
+			// Return an error context to exit with a non-zero code since structural differences were found
+			return NewToolError("dotenv files diverge", nil)
+			// === MODIFIED SECTION END ===
+		},
+	}
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -39,15 +39,21 @@ func newDiffCmd() *cobra.Command {
 			}
 
 			if len(res.MissingFromLeft) == 0 && len(res.MissingFromRight) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "No key differences found")
+				if err := writeDiffLine(cmd, "No key differences found"); err != nil {
+					return err
+				}
 				return nil
 			}
 
 			if len(res.MissingFromLeft) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), missingKeysLine(leftPath, res.MissingFromLeft))
+				if err := writeDiffLine(cmd, missingKeysLine(leftPath, res.MissingFromLeft)); err != nil {
+					return err
+				}
 			}
 			if len(res.MissingFromRight) > 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), missingKeysLine(rightPath, res.MissingFromRight))
+				if err := writeDiffLine(cmd, missingKeysLine(rightPath, res.MissingFromRight)); err != nil {
+					return err
+				}
 			}
 
 			return ExitError{Code: ExitFindings}
@@ -69,6 +75,9 @@ func readDiffFile(path string) ([]byte, error) {
 		if info.IsDir() {
 			return nil, NewToolError(fmt.Sprintf("%s is a directory, expected a dotenv file", path), nil)
 		}
+		if !info.Mode().IsRegular() {
+			return nil, NewToolError(fmt.Sprintf("%s is not a regular file, expected a dotenv file", path), nil)
+		}
 	case os.IsNotExist(err):
 		return nil, NewToolError(fmt.Sprintf("reading %s: file does not exist", path), nil)
 	default:
@@ -80,6 +89,13 @@ func readDiffFile(path string) ([]byte, error) {
 		return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
 	}
 	return data, nil
+}
+
+func writeDiffLine(cmd *cobra.Command, line string) error {
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), line); err != nil {
+		return NewToolError("writing diff output failed", err)
+	}
+	return nil
 }
 
 func missingKeysLine(path string, keys []string) string {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -72,8 +72,8 @@ func newDiffCmd() *cobra.Command {
 				}
 			}
 
-			// Return an error context to exit with a non-zero code since structural differences were found
-			return NewToolError("dotenv files diverge", nil)
+			// Return the specific structured ExitError highlighting findings detection
+			return ExitError{Code: ExitFindings}
 			// === MODIFIED SECTION END ===
 		},
 	}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,8 +1,14 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package cli
 
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/envaar/vaar/internal/diff"
 	"github.com/spf13/cobra"
@@ -10,71 +16,76 @@ import (
 
 func newDiffCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "diff",
+		Use:   "diff <left> <right>",
 		Short: "Compare dotenv key presence",
+		Args:  exactDiffArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
-				return NewToolError("diff requires exactly two dotenv files", nil)
-			}
-
 			leftPath := args[0]
 			rightPath := args[1]
 
-			leftData, err := os.ReadFile(leftPath)
+			leftData, err := readDiffFile(leftPath)
 			if err != nil {
-				return NewToolError(
-					fmt.Sprintf("reading %s", leftPath),
-					err,
-				)
+				return err
 			}
 
-			rightData, err := os.ReadFile(rightPath)
+			rightData, err := readDiffFile(rightPath)
 			if err != nil {
-				return NewToolError(
-					fmt.Sprintf("reading %s", rightPath),
-					err,
-				)
+				return err
 			}
 
-			// === MODIFIED SECTION START ===
 			res, err := diff.Compare(leftPath, leftData, rightPath, rightData)
 			if err != nil {
 				return NewToolError("comparing dotenv files", err)
 			}
 
-			// If both lists are empty, the files match structurally
 			if len(res.MissingFromLeft) == 0 && len(res.MissingFromRight) == 0 {
-				fmt.Println("Files are structurally identical.")
+				fmt.Fprintln(cmd.OutOrStdout(), "No key differences found")
 				return nil
 			}
 
-			// Helper to get correct singular/plural text
-			pluralize := func(count int) string {
-				if count == 1 {
-					return "key"
-				}
-				return "keys"
-			}
-
-			// Print findings for the left file
 			if len(res.MissingFromLeft) > 0 {
-				fmt.Printf("%s is missing %d %s:\n", leftPath, len(res.MissingFromLeft), pluralize(len(res.MissingFromLeft)))
-				for _, k := range res.MissingFromLeft {
-					fmt.Printf("  - %s\n", k)
-				}
+				fmt.Fprintln(cmd.OutOrStdout(), missingKeysLine(leftPath, res.MissingFromLeft))
 			}
-
-			// Print findings for the right file
 			if len(res.MissingFromRight) > 0 {
-				fmt.Printf("%s is missing %d %s:\n", rightPath, len(res.MissingFromRight), pluralize(len(res.MissingFromRight)))
-				for _, k := range res.MissingFromRight {
-					fmt.Printf("  - %s\n", k)
-				}
+				fmt.Fprintln(cmd.OutOrStdout(), missingKeysLine(rightPath, res.MissingFromRight))
 			}
 
-			// Return the specific structured ExitError highlighting findings detection
 			return ExitError{Code: ExitFindings}
-			// === MODIFIED SECTION END ===
 		},
 	}
+}
+
+func exactDiffArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return NewToolError("diff requires exactly two dotenv files", nil)
+	}
+	return nil
+}
+
+func readDiffFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() {
+			return nil, NewToolError(fmt.Sprintf("%s is a directory, expected a dotenv file", path), nil)
+		}
+	case os.IsNotExist(err):
+		return nil, NewToolError(fmt.Sprintf("reading %s: file does not exist", path), nil)
+	default:
+		return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
+	}
+	return data, nil
+}
+
+func missingKeysLine(path string, keys []string) string {
+	noun := "key"
+	if len(keys) != 1 {
+		noun = "keys"
+	}
+	return fmt.Sprintf("%s is missing %s: %s", path, noun, strings.Join(keys, ", "))
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -7,7 +7,7 @@ package cli
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -213,6 +213,35 @@ func TestDiffCommandReportsOperationalFailures(t *testing.T) {
 	}
 }
 
+func TestDiffCommandRejectsNonRegularInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-regular /dev/null fixture is Unix-specific")
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", "/dev/null")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	wantText := "/dev/null is not a regular file, expected a dotenv file"
+	if !strings.Contains(err.Error(), wantText) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if stderr != "error: "+wantText+"\n" {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
 func TestDiffCommandReportsUnreadableFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission-denied fixtures are not portable on windows")
@@ -234,6 +263,10 @@ func TestDiffCommandReportsUnreadableFile(t *testing.T) {
 	if err := os.Chmod(locked, 0); err != nil {
 		t.Fatalf("chmod failed: %v", err)
 	}
+	if file, err := os.Open(locked); err == nil {
+		_ = file.Close()
+		t.Skip("permission-denied fixture remains readable, likely running with elevated privileges")
+	}
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
 	if err == nil {
@@ -253,6 +286,60 @@ func TestDiffCommandReportsUnreadableFile(t *testing.T) {
 	}
 }
 
+func TestDiffCommandPropagatesStdoutWriteFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	withWorkingDir(t, root)
+
+	cmd := newRootCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"diff", ".env", ".env.example"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "writing diff output failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDiffCommandPropagatesSuccessStdoutWriteFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	withWorkingDir(t, root)
+
+	cmd := newRootCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"diff", ".env", ".env.example"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "writing diff output failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func runDiffCommandWithStreams(t *testing.T, root string, args ...string) (string, string, error) {
 	t.Helper()
 
@@ -266,7 +353,13 @@ func runDiffCommandWithStreams(t *testing.T, root string, args ...string) (strin
 
 	err := cmd.Execute()
 	if err != nil && !IsExitError(err) {
-		fmt.Fprintf(&stderr, "error: %v\n", err)
+		writeCLIError(&stderr, err)
 	}
 	return stdout.String(), stderr.String(), err
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDiffCommandReportsDifferencesForRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := ".env is missing key: BAR\n.env.example is missing key: FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandReportsDifferencesForAbsolutePaths(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left.env")
+	right := filepath.Join(root, "right.env")
+	if err := os.WriteFile(left, []byte("DEBUG=true\nFOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("DATABASE_URL=postgres://example\nBAR=example\nBAZ=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right)
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := left + " is missing keys: BAR, BAZ, DATABASE_URL\n" +
+		right + " is missing keys: DEBUG, FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandSupportsPathsContainingSpaces(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "local env")
+	right := filepath.Join(root, "example env")
+	if err := os.WriteFile(left, []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("BAR=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, "local env", "example env")
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := "local env is missing key: BAR\nexample env is missing key: FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandMatchingFilesExitZero(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("COMMON=example\nFOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err != nil {
+		t.Fatalf("expected matching files to succeed, got %v", err)
+	}
+	if got := ExitCode(err); got != ExitOK {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitOK)
+	}
+	if want := "No key differences found\n"; stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandRejectsWrongArgumentCount(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "too few",
+			args: []string{".env"},
+		},
+		{
+			name: "too many",
+			args: []string{".env", ".env.example", ".env.production"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runDiffCommandWithStreams(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if got, want := err.Error(), "diff requires exactly two dotenv files"; got != want {
+				t.Fatalf("unexpected error: got %q want %q", got, want)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout, got %q", stdout)
+			}
+			if want := "error: diff requires exactly two dotenv files\n"; stderr != want {
+				t.Fatalf("unexpected stderr: got %q want %q", stderr, want)
+			}
+		})
+	}
+}
+
+func TestDiffCommandReportsOperationalFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "configs"), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "missing input",
+			args:     []string{".env", ".env.example"},
+			wantText: "reading .env.example: file does not exist",
+		},
+		{
+			name:     "directory input",
+			args:     []string{".env", "configs"},
+			wantText: "configs is a directory, expected a dotenv file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runDiffCommandWithStreams(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout, got %q", stdout)
+			}
+			wantStderr := "error: " + tc.wantText + "\n"
+			if stderr != wantStderr {
+				t.Fatalf("unexpected stderr: got %q want %q", stderr, wantStderr)
+			}
+		})
+	}
+}
+
+func TestDiffCommandReportsUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied fixtures are not portable on windows")
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	locked := filepath.Join(root, ".env.example")
+	if err := os.WriteFile(locked, []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(locked, 0o644); err != nil {
+			t.Errorf("restore permissions failed: %v", err)
+		}
+	})
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "reading .env.example") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "error: reading .env.example") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func runDiffCommandWithStreams(t *testing.T, root string, args ...string) (string, string, error) {
+	t.Helper()
+
+	withWorkingDir(t, root)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"diff"}, args...))
+
+	err := cmd.Execute()
+	if err != nil && !IsExitError(err) {
+		fmt.Fprintf(&stderr, "error: %v\n", err)
+	}
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,6 +9,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -49,10 +50,14 @@ func Execute() int {
 
 	if err := cmd.Execute(); err != nil {
 		if !IsExitError(err) {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			writeCLIError(os.Stderr, err)
 		}
 		return ExitCode(err)
 	}
 
 	return ExitOK
+}
+
+func writeCLIError(w io.Writer, err error) {
+	fmt.Fprintf(w, "error: %v\n", err)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,9 +34,9 @@ and automation-friendly output.`,
 	cmd.SetVersionTemplate("vaar version {{.Version}}\n")
 
 	cmd.AddCommand(
-    newLintCmd(),
-    newDiffCmd(),
-)
+		newLintCmd(),
+		newDiffCmd(),
+	)
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -59,5 +59,5 @@ func Execute() int {
 }
 
 func writeCLIError(w io.Writer, err error) {
-	fmt.Fprintf(w, "error: %v\n", err)
+	_, _ = fmt.Fprintf(w, "error: %v\n", err)
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,10 @@ and automation-friendly output.`,
 	cmd.SilenceUsage = true
 	cmd.SetVersionTemplate("vaar version {{.Version}}\n")
 
-	cmd.AddCommand(newLintCmd())
+	cmd.AddCommand(
+    newLintCmd(),
+    newDiffCmd(),
+)
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Fixes #48

- Added `vaar diff` command.
- Compares two dotenv files for missing keys.
- Prints missing keys for each file.
- Returns a non-zero exit status when differences are found.
- Added the command to the CLI root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a `diff` CLI subcommand to compare two dotenv files and report missing keys for each side.

* **Bug Fixes / Improvements**
  * Improved argument and input validation (missing, unreadable, directory/non-regular inputs) with clearer `error:` messaging.
  * Refined diff output details, including correct singular/plural wording and consistent “No key differences found” messaging.

* **Tests**
  * Expanded CLI tests for exact output formatting, path edge cases, invalid inputs, and both success and failure cases when writing output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->