### PR TITLE
feat: add substitution-key rule

### DIFF
--- a/docs/lint/rules/README.md
+++ b/docs/lint/rules/README.md
@@ -38,6 +38,7 @@ Use the accurate matching evidence level for each rule page:
 | [leading-character](./deterministic/leading-character.md)     | Deterministic  | Flags leading whitespace before content.                    |
 | [quote-character](./deterministic/quote-character.md)         | Deterministic  | Flags unbalanced quote usage.                               |
 | [value-without-quotes](./deterministic/value-without-quotes.md) | Deterministic  | Flags unquoted values containing whitespace.                |
+| [substitution-key](./deterministic/substitution-key.md)       | Deterministic  | Flags malformed env-var substitution syntax inside values.  |
 | [space-character](./deterministic/space-character.md)         | Deterministic  | Flags spaces around the key, delimiter or value.            |
 | [trailing-whitespace](./deterministic/trailing-whitespace.md) | Deterministic  | Flags trailing spaces or tabs.                              |
 | [ending-blank-line](./deterministic/ending-blank-line.md)     | Deterministic  | Flags a file ending that does not match the current policy. |

--- a/docs/lint/rules/deterministic/substitution-key.md
+++ b/docs/lint/rules/deterministic/substitution-key.md
@@ -1,0 +1,77 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
+# substitution-key
+
+Flags malformed `$KEY` and `${KEY}` substitution syntax inside assignment values.
+
+## Problem
+
+Dotenv parsers commonly recognize `$KEY` and `${KEY}` inside values. A missing or extra brace can make the value behave like a substitution or literal text.
+
+## What it catches
+
+Malformed substitutions in unquoted and double-quoted assignment values.
+
+The rule reports:
+
+- `${KEY` missing its closing `}`
+- unbraced substitutions like `$KEY}` with an unmatched closing `}`
+- `${}` with an empty key
+- `${key-name}` when the key is not a portable environment variable name
+
+> [!NOTE]
+> Single-quoted values are literal text and are not scanned. Inline comments
+> recognized by the parser are also ignored.
+
+## Why it matters
+
+Malformed substitutions can behave differently across dotenv parsers, shells and
+deployment tools.
+
+## Evidence level
+
+- `Deterministic`: Vaar can prove this from the parsed file contents alone by detecting malformed `$KEY` and `${KEY}` syntax in assignment values, without expanding the value or checking whether the referenced key exists.
+
+## Fix
+
+Use one of the supported substitution forms: `$KEY` or `${KEY}`.
+
+Automatic fixing is not currently provided because adding or removing braces can
+change the value's meaning.
+
+## Bad example
+
+```dotenv
+ABC=${BAR
+FOO="$BAR}"
+EMPTY_REFERENCE=${}
+```
+
+## Good example
+
+```dotenv
+ABC=${BAR}
+FOO="$BAR"
+BRACED=${BAR}
+UNBRACED=$BAR
+QUOTED_BRACED="${BAR}"
+QUOTED_UNBRACED="$BAR"
+MIXED="prefix-${BAR}-$BAZ-suffix"
+```
+
+## Example output
+
+Linting the bad example above, saved as `.env`:
+
+```bash
+vaar lint --only=substitution-key
+```
+
+Bad Example Produces:
+
+```text
+error substitution-key .env:1 substitution "${BAR" is missing a closing "}"
+error substitution-key .env:2 substitution "$BAR}" contains an unmatched closing "}"
+error substitution-key .env:3 substitution "${}" is empty
+```

--- a/docs/lint/rules/deterministic/substitution-key.md
+++ b/docs/lint/rules/deterministic/substitution-key.md
@@ -18,11 +18,11 @@ The rule reports:
 - `${KEY` missing its closing `}`
 - unbraced substitutions like `$KEY}` with an unmatched closing `}`
 - `${}` with an empty key
-- `${key-name}` when the key is not a portable environment variable name
 
 > [!NOTE]
 > Single-quoted values are literal text and are not scanned. Inline comments
-> recognized by the parser are also ignored.
+> recognized by the parser are also ignored. Unsupported shell expansion forms
+> such as `${KEY:-fallback}` are ignored.
 
 ## Why it matters
 

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -143,6 +143,27 @@ func TestLintCommandOnlyValueWithoutQuotesReportsOnlyThatRule(t *testing.T) {
 	}
 }
 
