### PR TITLE
feat(normalize): add an opt-in vaar normalize command

### DIFF
--- a/internal/cli/normalize.go
+++ b/internal/cli/normalize.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/spf13/cobra"
+)
+
+// newNormalizeCmd builds the normalize subcommand, which applies the blunt
+// whole-file formatting normalization on demand, independent of any lint
+// finding.
+func newNormalizeCmd() *cobra.Command {
+	var scope lint.Options
+
+	cmd := &cobra.Command{
+		Use:   "normalize",
+		Short: "Normalize dotenv formatting on demand",
+		Long: `Apply Vaar's blunt formatting normalization to discovered dotenv files,
+whether or not any lint rule reports a finding.
+
+It strips a leading UTF-8 BOM, converts every line ending to LF (including
+uniform CRLF or lone-CR files, which lint --fix deliberately leaves alone),
+trims trailing whitespace, collapses repeated blank lines to one and leaves
+exactly one final newline. Each rewritten file is reported as it is written;
+files that are already normalized are left untouched.
+
+Use --target to normalize one file and --target-dir to discover files under
+one directory. Use either --target or --target-dir, not both. To repair only
+what the lint rules actually report, use vaar lint --fix instead.`,
+		Example: `  vaar normalize
+  vaar normalize --target=.env.staging
+  vaar normalize --target-dir=src`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			normalized, err := lint.Normalize(lint.Options{
+				Root:      ".",
+				Target:    scope.Target,
+				TargetDir: scope.TargetDir,
+			})
+			if err != nil {
+				return NewToolError("normalize failed", err)
+			}
+
+			for _, path := range normalized {
+				fmt.Fprintf(cmd.OutOrStdout(), "normalized %s\n", path)
+			}
+			return nil
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&scope.Target, "target", "", "Normalize only the specified file path.")
+	flags.StringVar(&scope.TargetDir, "target-dir", "", "Recursively normalize dotenv files under the specified directory.")
+
+	return cmd
+}

