### PR TITLE
docs: give trailing-whitespace's bad example real trailing whitespace (#39)

### DIFF
--- a/docs/lint/rules/deterministic/trailing-whitespace.md
+++ b/docs/lint/rules/deterministic/trailing-whitespace.md
@@ -27,7 +27,7 @@ Trim the trailing whitespace.
 ## Bad example
 
 ```dotenv
-KEY=value
+KEY=value\s
 ```
 
 ## Good example
@@ -35,3 +35,22 @@ KEY=value
 ```dotenv
 KEY=value
 ```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=trailing-whitespace
+```
+
+Bad Example Produces:
+
+```text
+warn trailing-whitespace .env:1 line has trailing whitespace
+```
+
+> [!NOTE]
+> `\s` above stands for an actual trailing space, which Markdown cannot show.
+> A file containing the literal two characters `\s` has no trailing
+> whitespace and does not produce this finding.


### PR DESCRIPTION
Fixes #39.

The bad example on the trailing-whitespace rule page was byte-identical to the good example — no trailing whitespace in either — so the documented bad input produced no finding for its own rule.

**Changes:**
- Bad example is now `KEY=value\s`, using the same escape-notation convention the neighbouring pages already use for bytes Markdown can't render (bom-character's `﻿`, line-ending's `\r\n`), with a `> [!NOTE]` clarifying `\s` stands for a real trailing space (and that the literal two characters `\s` do not trip the rule).
- Added the **Example output** section this page was missing — it was the one page PR #42 deliberately skipped because there was no valid bad example to run; same structure as the other 12 rule pages.

**Verification:** built `bin/vaar` from source and ran it on a fixture containing a real trailing space (`cat -A`: `KEY=value $`): `vaar lint --only=trailing-whitespace` → `warn trailing-whitespace .env:1 line has trailing whitespace` (exit 1), byte-exact to the documented output block; plain `vaar lint` is identical (no other rule trips). The good example still produces no finding (exit 0, no output).

---
Generated by Claude Fable 5 (brief, review), Claude Sonnet 5 (implementation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how trailing whitespace is represented and detected in rule examples.
  * Added sample lint output showing the warning produced for trailing whitespace.
  * Explained Markdown display limitations and clarified that literal `\s` characters do not trigger the rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->