+func TestLintCommandOnlySubstitutionKeyReportsOnlyThatRule(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=${VALUE\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--only=substitution-key")
+	if err == nil {
+		t.Fatal("expected findings")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	want := "error substitution-key .env:1 substitution \"${VALUE\" is missing a closing \"}\"\n"
+	if stdout != want {
+		t.Fatalf("unexpected output: got %q want %q", stdout, want)
+	}
+}
+
 func TestLintCommandSkipValueWithoutQuotesSuppressesThatRule(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")
@@ -151,6 +172,27 @@ func TestLintCommandSkipValueWithoutQuotesSuppressesThatRule(t *testing.T) {
 	}
 
 	stdout, err := runLintCommand(t, root, "--skip=value-without-quotes")
+	if err == nil {
+		t.Fatal("expected remaining findings")
+	}
+	if got := ExitCode(err); got != ExitFindings {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitFindings)
+	}
+
+	want := "error duplicate-key .env:2 KEY is defined more than once\n"
+	if stdout != want {
+		t.Fatalf("unexpected output: got %q want %q", stdout, want)
+	}
+}
+
+func TestLintCommandSkipSubstitutionKeySuppressesThatRule(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte("KEY=${VALUE\nKEY=other\n"), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	stdout, err := runLintCommand(t, root, "--skip=substitution-key")
 	if err == nil {
 		t.Fatal("expected remaining findings")
 	}

--- a/internal/lint/rules/all.go
+++ b/internal/lint/rules/all.go
@@ -22,6 +22,7 @@ func All() []lint.Rule {
 		deterministic.NewLeadingCharacter(),
 		deterministic.NewQuoteCharacter(),
 		deterministic.NewValueWithoutQuotes(),
+		deterministic.NewSubstitutionKey(),
 		deterministic.NewSpaceCharacter(),
 		deterministic.NewTrailingWhitespace(),
 		deterministic.NewEndingBlankLine(),

--- a/internal/lint/rules/compat.go
+++ b/internal/lint/rules/compat.go
@@ -24,6 +24,8 @@ func NewQuoteCharacter() lint.Rule { return deterministic.NewQuoteCharacter() }
 
 func NewValueWithoutQuotes() lint.Rule { return deterministic.NewValueWithoutQuotes() }
 
+func NewSubstitutionKey() lint.Rule { return deterministic.NewSubstitutionKey() }
+
 func NewSpaceCharacter() lint.Rule { return deterministic.NewSpaceCharacter() }
 
 func NewTrailingWhitespace() lint.Rule { return deterministic.NewTrailingWhitespace() }

--- a/internal/lint/rules/deterministic/substitution_key.go
+++ b/internal/lint/rules/deterministic/substitution_key.go
@@ -1,0 +1,180 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deterministic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+)
+
+type substitutionKeyRule struct{}
+
+// NewSubstitutionKey returns a rule that flags malformed env-var
+// substitutions inside assignment values.
+func NewSubstitutionKey() lint.Rule { return substitutionKeyRule{} }
+
+func (substitutionKeyRule) ID() string { return "substitution-key" }
+
+func (substitutionKeyRule) Description() string {
+	return "flags malformed env-var substitution syntax inside values"
+}
+
+func (substitutionKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
+	findings := make([]lint.Finding, 0)
+
+	for _, file := range ctx.Files {
+		for _, line := range file.Lines {
+			if !line.HasAssignment || !line.HasValue {
+				continue
+			}
+			if line.QuoteState == envfile.QuoteSingle ||
+				line.QuoteState == envfile.QuoteUnbalanced {
+				// Single-quoted values are literal text, and quote-character owns
+				// malformed wrapping quotes, so this rule stays focused on
+				// substitution syntax in values where substitution-like text is
+				// semantically active.
+				continue
+			}
+
+			findings = append(findings, scanSubstitutionFindings(
+				file.Path,
+				line.Number,
+				line.Value,
+			)...)
+		}
+	}
+
+	return findings, nil
+}
+
+func scanSubstitutionFindings(path string, line int, value string) []lint.Finding {
+	findings := make([]lint.Finding, 0)
+
+	for i := 0; i < len(value); {
+		if value[i] != '$' {
+			i++
+			continue
+		}
+
+		if i+1 >= len(value) {
+			i++
+			continue
+		}
+
+		if value[i+1] == '{' {
+			finding, next := scanBracedSubstitution(path, line, value, i)
+			if finding != nil {
+				findings = append(findings, *finding)
+			}
+			i = next
+			continue
+		}
+
+		if !isPortableKeyStart(value[i+1]) {
+			i++
+			continue
+		}
+
+		end := i + 2
+		for end < len(value) && isPortableKeyContinue(value[end]) {
+			end++
+		}
+
+		key := value[i+1 : end]
+		if !validKeyName(key) {
+			i = end
+			continue
+		}
+
+		if end < len(value) && value[end] == '}' {
+			tokenEnd := end + 1
+			for tokenEnd < len(value) && value[tokenEnd] == '}' {
+				tokenEnd++
+			}
+			findings = append(findings, finding(
+				substitutionKeyRule{}.ID(),
+				lint.SeverityError,
+				path,
+				line,
+				fmt.Sprintf(`substitution %q contains an unmatched closing "}"`, value[i:tokenEnd]),
+			))
+			i = tokenEnd
+			continue
+		}
+
+		i = end
+	}
+
+	return findings
+}
+
+func scanBracedSubstitution(path string, line int, value string, start int) (*lint.Finding, int) {
+	closeOffset := strings.IndexByte(value[start+2:], '}')
+	if closeOffset < 0 {
+		finding := finding(
+			substitutionKeyRule{}.ID(),
+			lint.SeverityError,
+			path,
+			line,
+			fmt.Sprintf(`substitution %q is missing a closing "}"`, value[start:]),
+		)
+		return &finding, len(value)
+	}
+
+	closeIdx := start + 2 + closeOffset
+	token := value[start : closeIdx+1]
+	key := value[start+2 : closeIdx]
+
+	if key == "" {
+		finding := finding(
+			substitutionKeyRule{}.ID(),
+			lint.SeverityError,
+			path,
+			line,
+			fmt.Sprintf("substitution %q is empty", token),
+		)
+		return &finding, closeIdx + 1
+	}
+
+	if !validKeyName(key) {
+		finding := finding(
+			substitutionKeyRule{}.ID(),
+			lint.SeverityError,
+			path,
+			line,
+			fmt.Sprintf("substitution %q does not use a portable env key name", token),
+		)
+		return &finding, closeIdx + 1
+	}
+
+	if closeIdx+1 < len(value) && value[closeIdx+1] == '}' {
+		tokenEnd := closeIdx + 2
+		for tokenEnd < len(value) && value[tokenEnd] == '}' {
+			tokenEnd++
+		}
+		finding := finding(
+			substitutionKeyRule{}.ID(),
+			lint.SeverityError,
+			path,
+			line,
+			fmt.Sprintf(`substitution %q contains an unmatched closing "}"`, value[start:tokenEnd]),
+		)
+		return &finding, tokenEnd
+	}
+
+	return nil, closeIdx + 1
+}
+
+func isPortableKeyStart(b byte) bool {
+	return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
+}
+
+func isPortableKeyContinue(b byte) bool {
+	return isPortableKeyStart(b) || (b >= '0' && b <= '9')
+}

--- a/internal/lint/rules/deterministic/substitution_key.go
+++ b/internal/lint/rules/deterministic/substitution_key.go
@@ -15,14 +15,14 @@ import (
 
 type substitutionKeyRule struct{}
 
-// NewSubstitutionKey returns a rule that flags malformed env-var
+// NewSubstitutionKey returns a rule that flags malformed $KEY and ${KEY}
 // substitutions inside assignment values.
 func NewSubstitutionKey() lint.Rule { return substitutionKeyRule{} }
 
 func (substitutionKeyRule) ID() string { return "substitution-key" }
 
 func (substitutionKeyRule) Description() string {
-	return "flags malformed env-var substitution syntax inside values"
+	return "flags malformed $KEY and ${KEY} substitution syntax inside values"
 }
 
 func (substitutionKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
@@ -143,14 +143,7 @@ func scanBracedSubstitution(path string, line int, value string, start int) (*li
 	}
 
 	if !validKeyName(key) {
-		finding := finding(
-			substitutionKeyRule{}.ID(),
-			lint.SeverityError,
-			path,
-			line,
-			fmt.Sprintf("substitution %q does not use a portable env key name", token),
-		)
-		return &finding, closeIdx + 1
+		return nil, closeIdx + 1
 	}
 
 	if closeIdx+1 < len(value) && value[closeIdx+1] == '}' {

--- a/internal/lint/rules/deterministic/substitution_key.go
+++ b/internal/lint/rules/deterministic/substitution_key.go
@@ -25,6 +25,7 @@ func (substitutionKeyRule) Description() string {
 	return "flags malformed $KEY and ${KEY} substitution syntax inside values"
 }
 
+// Run scans assignment values for malformed supported substitution syntax.
 func (substitutionKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
 
@@ -53,6 +54,7 @@ func (substitutionKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	return findings, nil
 }
 
+// scanSubstitutionFindings reports malformed substitutions found in one value.
 func scanSubstitutionFindings(path string, line int, value string) []lint.Finding {
 	findings := make([]lint.Finding, 0)
 
@@ -114,6 +116,7 @@ func scanSubstitutionFindings(path string, line int, value string) []lint.Findin
 	return findings
 }
 
+// scanBracedSubstitution validates one ${KEY} candidate starting at start.
 func scanBracedSubstitution(path string, line int, value string, start int) (*lint.Finding, int) {
 	closeOffset := strings.IndexByte(value[start+2:], '}')
 	if closeOffset < 0 {
@@ -164,10 +167,12 @@ func scanBracedSubstitution(path string, line int, value string, start int) (*li
 	return nil, closeIdx + 1
 }
 
+// isPortableKeyStart reports whether b can begin a supported key reference.
 func isPortableKeyStart(b byte) bool {
 	return b == '_' || (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z')
 }
 
+// isPortableKeyContinue reports whether b can continue a supported key reference.
 func isPortableKeyContinue(b byte) bool {
 	return isPortableKeyStart(b) || (b >= '0' && b <= '9')
 }

--- a/internal/lint/rules/deterministic/substitution_key_test.go
+++ b/internal/lint/rules/deterministic/substitution_key_test.go
@@ -28,6 +28,9 @@ func TestSubstitutionKeyAcceptsValidForms(t *testing.T) {
 			"LITERAL_BRACE=value}",
 			"JSON_VALUE={\"enabled\":true}",
 			"LITERAL_DOLLAR=$",
+			"UNSUPPORTED_DEFAULT=${KEY:-fallback}",
+			"UNSUPPORTED_REQUIRED=${KEY:?required}",
+			"UNSUPPORTED_NESTED=${OUTER:-${INNER}}",
 			"PLAIN_VALUE=value",
 		}, "\n") + "\n"),
 		wantCount: 0,
@@ -40,7 +43,6 @@ func TestSubstitutionKeyReportsMalformedSubstitutions(t *testing.T) {
 		"FOO=\"$BAR}\"",
 		"EMPTY_REFERENCE=${}",
 		"EXTRA_CLOSE=${BAR}}",
-		"INVALID_BRACED=${1BAR}",
 	}, "\n")+"\n")
 
 	assertSubstitutionFindings(t, findings, []expectedFinding{
@@ -59,10 +61,6 @@ func TestSubstitutionKeyReportsMalformedSubstitutions(t *testing.T) {
 		{
 			line:        4,
 			messagePart: `substitution "${BAR}}" contains an unmatched closing "}"`,
-		},
-		{
-			line:        5,
-			messagePart: `substitution "${1BAR}" does not use a portable env key name`,
 		},
 	})
 }

--- a/internal/lint/rules/deterministic/substitution_key_test.go
+++ b/internal/lint/rules/deterministic/substitution_key_test.go
@@ -105,6 +105,7 @@ type expectedFinding struct {
 	messagePart string
 }
 
+// runSubstitutionKey parses input and runs only the substitution-key rule.
 func runSubstitutionKey(t *testing.T, input string) []lint.Finding {
 	t.Helper()
 
@@ -123,6 +124,7 @@ func runSubstitutionKey(t *testing.T, input string) []lint.Finding {
 	return findings
 }
 
+// assertSubstitutionFindings checks the stable fields this rule owns.
 func assertSubstitutionFindings(t *testing.T, findings []lint.Finding, want []expectedFinding) {
 	t.Helper()
 

--- a/internal/lint/rules/deterministic/substitution_key_test.go
+++ b/internal/lint/rules/deterministic/substitution_key_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package deterministic_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules/deterministic"
+)
+
+func TestSubstitutionKeyAcceptsValidForms(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule: deterministic.NewSubstitutionKey(),
+		input: []byte(strings.Join([]string{
+			"VALID_BRACED=${BAR}",
+			"VALID_UNBRACED=$BAR",
+			"VALID_QUOTED_BRACED=\"${BAR}\"",
+			"VALID_QUOTED_UNBRACED=\"$BAR\"",
+			"VALID_SINGLE_QUOTED='${BAR}-$BAZ'",
+			"VALID_MIXED=\"prefix-${BAR}-$BAZ-suffix\"",
+			"VALUE=$BAR # } is part of the comment",
+			"LITERAL_BRACE=value}",
+			"JSON_VALUE={\"enabled\":true}",
+			"LITERAL_DOLLAR=$",
+			"PLAIN_VALUE=value",
+		}, "\n") + "\n"),
+		wantCount: 0,
+	})
+}
+
+func TestSubstitutionKeyReportsMalformedSubstitutions(t *testing.T) {
+	findings := runSubstitutionKey(t, strings.Join([]string{
+		"ABC=${BAR",
+		"FOO=\"$BAR}\"",
+		"EMPTY_REFERENCE=${}",
+		"EXTRA_CLOSE=${BAR}}",
+		"INVALID_BRACED=${1BAR}",
+	}, "\n")+"\n")
+
+	assertSubstitutionFindings(t, findings, []expectedFinding{
+		{
+			line:        1,
+			messagePart: `substitution "${BAR" is missing a closing "}"`,
+		},
+		{
+			line:        2,
+			messagePart: `substitution "$BAR}" contains an unmatched closing "}"`,
+		},
+		{
+			line:        3,
+			messagePart: `substitution "${}" is empty`,
+		},
+		{
+			line:        4,
+			messagePart: `substitution "${BAR}}" contains an unmatched closing "}"`,
+		},
+		{
+			line:        5,
+			messagePart: `substitution "${1BAR}" does not use a portable env key name`,
+		},
+	})
+}
+
+func TestSubstitutionKeySupportsMultipleSubstitutionsInOneValue(t *testing.T) {
+	findings := runSubstitutionKey(t, "CHAIN=$FOO}$BAR}\n")
+
+	assertSubstitutionFindings(t, findings, []expectedFinding{
+		{
+			line:        1,
+			messagePart: `substitution "$FOO}" contains an unmatched closing "}"`,
+		},
+		{
+			line:        1,
+			messagePart: `substitution "$BAR}" contains an unmatched closing "}"`,
+		},
+	})
+}
+
+func TestSubstitutionKeySkipsSingleQuotedLiterals(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule: deterministic.NewSubstitutionKey(),
+		input: []byte(strings.Join([]string{
+			"LITERAL='${BAR'",
+			"ALSO_LITERAL='$BAR}'",
+			"EMPTY_LITERAL='${}'",
+		}, "\n") + "\n"),
+		wantCount: 0,
+	})
+}
+
+func TestSubstitutionKeySkipsUnbalancedQuotedValues(t *testing.T) {
+	runRuleTest(t, ruleTestCase{
+		rule:      deterministic.NewSubstitutionKey(),
+		input:     []byte("BROKEN=\"${BAR\n"),
+		wantCount: 0,
+	})
+}
+
+type expectedFinding struct {
+	line        int
+	messagePart string
+}
+
+func runSubstitutionKey(t *testing.T, input string) []lint.Finding {
+	t.Helper()
+
+	file, err := envfile.Parse("test.env", []byte(input))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	findings, err := deterministic.NewSubstitutionKey().Run(lint.Context{
+		Files: []envfile.File{file},
+	})
+	if err != nil {
+		t.Fatalf("rule run failed: %v", err)
+	}
+
+	return findings
+}
+
+func assertSubstitutionFindings(t *testing.T, findings []lint.Finding, want []expectedFinding) {
+	t.Helper()
+
+	if got, wantCount := len(findings), len(want); got != wantCount {
+		t.Fatalf("unexpected finding count: got %d want %d", got, wantCount)
+	}
+
+	for i, finding := range findings {
+		if finding.Rule != "substitution-key" {
+			t.Fatalf("finding %d rule: got %q want %q", i, finding.Rule, "substitution-key")
+		}
+		if finding.Severity != lint.SeverityError {
+			t.Fatalf("finding %d severity: got %q want %q", i, finding.Severity, lint.SeverityError)
+		}
+		if finding.Line != want[i].line {
+			t.Fatalf("finding %d line: got %d want %d", i, finding.Line, want[i].line)
+		}
+		if !strings.Contains(finding.Message, want[i].messagePart) {
+			t.Fatalf("finding %d message: got %q want substring %q", i, finding.Message, want[i].messagePart)
+		}
+	}
+}

--- a/internal/lint/rules/fixability_test.go
+++ b/internal/lint/rules/fixability_test.go
@@ -59,6 +59,7 @@ func fixabilityFixtures() map[string][]byte {
 		"line-ending":          []byte("KEY=one\r\nKEY2=two\n"),
 		"quote-character":      []byte("KEY=\"broken\n"),
 		"space-character":      []byte("KEY = value\n"),
+		"substitution-key":     []byte("BROKEN=${BAR\n"),
 		"trailing-whitespace":  []byte("KEY=value  \n"),
 		"value-without-key":    []byte("=supersecret-token-123\n"),
 		"value-without-quotes": []byte("FOO=BAR BAZ\n"),


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Fixes #46. Add the deterministic `substitution-key` lint rule for malformed `$KEY` and `${KEY}` syntax in dotenv assignment values.

## Why

Malformed substitution syntax can be interpreted differently across dotenv parsers, shells and deployment tools. Vaar should report incomplete, empty or mismatched substitution syntax before the file reaches an application or deployment environment.

## Type

- [ ] Bug fix
- [x] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [x] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added the `substitution-key` deterministic lint rule and registered it in the canonical rule set.
- Added coverage for valid substitutions, malformed substitutions, quoted values, inline comments, unrelated braces, `--only`, `--skip` and fixability behavior.

## User-visible changes

Before:

```dotenv
ABC=${BAR
FOO="$BAR}"
EMPTY_REFERENCE=${}
```

These malformed substitution values were not reported by a dedicated rule.

After:

```text
error substitution-key .env:1 substitution "${BAR" is missing a closing "}"
error substitution-key .env:2 substitution "$BAR}" contains an unmatched closing "}"
error substitution-key .env:3 substitution "${}" is empty
```

## Validation

Commands run:

- [ ] `gofmt -w <touched Go files>`
- [ ] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...`

Additional commands:

```text
env GOCACHE=/tmp/go-build go test ./internal/lint/rules/deterministic ./internal/lint/rules ./internal/cli
env GOCACHE=/tmp/go-build go test ./...
```

## Tests

- [x] Added tests
- [x] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Add the `substitution-key` lint rule to report malformed `$KEY` and `${KEY}` substitution syntax in dotenv assignment values.

## Reviewer notes

Please pay special attention to substitution parsing scope: the rule scans unquoted and double-quoted assignment values, ignores recognized inline comments, treats single-quoted values as literal text, and does not expand values or check whether referenced keys exist.

## Checklist

- [x] PR title follows Conventional Commits
- [ ] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `substitution-key` lint rule to detect malformed `$KEY` / `${KEY}` syntax in dotenv assignment values.
  * Reports missing closing braces, empty `${}`, and unmatched extra `}` with precise, line-based errors.
  * Works with `--only` / `--skip` and skips scanning inside single-quoted values.
* **Documentation**
  * Updated the rule catalog and added a dedicated rule page with good/bad examples and sample CLI output.
* **Tests**
  * Added unit and end-to-end CLI coverage for rule selection, reporting, and fixability coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->