### PR TITLE
feat: add --json output to vaar diff

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/envaar/vaar/internal/diff"
 	"github.com/spf13/cobra"
@@ -28,54 +29,39 @@ func newDiffCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "diff <left> <right>",
-		Short: "Compare dotenv key presence between two files",
-		Args:  cobra.ExactArgs(2),
-
+		Short: "Compare dotenv key presence",
+		Args:  exactDiffArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if jsonOutput && quiet {
-				return fmt.Errorf("--quiet and --json cannot be used together")
+				return NewToolError("--quiet and --json cannot be used together", nil)
 			}
 
-			leftData, err := os.ReadFile(args[0])
+			leftPath := args[0]
+			rightPath := args[1]
+
+			leftData, err := readDiffFile(leftPath)
 			if err != nil {
 				return err
 			}
 
-			rightData, err := os.ReadFile(args[1])
+			rightData, err := readDiffFile(rightPath)
 			if err != nil {
 				return err
 			}
 
-			result, err := diff.Compare(
-				args[0],
-				leftData,
-				args[1],
-				rightData,
-			)
-
+			result, err := diff.Compare(leftPath, leftData, rightPath, rightData)
 			if err != nil {
-				return err
+				return NewToolError("comparing dotenv files", err)
 			}
 
-			different := len(result.MissingFromLeft) > 0 ||
-				len(result.MissingFromRight) > 0
+			different := diffHasDifferences(result)
 
 			if jsonOutput {
-				output := diffJSON{
-					Left:             result.Left,
-					Right:            result.Right,
-					MissingFromLeft:  result.MissingFromLeft,
-					MissingFromRight: result.MissingFromRight,
-					Different:        different,
-				}
-
-				data, err := json.MarshalIndent(output, "", "  ")
-				if err != nil {
+				if err := writeDiffJSON(cmd, result, different); err != nil {
 					return err
 				}
-
-				if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+			} else if !quiet {
+				if err := writeDiffText(cmd, result); err != nil {
 					return err
 				}
 			}
@@ -88,19 +74,93 @@ func newDiffCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(
-		&jsonOutput,
-		"json",
-		false,
-		"output machine-readable JSON",
-	)
-
-	cmd.Flags().BoolVar(
-		&quiet,
-		"quiet",
-		false,
-		"only return exit status",
-	)
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Render key differences as JSON")
+	cmd.Flags().BoolVar(&quiet, "quiet", false, "Suppress normal output and use exit status only")
 
 	return cmd
+}
+
+func exactDiffArgs(_ *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return NewToolError("diff requires exactly two dotenv files", nil)
+	}
+	return nil
+}
+
+func readDiffFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() {
+			return nil, NewToolError(fmt.Sprintf("%s is a directory, expected a dotenv file", path), nil)
+		}
+		if !info.Mode().IsRegular() {
+			return nil, NewToolError(fmt.Sprintf("%s is not a regular file, expected a dotenv file", path), nil)
+		}
+	case os.IsNotExist(err):
+		return nil, NewToolError(fmt.Sprintf("reading %s: file does not exist", path), nil)
+	default:
+		return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
+	}
+	return data, nil
+}
+
+func writeDiffText(cmd *cobra.Command, result diff.Result) error {
+	if !diffHasDifferences(result) {
+		return writeDiffLine(cmd, "No key differences found")
+	}
+
+	if len(result.MissingFromLeft) > 0 {
+		if err := writeDiffLine(cmd, missingKeysLine(result.Left, result.MissingFromLeft)); err != nil {
+			return err
+		}
+	}
+	if len(result.MissingFromRight) > 0 {
+		if err := writeDiffLine(cmd, missingKeysLine(result.Right, result.MissingFromRight)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeDiffJSON(cmd *cobra.Command, result diff.Result, different bool) error {
+	output := diffJSON{
+		Left:             result.Left,
+		Right:            result.Right,
+		MissingFromLeft:  result.MissingFromLeft,
+		MissingFromRight: result.MissingFromRight,
+		Different:        different,
+	}
+
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return NewToolError("rendering diff JSON output failed", err)
+	}
+
+	return writeDiffLine(cmd, string(data))
+}
+
+func writeDiffLine(cmd *cobra.Command, line string) error {
+	if _, err := fmt.Fprintln(cmd.OutOrStdout(), line); err != nil {
+		return NewToolError("writing diff output failed", err)
+	}
+	return nil
+}
+
+func diffHasDifferences(result diff.Result) bool {
+	return len(result.MissingFromLeft) > 0 || len(result.MissingFromRight) > 0
+}
+
+func missingKeysLine(path string, keys []string) string {
+	noun := "key"
+	if len(keys) != 1 {
+		noun = "keys"
+	}
+	return fmt.Sprintf("%s is missing %s: %s", path, noun, strings.Join(keys, ", "))
 }

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -75,7 +75,9 @@ func newDiffCmd() *cobra.Command {
 					return err
 				}
 
-				fmt.Fprintln(cmd.OutOrStdout(), string(data))
+				if _, err := fmt.Fprintln(cmd.OutOrStdout(), string(data)); err != nil {
+					return err
+				}
 			}
 
 			if different {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/envaar/vaar/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+type diffJSON struct {
+	Left             string   `json:"left"`
+	Right            string   `json:"right"`
+	MissingFromLeft  []string `json:"missing_from_left"`
+	MissingFromRight []string `json:"missing_from_right"`
+	Different        bool     `json:"different"`
+}
+
+func newDiffCmd() *cobra.Command {
+	var jsonOutput bool
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "diff <left> <right>",
+		Short: "Compare dotenv key presence between two files",
+		Args:  cobra.ExactArgs(2),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if jsonOutput && quiet {
+				return fmt.Errorf("--quiet and --json cannot be used together")
+			}
+
+			leftData, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+
+			rightData, err := os.ReadFile(args[1])
+			if err != nil {
+				return err
+			}
+
+			result, err := diff.Compare(
+				args[0],
+				leftData,
+				args[1],
+				rightData,
+			)
+
+			if err != nil {
+				return err
+			}
+
+			different := len(result.MissingFromLeft) > 0 ||
+				len(result.MissingFromRight) > 0
+
+			if jsonOutput {
+				output := diffJSON{
+					Left:             result.Left,
+					Right:            result.Right,
+					MissingFromLeft:  result.MissingFromLeft,
+					MissingFromRight: result.MissingFromRight,
+					Different:        different,
+				}
+
+				data, err := json.MarshalIndent(output, "", "  ")
+				if err != nil {
+					return err
+				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), string(data))
+			}
+
+			if different {
+				return ExitError{Code: ExitFindings}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(
+		&jsonOutput,
+		"json",
+		false,
+		"output machine-readable JSON",
+	)
+
+	cmd.Flags().BoolVar(
+		&quiet,
+		"quiet",
+		false,
+		"only return exit status",
+	)
+
+	return cmd
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -54,7 +54,7 @@ func newDiffCmd() *cobra.Command {
 				return NewToolError("comparing dotenv files", err)
 			}
 
-			different := diffHasDifferences(result)
+			different := result.HasDifferences()
 
 			if jsonOutput {
 				if err := writeDiffJSON(cmd, result, different); err != nil {
@@ -111,7 +111,7 @@ func readDiffFile(path string) ([]byte, error) {
 }
 
 func writeDiffText(cmd *cobra.Command, result diff.Result) error {
-	if !diffHasDifferences(result) {
+	if !result.HasDifferences() {
 		return writeDiffLine(cmd, "No key differences found")
 	}
 
@@ -151,10 +151,6 @@ func writeDiffLine(cmd *cobra.Command, line string) error {
 		return NewToolError("writing diff output failed", err)
 	}
 	return nil
-}
-
-func diffHasDifferences(result diff.Result) bool {
-	return len(result.MissingFromLeft) > 0 || len(result.MissingFromRight) > 0
 }
 
 func missingKeysLine(path string, keys []string) string {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -79,8 +79,13 @@ func TestDiffCommandJSONMatchingFiles(t *testing.T) {
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
 
-	os.WriteFile(left, []byte("FOO=123\n"), 0o644)
-	os.WriteFile(right, []byte("FOO=secret\n"), 0o644)
+	if err := os.WriteFile(left, []byte("FOO=123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(right, []byte("FOO=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	var stdout bytes.Buffer
 

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiffCommandJSONWithDifferences(t *testing.T) {
+	root := t.TempDir()
+
+	left := filepath.Join(root, ".env")
+	right := filepath.Join(root, ".env.example")
+
+	if err := os.WriteFile(left, []byte("FOO=secret\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(right, []byte("BAR=value\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{
+		"diff",
+		left,
+		right,
+		"--json",
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected difference exit")
+	}
+
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("got exit code %d want %d", got, ExitFindings)
+	}
+
+	var output diffJSON
+
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(output.MissingFromLeft) != 1 ||
+		output.MissingFromLeft[0] != "BAR" {
+		t.Fatalf("unexpected missing_from_left: %#v", output.MissingFromLeft)
+	}
+
+	if len(output.MissingFromRight) != 1 ||
+		output.MissingFromRight[0] != "FOO" {
+		t.Fatalf("unexpected missing_from_right: %#v", output.MissingFromRight)
+	}
+
+	if !output.Different {
+		t.Fatal("expected different=true")
+	}
+
+	if strings.Contains(stdout.String(), "secret") {
+		t.Fatal("JSON leaked value")
+	}
+}
+
+func TestDiffCommandJSONMatchingFiles(t *testing.T) {
+	root := t.TempDir()
+
+	left := filepath.Join(root, ".env")
+	right := filepath.Join(root, ".env.example")
+
+	os.WriteFile(left, []byte("FOO=123\n"), 0o644)
+	os.WriteFile(right, []byte("FOO=secret\n"), 0o644)
+
+	var stdout bytes.Buffer
+
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{
+		"diff",
+		left,
+		right,
+		"--json",
+	})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var output diffJSON
+
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatal(err)
+	}
+
+	if output.Different {
+		t.Fatal("expected different=false")
+	}
+
+	if strings.Contains(stdout.String(), "123") ||
+		strings.Contains(stdout.String(), "secret") {
+		t.Fatal("JSON leaked values")
+	}
+}
+
+func TestDiffCommandRejectsQuietWithJSON(t *testing.T) {
+	cmd := newRootCmd()
+
+	cmd.SetArgs([]string{
+		"diff",
+		"a.env",
+		"b.env",
+		"--json",
+		"--quiet",
+	})
+
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !strings.Contains(err.Error(), "--quiet and --json cannot be used together") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -8,135 +8,576 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 	"testing"
 )
 
+func TestDiffCommandReportsDifferencesForRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := ".env is missing key: BAR\n.env.example is missing key: FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandReportsDifferencesForAbsolutePaths(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "left.env")
+	right := filepath.Join(root, "right.env")
+	if err := os.WriteFile(left, []byte("DEBUG=true\nFOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("DATABASE_URL=postgres://example\nBAR=example\nBAZ=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right)
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := left + " is missing keys: BAR, BAZ, DATABASE_URL\n" +
+		right + " is missing keys: DEBUG, FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandSupportsPathsContainingSpaces(t *testing.T) {
+	root := t.TempDir()
+	left := filepath.Join(root, "local env")
+	right := filepath.Join(root, "example env")
+	if err := os.WriteFile(left, []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("BAR=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, "local env", "example env")
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	want := "local env is missing key: BAR\nexample env is missing key: FOO\n"
+	if stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandMatchingFilesExitZero(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("COMMON=example\nFOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err != nil {
+		t.Fatalf("expected matching files to succeed, got %v", err)
+	}
+	if got := ExitCode(err); got != ExitOK {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitOK)
+	}
+	if want := "No key differences found\n"; stdout != want {
+		t.Fatalf("unexpected stdout: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandQuietSuppressesDifferenceOutput(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
+	if err == nil {
+		t.Fatal("expected differences")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandQuietSuppressesSuccessOutput(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
+	if err != nil {
+		t.Fatalf("expected matching files to succeed, got %v", err)
+	}
+	if got := ExitCode(err); got != ExitOK {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitOK)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+}
+
+func TestDiffCommandQuietStillReportsOperationalFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	want := "error: reading .env.example: file does not exist\n"
+	if stderr != want {
+		t.Fatalf("unexpected stderr: got %q want %q", stderr, want)
+	}
+}
+
 func TestDiffCommandJSONWithDifferences(t *testing.T) {
 	root := t.TempDir()
-
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
-
-	if err := os.WriteFile(left, []byte("FOO=secret\n"), 0o644); err != nil {
-		t.Fatal(err)
+	if err := os.WriteFile(left, []byte("ZOO=left-secret\nFOO=left-token\nCOMMON=left\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("BAR=right-value\nAAA=right-secret\nCOMMON=right\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
 	}
 
-	if err := os.WriteFile(right, []byte("BAR=value\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var stdout bytes.Buffer
-
-	cmd := newRootCmd()
-	cmd.SetOut(&stdout)
-	cmd.SetArgs([]string{
-		"diff",
-		left,
-		right,
-		"--json",
-	})
-
-	err := cmd.Execute()
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right, "--json")
 	if err == nil {
-		t.Fatal("expected difference exit")
+		t.Fatal("expected differences")
 	}
-
 	if got := ExitCode(err); got != ExitFindings {
-		t.Fatalf("got exit code %d want %d", got, ExitFindings)
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
 	}
 
-	var output diffJSON
-
-	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+	output := parseDiffJSON(t, stdout)
+	if output.Left != left || output.Right != right {
+		t.Fatalf("unexpected paths: got left=%q right=%q", output.Left, output.Right)
 	}
-
-	if len(output.MissingFromLeft) != 1 ||
-		output.MissingFromLeft[0] != "BAR" {
+	if !slices.Equal(output.MissingFromLeft, []string{"AAA", "BAR"}) {
 		t.Fatalf("unexpected missing_from_left: %#v", output.MissingFromLeft)
 	}
-
-	if len(output.MissingFromRight) != 1 ||
-		output.MissingFromRight[0] != "FOO" {
+	if !slices.Equal(output.MissingFromRight, []string{"FOO", "ZOO"}) {
 		t.Fatalf("unexpected missing_from_right: %#v", output.MissingFromRight)
 	}
-
 	if !output.Different {
 		t.Fatal("expected different=true")
 	}
-
-	if strings.Contains(stdout.String(), "secret") {
-		t.Fatal("JSON leaked value")
+	for _, value := range []string{"left-secret", "left-token", "right-value", "right-secret"} {
+		if strings.Contains(stdout, value) {
+			t.Fatalf("JSON leaked value %q in %q", value, stdout)
+		}
 	}
 }
 
 func TestDiffCommandJSONMatchingFiles(t *testing.T) {
 	root := t.TempDir()
-
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
-
-	if err := os.WriteFile(left, []byte("FOO=123\n"), 0o644); err != nil {
-		t.Fatal(err)
+	if err := os.WriteFile(left, []byte("FOO=123\nCOMMON=local-secret\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(right, []byte("COMMON=example-secret\nFOO=456\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
 	}
 
-	if err := os.WriteFile(right, []byte("FOO=secret\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	var stdout bytes.Buffer
-
-	cmd := newRootCmd()
-	cmd.SetOut(&stdout)
-	cmd.SetArgs([]string{
-		"diff",
-		left,
-		right,
-		"--json",
-	})
-
-	err := cmd.Execute()
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right, "--json")
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("expected matching files to succeed, got %v", err)
+	}
+	if got := ExitCode(err); got != ExitOK {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitOK)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
 	}
 
-	var output diffJSON
-
-	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
-		t.Fatal(err)
+	output := parseDiffJSON(t, stdout)
+	if output.Left != left || output.Right != right {
+		t.Fatalf("unexpected paths: got left=%q right=%q", output.Left, output.Right)
 	}
-
+	if len(output.MissingFromLeft) != 0 {
+		t.Fatalf("unexpected missing_from_left: %#v", output.MissingFromLeft)
+	}
+	if len(output.MissingFromRight) != 0 {
+		t.Fatalf("unexpected missing_from_right: %#v", output.MissingFromRight)
+	}
 	if output.Different {
 		t.Fatal("expected different=false")
 	}
-
-	if strings.Contains(stdout.String(), "123") ||
-		strings.Contains(stdout.String(), "secret") {
-		t.Fatal("JSON leaked values")
+	for _, value := range []string{"123", "456", "local-secret", "example-secret"} {
+		if strings.Contains(stdout, value) {
+			t.Fatalf("JSON leaked value %q in %q", value, stdout)
+		}
 	}
 }
 
 func TestDiffCommandRejectsQuietWithJSON(t *testing.T) {
-	cmd := newRootCmd()
+	root := t.TempDir()
 
-	cmd.SetArgs([]string{
-		"diff",
-		"a.env",
-		"b.env",
-		"--json",
-		"--quiet",
-	})
-
-	err := cmd.Execute()
-
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, "a.env", "b.env", "--json", "--quiet")
 	if err == nil {
-		t.Fatal("expected error")
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if got, want := err.Error(), "--quiet and --json cannot be used together"; got != want {
+		t.Fatalf("unexpected error: got %q want %q", got, want)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if want := "error: --quiet and --json cannot be used together\n"; stderr != want {
+		t.Fatalf("unexpected stderr: got %q want %q", stderr, want)
+	}
+}
+
+func TestDiffCommandRejectsWrongArgumentCount(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "--quiet and --json cannot be used together") {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "too few",
+			args: []string{".env"},
+		},
+		{
+			name: "too many",
+			args: []string{".env", ".env.example", ".env.production"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runDiffCommandWithStreams(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if got, want := err.Error(), "diff requires exactly two dotenv files"; got != want {
+				t.Fatalf("unexpected error: got %q want %q", got, want)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout, got %q", stdout)
+			}
+			if want := "error: diff requires exactly two dotenv files\n"; stderr != want {
+				t.Fatalf("unexpected stderr: got %q want %q", stderr, want)
+			}
+		})
+	}
+}
+
+func TestDiffCommandReportsOperationalFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "configs"), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "missing input",
+			args:     []string{".env", ".env.example"},
+			wantText: "reading .env.example: file does not exist",
+		},
+		{
+			name:     "directory input",
+			args:     []string{".env", "configs"},
+			wantText: "configs is a directory, expected a dotenv file",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, err := runDiffCommandWithStreams(t, root, tc.args...)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if got := ExitCode(err); got != ExitInternal {
+				t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout, got %q", stdout)
+			}
+			wantStderr := "error: " + tc.wantText + "\n"
+			if stderr != wantStderr {
+				t.Fatalf("unexpected stderr: got %q want %q", stderr, wantStderr)
+			}
+		})
+	}
+}
+
+func TestDiffCommandRejectsNonRegularInput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("non-regular /dev/null fixture is Unix-specific")
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", "/dev/null")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	wantText := "/dev/null is not a regular file, expected a dotenv file"
+	if !strings.Contains(err.Error(), wantText) {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if stderr != "error: "+wantText+"\n" {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestDiffCommandReportsUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied fixtures are not portable on windows")
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	locked := filepath.Join(root, ".env.example")
+	if err := os.WriteFile(locked, []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(locked, 0o644); err != nil {
+			t.Errorf("restore permissions failed: %v", err)
+		}
+	})
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+	if file, err := os.Open(locked); err == nil {
+		_ = file.Close()
+		t.Skip("permission-denied fixture remains readable, likely running with elevated privileges")
+	}
+
+	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "reading .env.example") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdout != "" {
+		t.Fatalf("expected no stdout, got %q", stdout)
+	}
+	if !strings.Contains(stderr, "error: reading .env.example") {
+		t.Fatalf("unexpected stderr: %q", stderr)
+	}
+}
+
+func TestDiffCommandPropagatesStdoutWriteFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	withWorkingDir(t, root)
+
+	cmd := newRootCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"diff", ".env", ".env.example"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "writing diff output failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDiffCommandPropagatesSuccessStdoutWriteFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	withWorkingDir(t, root)
+
+	cmd := newRootCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"diff", ".env", ".env.example"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "writing diff output failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDiffCommandPropagatesJSONStdoutWriteFailures(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
+		t.Fatalf("write left failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
+		t.Fatalf("write right failed: %v", err)
+	}
+
+	withWorkingDir(t, root)
+
+	cmd := newRootCmd()
+	cmd.SetOut(failingWriter{})
+	cmd.SetArgs([]string{"diff", ".env", ".env.example", "--json"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "writing diff output failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func runDiffCommandWithStreams(t *testing.T, root string, args ...string) (string, string, error) {
+	t.Helper()
+
+	withWorkingDir(t, root)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"diff"}, args...))
+
+	err := cmd.Execute()
+	if err != nil && !IsExitError(err) {
+		writeTestCLIError(&stderr, err)
+	}
+	return stdout.String(), stderr.String(), err
+}
+
+func parseDiffJSON(t *testing.T, output string) diffJSON {
+	t.Helper()
+
+	var payload diffJSON
+	if err := json.Unmarshal([]byte(output), &payload); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	return payload
+}
+
+func writeTestCLIError(w *bytes.Buffer, err error) {
+	_, _ = w.WriteString("error: " + err.Error() + "\n")
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
 }

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -19,12 +19,8 @@ import (
 
 func TestDiffCommandReportsDifferencesForRelativePaths(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\nCOMMON=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "BAR=example\nCOMMON=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
 	if err == nil {
@@ -46,12 +42,8 @@ func TestDiffCommandReportsDifferencesForAbsolutePaths(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, "left.env")
 	right := filepath.Join(root, "right.env")
-	if err := os.WriteFile(left, []byte("DEBUG=true\nFOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(right, []byte("DATABASE_URL=postgres://example\nBAR=example\nBAZ=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, left, "DEBUG=true\nFOO=local\n")
+	mustWriteFile(t, right, "DATABASE_URL=postgres://example\nBAR=example\nBAZ=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right)
 	if err == nil {
@@ -74,12 +66,8 @@ func TestDiffCommandSupportsPathsContainingSpaces(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, "local env")
 	right := filepath.Join(root, "example env")
-	if err := os.WriteFile(left, []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(right, []byte("BAR=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, left, "FOO=local\n")
+	mustWriteFile(t, right, "BAR=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, "local env", "example env")
 	if err == nil {
@@ -99,12 +87,8 @@ func TestDiffCommandSupportsPathsContainingSpaces(t *testing.T) {
 
 func TestDiffCommandMatchingFilesExitZero(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("COMMON=example\nFOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\nCOMMON=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "COMMON=example\nFOO=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example")
 	if err != nil {
@@ -123,12 +107,8 @@ func TestDiffCommandMatchingFilesExitZero(t *testing.T) {
 
 func TestDiffCommandQuietSuppressesDifferenceOutput(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\nCOMMON=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "BAR=example\nCOMMON=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
 	if err == nil {
@@ -147,12 +127,8 @@ func TestDiffCommandQuietSuppressesDifferenceOutput(t *testing.T) {
 
 func TestDiffCommandQuietSuppressesSuccessOutput(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "FOO=example\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
 	if err != nil {
@@ -171,9 +147,7 @@ func TestDiffCommandQuietSuppressesSuccessOutput(t *testing.T) {
 
 func TestDiffCommandQuietStillReportsOperationalFailures(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", ".env.example", "--quiet")
 	if err == nil {
@@ -195,12 +169,8 @@ func TestDiffCommandJSONWithDifferences(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
-	if err := os.WriteFile(left, []byte("ZOO=left-secret\nFOO=left-token\nCOMMON=left\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(right, []byte("BAR=right-value\nAAA=right-secret\nCOMMON=right\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, left, "ZOO=left-secret\nFOO=left-token\nCOMMON=left\n")
+	mustWriteFile(t, right, "BAR=right-value\nAAA=right-secret\nCOMMON=right\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right, "--json")
 	if err == nil {
@@ -237,12 +207,8 @@ func TestDiffCommandJSONMatchingFiles(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
-	if err := os.WriteFile(left, []byte("FOO=123\nCOMMON=local-secret\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(right, []byte("COMMON=example-secret\nFOO=456\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, left, "FOO=123\nCOMMON=local-secret\n")
+	mustWriteFile(t, right, "COMMON=example-secret\nFOO=456\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right, "--json")
 	if err != nil {
@@ -298,12 +264,8 @@ func TestDiffCommandRejectsQuietWithJSON(t *testing.T) {
 
 func TestDiffCommandRejectsWrongArgumentCount(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "FOO=example\n")
 
 	tests := []struct {
 		name string
@@ -343,9 +305,7 @@ func TestDiffCommandRejectsWrongArgumentCount(t *testing.T) {
 
 func TestDiffCommandReportsOperationalFailures(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
 	if err := os.Mkdir(filepath.Join(root, "configs"), 0o755); err != nil {
 		t.Fatalf("mkdir failed: %v", err)
 	}
@@ -396,9 +356,7 @@ func TestDiffCommandRejectsNonRegularInput(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, ".env", "/dev/null")
 	if err == nil {
@@ -425,13 +383,9 @@ func TestDiffCommandReportsUnreadableFile(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
 	locked := filepath.Join(root, ".env.example")
-	if err := os.WriteFile(locked, []byte("FOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, locked, "FOO=example\n")
 	t.Cleanup(func() {
 		if err := os.Chmod(locked, 0o644); err != nil {
 			t.Errorf("restore permissions failed: %v", err)
@@ -465,12 +419,8 @@ func TestDiffCommandReportsUnreadableFile(t *testing.T) {
 
 func TestDiffCommandPropagatesStdoutWriteFailures(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\nCOMMON=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("BAR=example\nCOMMON=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\nCOMMON=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "BAR=example\nCOMMON=example\n")
 
 	withWorkingDir(t, root)
 
@@ -492,12 +442,8 @@ func TestDiffCommandPropagatesStdoutWriteFailures(t *testing.T) {
 
 func TestDiffCommandPropagatesSuccessStdoutWriteFailures(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "FOO=example\n")
 
 	withWorkingDir(t, root)
 
@@ -519,12 +465,8 @@ func TestDiffCommandPropagatesSuccessStdoutWriteFailures(t *testing.T) {
 
 func TestDiffCommandPropagatesJSONStdoutWriteFailures(t *testing.T) {
 	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("FOO=local\n"), 0o644); err != nil {
-		t.Fatalf("write left failed: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".env.example"), []byte("FOO=example\n"), 0o644); err != nil {
-		t.Fatalf("write right failed: %v", err)
-	}
+	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\n")
+	mustWriteFile(t, filepath.Join(root, ".env.example"), "FOO=example\n")
 
 	withWorkingDir(t, root)
 
@@ -570,6 +512,14 @@ func parseDiffJSON(t *testing.T, output string) diffJSON {
 		t.Fatalf("invalid JSON: %v", err)
 	}
 	return payload
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s failed: %v", path, err)
+	}
 }
 
 func writeTestCLIError(w *bytes.Buffer, err error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,10 @@ and automation-friendly output.`,
 	cmd.SilenceUsage = true
 	cmd.SetVersionTemplate("vaar version {{.Version}}\n")
 
-	cmd.AddCommand(newLintCmd())
+	cmd.AddCommand(
+		newLintCmd(),
+		newDiffCmd(),
+	)
 	return cmd
 }
 

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -25,6 +25,11 @@ type Result struct {
 	MissingFromRight []string
 }
 
+// HasDifferences reports whether either file is missing keys from the other.
+func (r Result) HasDifferences() bool {
+	return len(r.MissingFromLeft) > 0 || len(r.MissingFromRight) > 0
+}
+
 // Compare parses two dotenv inputs and compares assignment key presence only.
 func Compare(leftPath string, leftData []byte, rightPath string, rightData []byte) (Result, error) {
 	left, err := envfile.Parse(leftPath, leftData)

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -155,6 +155,53 @@ func TestCompareOnlyIncludesAssignmentKeys(t *testing.T) {
 	assertResult(t, result, []string{}, []string{})
 }
 
+func TestResultHasDifferences(t *testing.T) {
+	tests := []struct {
+		name   string
+		result Result
+		want   bool
+	}{
+		{
+			name: "no missing keys",
+			result: Result{
+				MissingFromLeft:  []string{},
+				MissingFromRight: []string{},
+			},
+			want: false,
+		},
+		{
+			name: "missing from left",
+			result: Result{
+				MissingFromLeft: []string{"BAR"},
+			},
+			want: true,
+		},
+		{
+			name: "missing from right",
+			result: Result{
+				MissingFromRight: []string{"FOO"},
+			},
+			want: true,
+		},
+		{
+			name: "missing from both files",
+			result: Result{
+				MissingFromLeft:  []string{"BAR"},
+				MissingFromRight: []string{"FOO"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.result.HasDifferences(); got != tc.want {
+				t.Fatalf("unexpected HasDifferences result: got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCompareFilesReusesParsedFiles(t *testing.T) {
 	left, err := envfile.Parse("left.env", []byte("FOO=left\n"))
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds machine-readable JSON output support for `vaar diff` using the new `--json` flag.

This allows automation tools and editor integrations to consume dotenv key differences in a stable JSON format without exposing any environment variable values.

Fixes #49 and #50

## Changes

- Added `vaar diff <left> <right> --json`
- Added stable JSON output schema:
  - `left`
  - `right`
  - `missing_from_left`
  - `missing_from_right`
  - `different`
- Ensured JSON output contains only key names and never exposes values
- Kept missing key arrays alphabetically sorted
- Added validation to reject `--quiet` with `--json`
- Added CLI tests for:
  - JSON output with differences
  - JSON output with matching files
  - value leakage prevention
  - invalid flag combination

## Testing

```bash
go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `diff` CLI subcommand to compare dotenv key presence between two files.
  - Added `--json` output with per-side missing-key lists and a `Different` indicator.
  - Added `--quiet` to suppress success/difference messaging while still surfacing operational failures.
  - Uses a non-zero “findings” exit status when differences are detected and rejects incompatible `--quiet` + `--json`.

- **Tests**
  - Added a comprehensive `diff` test suite for path handling, validation/IO errors, stdout write failures, and JSON behavior (including no secret/value leakage).
  - Added unit coverage for result difference detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->