### PR TITLE
test: avoid numeric JSON leak check collisions

### DIFF
--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -207,8 +207,8 @@ func TestDiffCommandJSONMatchingFiles(t *testing.T) {
 	root := t.TempDir()
 	left := filepath.Join(root, ".env")
 	right := filepath.Join(root, ".env.example")
-	mustWriteFile(t, left, "FOO=123\nCOMMON=local-secret\n")
-	mustWriteFile(t, right, "COMMON=example-secret\nFOO=456\n")
+	mustWriteFile(t, left, "FOO=left-token\nCOMMON=local-secret\n")
+	mustWriteFile(t, right, "COMMON=example-secret\nFOO=right-token\n")
 
 	stdout, stderr, err := runDiffCommandWithStreams(t, root, left, right, "--json")
 	if err != nil {
@@ -234,7 +234,7 @@ func TestDiffCommandJSONMatchingFiles(t *testing.T) {
 	if output.Different {
 		t.Fatal("expected different=false")
 	}
-	for _, value := range []string{"123", "456", "local-secret", "example-secret"} {
+	for _, value := range []string{"left-token", "right-token", "local-secret", "example-secret"} {
 		if strings.Contains(stdout, value) {
 			t.Fatalf("JSON leaked value %q in %q", value, stdout)
 		}


### PR DESCRIPTION

## Summary

Fixes #62. Fix a flaky `vaar diff --json` CLI test by avoiding numeric fixture values that can collide with temporary directory names.

## Why

CI failed when the JSON leak-check test searched stdout for `"123"`. The value appeared in the generated temp directory path, causing a false positive even though JSON output did not leak dotenv values.

## Type

- [x] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Internal refactor
- [x] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Replaced numeric dotenv fixture values with alphanumeric tokens in `TestDiffCommandJSONMatchingFiles`.
- Updated the JSON value-leak assertion to check the new fixture values.

## User-visible changes

**None.**

## Validation

Commands run:

- [ ] `gofmt -w <touched Go files>`
- [ ] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
env GOCACHE=/tmp/go-build-cache go test ./internal/cli -run TestDiffCommandJSONMatchingFiles -count=20
git diff --check
```

## Tests

- [ ] Added tests
- [x] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [ ] Updated documentation
- [x] Not applicable

## Release notes

Fix flaky `vaar diff --json` test failures caused by temp path collisions in CI.

## Reviewer notes

This is a test-only hotfix. No CLI behavior or JSON output format changed.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included