--- a/internal/cli/normalize_test.go
+++ b/internal/cli/normalize_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// uniformCRLFContent has no mixed line endings, so the line-ending rule reports
+// nothing about it and lint --fix leaves it alone. It is exactly the file the
+// normalize command exists to repair.
+const uniformCRLFContent = "KEY=value\r\nNEXT=2\r\n"
+
+func TestNormalizeCommandRewritesFileThatLintFixLeavesAlone(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWriteFile(t, path, uniformCRLFContent)
+
+	// Regression guard for the finding-scoped --fix: no finding, no rewrite.
+	if _, err := runLintCommand(t, root, "--fix"); err != nil {
+		t.Fatalf("expected lint --fix to succeed, got %v", err)
+	}
+	if got := mustReadFile(t, path); got != uniformCRLFContent {
+		t.Fatalf("lint --fix rewrote a file with no finding: got %q want %q", got, uniformCRLFContent)
+	}
+
+	// The normalize command is the opt-in surface that does rewrite it.
+	stdout, stderr, err := runNormalizeCommandWithStreams(t, root)
+	if err != nil {
+		t.Fatalf("expected normalize to succeed, got %v", err)
+	}
+	if want := "normalized .env\n"; stdout != want {
+		t.Fatalf("unexpected normalize report: got %q want %q", stdout, want)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+	if got, want := mustReadFile(t, path), "KEY=value\nNEXT=2\n"; got != want {
+		t.Fatalf("unexpected normalized content: got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeCommandLeavesNormalizedFileByteIdentical(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	const content = "KEY=value\n\nNEXT=2\n"
+	mustWriteFile(t, path, content)
+
+	stdout, stderr, err := runNormalizeCommandWithStreams(t, root)
+	if err != nil {
+		t.Fatalf("expected normalize to succeed, got %v", err)
+	}
+	// Nothing is reported because nothing was written.
+	if stdout != "" {
+		t.Fatalf("expected no normalize report, got %q", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("expected no stderr, got %q", stderr)
+	}
+	if got := mustReadFile(t, path); got != content {
+		t.Fatalf("normalize rewrote an already normalized file: got %q want %q", got, content)
+	}
+}
+
+func TestNormalizeCommandTargetNormalizesOnlyThatFile(t *testing.T) {
+	root := t.TempDir()
+	envPath := filepath.Join(root, ".env")
+	stagingPath := filepath.Join(root, ".env.staging")
+	mustWriteFile(t, envPath, uniformCRLFContent)
+	mustWriteFile(t, stagingPath, uniformCRLFContent)
+
+	stdout, _, err := runNormalizeCommandWithStreams(t, root, "--target=.env.staging")
+	if err != nil {
+		t.Fatalf("expected normalize --target to succeed, got %v", err)
+	}
+	if want := "normalized .env.staging\n"; stdout != want {
+		t.Fatalf("unexpected normalize report: got %q want %q", stdout, want)
+	}
+
+	if got, want := mustReadFile(t, stagingPath), "KEY=value\nNEXT=2\n"; got != want {
+		t.Fatalf("unexpected normalized content: got %q want %q", got, want)
+	}
+	if got := mustReadFile(t, envPath); got != uniformCRLFContent {
+		t.Fatalf("normalize left the target scope: got %q want %q", got, uniformCRLFContent)
+	}
+}
+
+func TestNormalizeCommandTargetDirNormalizesOnlyThatTree(t *testing.T) {
+	root := t.TempDir()
+	envPath := filepath.Join(root, ".env")
+	nestedPath := filepath.Join(root, "src", "app", ".env.example")
+	mustWriteFile(t, envPath, uniformCRLFContent)
+	if err := os.MkdirAll(filepath.Dir(nestedPath), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	mustWriteFile(t, nestedPath, uniformCRLFContent)
+
+	stdout, _, err := runNormalizeCommandWithStreams(t, root, "--target-dir=src")
+	if err != nil {
+		t.Fatalf("expected normalize --target-dir to succeed, got %v", err)
+	}
+	if want := "normalized " + filepath.Join("src", "app", ".env.example") + "\n"; stdout != want {
+		t.Fatalf("unexpected normalize report: got %q want %q", stdout, want)
+	}
+
+	if got, want := mustReadFile(t, nestedPath), "KEY=value\nNEXT=2\n"; got != want {
+		t.Fatalf("unexpected normalized content: got %q want %q", got, want)
+	}
+	if got := mustReadFile(t, envPath); got != uniformCRLFContent {
+		t.Fatalf("normalize left the target-dir scope: got %q want %q", got, uniformCRLFContent)
+	}
+}
+
+func TestNormalizeCommandRejectsTargetAndTargetDirTogether(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".env"), uniformCRLFContent)
+
+	_, _, err := runNormalizeCommandWithStreams(t, root, "--target=.env", "--target-dir=.")
+	if err == nil {
+		t.Fatal("expected normalize to reject both scope flags")
+	}
+	if got := ExitCode(err); got != ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "--target and --target-dir cannot be used together") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNormalizeCommandRejectsPositionalArguments(t *testing.T) {
+	root := t.TempDir()
+	mustWriteFile(t, filepath.Join(root, ".env"), uniformCRLFContent)
+
+	if _, _, err := runNormalizeCommandWithStreams(t, root, ".env"); err == nil {
+		t.Fatal("expected normalize to reject positional arguments")
+	}
+}
+
+func runNormalizeCommandWithStreams(t *testing.T, root string, args ...string) (string, string, error) {
+	t.Helper()
+
+	withWorkingDir(t, root)
+
+	var stdout, stderr bytes.Buffer
+	cmd := newRootCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(append([]string{"normalize"}, args...))
+
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s failed: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,6 +37,7 @@ and automation-friendly output.`,
 	cmd.AddCommand(
 		newLintCmd(),
 		newDiffCmd(),
+		newNormalizeCmd(),
 	)
 	return cmd
 }

--- a/internal/lint/normalize.go
+++ b/internal/lint/normalize.go
@@ -1,0 +1,84 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/envaar/vaar/internal/envfile"
+)
+
+// normalizePipeline is the blunt whole-file formatting normalization exposed by
+// the normalize command, in the canonical order the fix pipeline documents:
+//
+//	StripBOM -> NormalizeLineEndings -> TrimTrailingWhitespace ->
+//	CollapseBlankLines -> TrimFinalBlankLines
+//
+// Unlike the rule fix halves behind lint --fix, every transform here runs
+// unconditionally: line endings are forced to LF even when a file is uniform
+// CRLF or uniform lone CR, so the pass does not depend on any rule reporting a
+// finding.
+var normalizePipeline = []func([]byte) []byte{
+	envfile.StripBOM,
+	envfile.NormalizeLineEndings,
+	envfile.TrimTrailingWhitespace,
+	envfile.CollapseBlankLines,
+	envfile.TrimFinalBlankLines,
+}
+
+// NormalizeData applies the blunt normalization pipeline to data and returns
+// the normalized bytes. It performs no I/O so tests can pin the pipeline
+// directly.
+func NormalizeData(data []byte) []byte {
+	for _, transform := range normalizePipeline {
+		data = transform(data)
+	}
+	return data
+}
+
+// Normalize discovers dotenv files for the given scope and rewrites each one
+// whose bytes change under the blunt normalization pipeline, returning the
+// rewritten paths relative to the root in discovery order. A file that is
+// already normalized is not rewritten, so repeated runs are stable. Like
+// ApplyFixes, it reports the first read or write failure and stops.
+func Normalize(opts Options) ([]string, error) {
+	if opts.Root == "" {
+		opts.Root = "."
+	}
+
+	absRoot, err := filepath.Abs(opts.Root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve root %q: %w", opts.Root, err)
+	}
+
+	paths, err := discoverPaths(absRoot, opts.Root, opts.Target, opts.TargetDir)
+	if err != nil {
+		return nil, err
+	}
+
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		fixed := NormalizeData(data)
+		if bytes.Equal(fixed, data) {
+			continue
+		}
+
+		if err := envfile.Write(path, fixed); err != nil {
+			return nil, err
+		}
+		normalized = append(normalized, displayPath(absRoot, path))
+	}
+
+	return normalized, nil
+}

--- a/internal/lint/normalize_test.go
+++ b/internal/lint/normalize_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+)
+
+// uniformCRLF has no mixed line endings, so the line-ending rule reports
+// nothing and the finding-scoped --fix pipeline must leave it alone. It is the
+// exact input the normalize pass exists to repair.
+const uniformCRLF = "KEY=value\r\nNEXT=2\r\n"
+
+func TestNormalizeDataForcesLineEndingsThatFixDataKeeps(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"uniform-crlf", uniformCRLF, "KEY=value\nNEXT=2\n"},
+		{"lone-cr", "A=1\rB=2\r", "A=1\nB=2\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The rule fix halves behind --fix are finding-scoped: uniform
+			// endings produce no finding, so composing every rule changes
+			// nothing here.
+			if got := string(lint.FixData(rules.All(), []byte(tc.input))); got != tc.input {
+				t.Fatalf("--fix pipeline rewrote a file with no finding: got %q want %q", got, tc.input)
+			}
+
+			// NormalizeData is deliberately blunt and rewrites the endings anyway.
+			if got := string(lint.NormalizeData([]byte(tc.input))); got != tc.want {
+				t.Fatalf("unexpected normalized bytes: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDataAppliesTheWholeFilePipeline(t *testing.T) {
+	input := append([]byte{0xEF, 0xBB, 0xBF}, []byte("KEY=value  \r\n\r\n\r\nFOO=bar   ")...)
+
+	// BOM stripped, endings forced to LF, trailing whitespace trimmed, the
+	// blank run collapsed to one and exactly one final newline left behind.
+	if got, want := string(lint.NormalizeData(input)), "KEY=value\n\nFOO=bar\n"; got != want {
+		t.Fatalf("unexpected normalized bytes: got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeRewritesUniformCRLFFileAndReportsIt(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte(uniformCRLF), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	normalized, err := lint.Normalize(lint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	if len(normalized) != 1 || normalized[0] != ".env" {
+		t.Fatalf("unexpected normalized paths: %q", normalized)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if want := "KEY=value\nNEXT=2\n"; string(got) != want {
+		t.Fatalf("unexpected normalized content: got %q want %q", string(got), want)
+	}
+}
+
+func TestNormalizeLeavesAlreadyNormalizedFileUntouched(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	const content = "KEY=value\n\nNEXT=2\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	normalized, err := lint.Normalize(lint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("normalize failed: %v", err)
+	}
+	// An empty report means the file was skipped rather than rewritten.
+	if len(normalized) != 0 {
+		t.Fatalf("expected no file to be rewritten, got %q", normalized)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if string(got) != content {
+		t.Fatalf("normalized file changed: got %q want %q", string(got), content)
+	}
+}
+
+func TestNormalizeIsStableAcrossRuns(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	if err := os.WriteFile(path, []byte(uniformCRLF), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	first, err := lint.Normalize(lint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("first normalize failed: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("expected the first run to rewrite the file, got %q", first)
+	}
+
+	second, err := lint.Normalize(lint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("second normalize failed: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("expected the second run to rewrite nothing, got %q", second)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `vaar normalize` — the blunt whole-file formatting pass, as its own opt-in surface.

## Why

Since #54 made `--fix` strictly finding-scoped, a *uniform* CRLF file produces no line-ending finding, so `--fix` correctly leaves it alone. This gives that normalization an explicit home instead of folding it back into `--fix`, so a blunt rewrite is always something you asked for by name.

I went with a subcommand rather than a `--fix --normalize` flag because it matches how `diff` is structured — same `discoverPaths` handling, same `--target` / `--target-dir` shape, same report style.

Closes #63

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Internal refactor
- [ ] Hotfix

None of the listed types fits cleanly — this adds a new CLI subcommand rather than a rule, parser or reporter change. Tell me which you'd file it under and I'll tick it.

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

`lint --fix` is untouched.

## Changes

- `internal/lint/normalize.go` (+84) — composes the existing `envfile` transforms unconditionally: line endings (uniform CRLF and lone CR forced to LF), BOM, trailing whitespace, blank-run collapsing
- `internal/cli/normalize.go` (+62) — the subcommand, with `--target` / `--target-dir`
- `internal/cli/root.go` (+1) — registration
- `internal/lint/normalize_test.go` (+131), `internal/cli/normalize_test.go` (+169) — 11 new tests

Files already normalized are left byte-identical and produce no output, so it is idempotent and safe to run repeatedly.

## User-visible changes

A new subcommand. On `KEY=value\r\nNEXT=2\r\n`, verified end-to-end with the built binary:

```
$ vaar lint --fix        # unchanged behaviour — no finding, file untouched
$ vaar normalize
normalized .env
$ vaar normalize         # idempotent — prints nothing
```

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>` — `gofmt -l` empty
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...`

Additional commands:

```text
go vet ./...
go build ./...
go mod tidy          # no diff
CI lint / JSON / fix smoke tests — all clean
```

`TestLintCommandTargetFileReportsUnreadablePath` and `TestLintCommandReturnsInternalErrorWhenDiscoveryFails` fail in my environment, but they fail identically on a clean checkout: I'm running as uid 0 and `chmod 0` doesn't block root. Unrelated to this change.

## Tests

- [x] Added tests

11 new, covering the blunt-vs-scoped divergence at both the `NormalizeData`/`FixData` level and through the CLI (the regression guard for #54's behavior), the full transform pipeline on a BOM+CRLF+trailing-whitespace+blank-run fixture, already-normalized files left byte-identical, idempotence, and the `--target` / `--target-dir` / both-flags-rejected / positional-args paths.

They were checked against a revert rather than just observed passing: dropping `NormalizeLineEndings` from the pipeline produces 5 failures (`got "KEY=value\r\nNEXT=2\r\n" want "KEY=value\nNEXT=2\n"`), and removing the feature entirely fails them with `undefined: lint.NormalizeData`.

The existing `--fix` tests are unmodified and passing.

No docs entry, since `diff` doesn't have one either — happy to add both if you'd like.

## Footer

Generated by Claude Opus 5 (implementation), Claude Opus 4.8 (brief, review)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `normalize` CLI command for whole-file dotenv formatting.
  * Supports targeting a specific file or directory.
  * Normalizes line endings, whitespace, blank lines, and file headers.
  * Reports each file that was rewritten while leaving already-normalized files unchanged.
* **Bug Fixes**
  * Added validation for conflicting target options and unsupported positional arguments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->