### PR TITLE
refactor(scope): extract lint input selection (#66)

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -81,11 +81,16 @@ Use either --target or --target-dir, not both.`,
 				SkipRules: selection.SkipRules,
 				Fix:       lintFix,
 			}
+			allRules := rules.All()
 
 			if lintOutput != "" {
 				if err := validateOutputDestination(lintOutput); err != nil {
 					return err
 				}
+			}
+
+			if err := lint.ValidateRuleSelection(allRules, opts.OnlyRules, opts.SkipRules); err != nil {
+				return NewToolError("lint failed", err)
 			}
 
 			scopeSelection, err := scope.Resolve(scope.Options{
@@ -106,7 +111,7 @@ Use either --target or --target-dir, not both.`,
 				}
 			}
 
-			runner := lint.NewRunner(rules.All()...)
+			runner := lint.NewRunner(allRules...)
 			result, err := runner.RunWithSelection(cmd.Context(), opts, scopeSelection)
 			if err != nil {
 				return NewToolError("lint failed", err)

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -13,6 +13,7 @@ import (
 	"github.com/envaar/vaar/internal/lint"
 	"github.com/envaar/vaar/internal/lint/rules"
 	"github.com/envaar/vaar/internal/report"
+	"github.com/envaar/vaar/internal/scope"
 	"github.com/spf13/cobra"
 )
 
@@ -85,13 +86,28 @@ Use either --target or --target-dir, not both.`,
 				if err := validateOutputDestination(lintOutput); err != nil {
 					return err
 				}
-				if err := lint.ValidateOutputPath(opts, lintOutput); err != nil {
+			}
+
+			scopeSelection, err := scope.Resolve(scope.Options{
+				Root:      opts.Root,
+				Target:    opts.Target,
+				TargetDir: opts.TargetDir,
+			})
+			if err != nil {
+				if lintOutput != "" {
+					return NewToolError(err.Error(), nil)
+				}
+				return NewToolError("lint failed", err)
+			}
+
+			if lintOutput != "" {
+				if err := lint.ValidateOutputPath(scopeSelection, lintOutput); err != nil {
 					return NewToolError(err.Error(), nil)
 				}
 			}
 
 			runner := lint.NewRunner(rules.All()...)
-			result, err := runner.Run(cmd.Context(), opts)
+			result, err := runner.RunWithSelection(cmd.Context(), opts, scopeSelection)
 			if err != nil {
 				return NewToolError("lint failed", err)
 			}

--- a/internal/cli/lint_test.go
+++ b/internal/cli/lint_test.go
@@ -685,6 +685,16 @@ func TestLintCommandTargetScopeErrors(t *testing.T) {
 			wantText: "--target path does not exist: missing.env",
 		},
 		{
+			name:     "invalid only beats missing target file",
+			args:     []string{"--only=json-output", "--target=missing.env"},
+			wantText: "unknown lint rule \"json-output\"",
+		},
+		{
+			name:     "invalid skip beats missing target file",
+			args:     []string{"--skip=json-output", "--target=missing.env"},
+			wantText: "unknown lint rule \"json-output\"",
+		},
+		{
 			name:     "target points to directory",
 			args:     []string{"--target=src"},
 			wantText: "--target must point to a file: src",

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/envaar/vaar/internal/envfile"
-	"github.com/envaar/vaar/internal/fs"
+	"github.com/envaar/vaar/internal/scope"
 )
 
 // Runner executes a rule set over discovered dotenv files and keeps the
@@ -40,44 +40,39 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	if opts.Root == "" {
-		opts.Root = "."
-	}
-
-	absRoot, err := filepath.Abs(opts.Root)
-	if err != nil {
-		return Result{}, fmt.Errorf("resolve root %q: %w", opts.Root, err)
-	}
-
-	paths, err := discoverPaths(absRoot, opts.Root, opts.Target, opts.TargetDir)
+	selection, err := scope.Resolve(scope.Options{
+		Root:      opts.Root,
+		Target:    opts.Target,
+		TargetDir: opts.TargetDir,
+	})
 	if err != nil {
 		return Result{}, err
 	}
 
-	files, err := loadFiles(absRoot, paths)
+	files, err := loadFiles(selection)
 	if err != nil {
 		return Result{}, err
 	}
 
-	findings, err := r.runRules(ctx, absRoot, selected, files, opts)
+	findings, err := r.runRules(ctx, selection.Root, selected, files, opts)
 	if err != nil {
 		return Result{}, err
 	}
 
 	changed := false
 	if opts.Fix {
-		changed, err = ApplyFixes(selected, paths)
+		changed, err = ApplyFixes(selected, selection.Paths)
 		if err != nil {
 			return Result{}, err
 		}
 
 		if changed {
-			fixedFiles, err := loadFiles(absRoot, paths)
+			fixedFiles, err := loadFiles(selection)
 			if err != nil {
 				return Result{}, err
 			}
 
-			remaining, err := r.runRules(ctx, absRoot, selected, fixedFiles, opts)
+			remaining, err := r.runRules(ctx, selection.Root, selected, fixedFiles, opts)
 			if err != nil {
 				return Result{}, err
 			}
@@ -151,82 +146,16 @@ func markFixedFindings(original, remaining []Finding) []Finding {
 	return append(findings, remaining...)
 }
 
-// discoverPaths resolves the active lint scope and keeps the default recursive
-// repository walk unchanged when no explicit target flags are provided.
-func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) {
-	if target != "" && targetDir != "" {
-		return nil, fmt.Errorf("--target and --target-dir cannot be used together")
-	}
-
-	if target != "" {
-		path := resolvePath(root, target)
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil, scopePathError("--target", target, err)
-		}
-		if info.IsDir() {
-			return nil, fmt.Errorf("--target must point to a file: %s", target)
-		}
-		return []string{path}, nil
-	}
-
-	if targetDir != "" {
-		path := resolvePath(root, targetDir)
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil, scopePathError("--target-dir", targetDir, err)
-		}
-		if !info.IsDir() {
-			return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
-		}
-
-		paths, err := fs.Discover(path)
-		if err != nil {
-			return nil, fmt.Errorf("discovering files under %q: %w", targetDir, err)
-		}
-		return paths, nil
-	}
-
-	paths, err := fs.Discover(root)
-	if err != nil {
-		return nil, fmt.Errorf("discovering files under %q: %w", rootLabel, err)
-	}
-	return paths, nil
-}
-
-// resolvePath turns a user-supplied relative or absolute scope path into an
-// absolute path anchored to the current lint root.
-func resolvePath(root, path string) string {
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-	return filepath.Join(root, path)
-}
-
-// scopePathError keeps target scope failures easy to understand while
-// preserving the underlying OS error for troubleshooting.
-func scopePathError(flag, path string, err error) error {
-	if os.IsNotExist(err) {
-		return fmt.Errorf("%s path does not exist: %s", flag, path)
-	}
-	return fmt.Errorf("%s path cannot be read: %s: %w", flag, path, err)
-}
-
 // ValidateOutputPath reports an error if outputPath resolves to the same file
 // as any input path that would be linted with opts. The comparison uses
 // canonical absolute paths so relative, cleaned and symlink-equivalent forms
 // are detected.
 func ValidateOutputPath(opts Options, outputPath string) error {
-	if opts.Root == "" {
-		opts.Root = "."
-	}
-
-	absRoot, err := filepath.Abs(opts.Root)
-	if err != nil {
-		return fmt.Errorf("resolve root %q: %w", opts.Root, err)
-	}
-
-	inputs, err := discoverPaths(absRoot, opts.Root, opts.Target, opts.TargetDir)
+	selection, err := scope.Resolve(scope.Options{
+		Root:      opts.Root,
+		Target:    opts.Target,
+		TargetDir: opts.TargetDir,
+	})
 	if err != nil {
 		return err
 	}
@@ -236,7 +165,7 @@ func ValidateOutputPath(opts Options, outputPath string) error {
 		return fmt.Errorf("resolve output path %q: %w", outputPath, err)
 	}
 
-	for _, input := range inputs {
+	for _, input := range selection.Paths {
 		in, err := canonicalPath(input)
 		if err != nil {
 			return fmt.Errorf("resolve input path %q: %w", input, err)
@@ -271,19 +200,20 @@ func canonicalPath(path string) (string, error) {
 	return filepath.Join(resolvedDir, filepath.Base(abs)), nil
 }
 
-// loadFiles reads each discovered path and parses it relative to the configured
+// loadFiles reads each selected path and parses it relative to the configured
 // repository root.
-func loadFiles(root string, paths []string) ([]envfile.File, error) {
-	files := make([]envfile.File, 0, len(paths))
-	for _, path := range paths {
+func loadFiles(selection scope.Selection) ([]envfile.File, error) {
+	files := make([]envfile.File, 0, len(selection.Paths))
+	for _, path := range selection.Paths {
+		display := selection.DisplayPath(path)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("read %q: %w", displayPath(root, path), err)
+			return nil, fmt.Errorf("read %q: %w", display, err)
 		}
 
-		parsed, err := envfile.Parse(displayPath(root, path), data)
+		parsed, err := envfile.Parse(display, data)
 		if err != nil {
-			return nil, fmt.Errorf("parse %q: %w", displayPath(root, path), err)
+			return nil, fmt.Errorf("parse %q: %w", display, err)
 		}
 		files = append(files, parsed)
 	}
@@ -370,14 +300,4 @@ func sortFindings(findings []Finding) {
 		}
 		return left.Message < right.Message
 	})
-}
-
-// displayPath keeps user-facing paths relative to the configured root when
-// possible.
-func displayPath(root, path string) string {
-	rel, err := filepath.Rel(root, path)
-	if err != nil {
-		return path
-	}
-	return rel
 }

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -31,6 +31,13 @@ func NewRunner(rules ...Rule) *Runner {
 	return &Runner{rules: copied}
 }
 
+// ValidateRuleSelection checks the requested only/skip rule IDs against the
+// available rule set and returns the same validation errors that Run would.
+func ValidateRuleSelection(all []Rule, only, skip []string) error {
+	_, err := selectRules(all, only, skip)
+	return err
+}
+
 // Run resolves the root, discovers dotenv files and executes the selected
 // rules in declaration order. When fixes are requested, it reports the
 // original findings that disappeared as fixed and keeps the post-fix findings.

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -35,16 +35,28 @@ func NewRunner(rules ...Rule) *Runner {
 // rules in declaration order. When fixes are requested, it reports the
 // original findings that disappeared as fixed and keeps the post-fix findings.
 func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
-	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
-	if err != nil {
-		return Result{}, err
-	}
-
 	selection, err := scope.Resolve(scope.Options{
 		Root:      opts.Root,
 		Target:    opts.Target,
 		TargetDir: opts.TargetDir,
 	})
+	if err != nil {
+		return Result{}, err
+	}
+
+	return r.runWithSelection(ctx, opts, selection)
+}
+
+// RunWithSelection executes the configured rules against a pre-resolved scope
+// selection. Callers that already resolved scope, such as the CLI preflight for
+// output-path validation, can reuse the same selection here to avoid walking the
+// tree twice.
+func (r *Runner) RunWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
+	return r.runWithSelection(ctx, opts, selection)
+}
+
+func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
+	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
 	if err != nil {
 		return Result{}, err
 	}
@@ -147,19 +159,10 @@ func markFixedFindings(original, remaining []Finding) []Finding {
 }
 
 // ValidateOutputPath reports an error if outputPath resolves to the same file
-// as any input path that would be linted with opts. The comparison uses
-// canonical absolute paths so relative, cleaned and symlink-equivalent forms
-// are detected.
-func ValidateOutputPath(opts Options, outputPath string) error {
-	selection, err := scope.Resolve(scope.Options{
-		Root:      opts.Root,
-		Target:    opts.Target,
-		TargetDir: opts.TargetDir,
-	})
-	if err != nil {
-		return err
-	}
-
+// as any input path in the resolved selection. The comparison uses canonical
+// absolute paths so relative, cleaned and symlink-equivalent forms are
+// detected.
+func ValidateOutputPath(selection scope.Selection, outputPath string) error {
 	out, err := canonicalPath(outputPath)
 	if err != nil {
 		return fmt.Errorf("resolve output path %q: %w", outputPath, err)

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -42,6 +42,11 @@ func ValidateRuleSelection(all []Rule, only, skip []string) error {
 // rules in declaration order. When fixes are requested, it reports the
 // original findings that disappeared as fixed and keeps the post-fix findings.
 func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
+	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
+	if err != nil {
+		return Result{}, err
+	}
+
 	selection, err := scope.Resolve(scope.Options{
 		Root:      opts.Root,
 		Target:    opts.Target,
@@ -51,7 +56,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	return r.runWithSelection(ctx, opts, selection)
+	return r.runWithSelection(ctx, opts, selection, selected)
 }
 
 // RunWithSelection executes the configured rules against a pre-resolved scope
@@ -59,15 +64,15 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 // output-path validation, can reuse the same selection here to avoid walking the
 // tree twice.
 func (r *Runner) RunWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
-	return r.runWithSelection(ctx, opts, selection)
-}
-
-func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
 	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
 	if err != nil {
 		return Result{}, err
 	}
 
+	return r.runWithSelection(ctx, opts, selection, selected)
+}
+
+func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection, selected []Rule) (Result, error) {
 	files, err := loadFiles(selection)
 	if err != nil {
 		return Result{}, err

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -42,6 +42,8 @@ func ValidateRuleSelection(all []Rule, only, skip []string) error {
 // rules in declaration order. When fixes are requested, it reports the
 // original findings that disappeared as fixed and keeps the post-fix findings.
 func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
+	opts = normalizeOptions(opts)
+
 	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
 	if err != nil {
 		return Result{}, err
@@ -64,6 +66,8 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 // output-path validation, can reuse the same selection here to avoid walking the
 // tree twice.
 func (r *Runner) RunWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
+	opts = normalizeOptions(opts)
+
 	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
 	if err != nil {
 		return Result{}, err
@@ -113,6 +117,13 @@ func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection s
 		Files:    files,
 		Changed:  changed,
 	}, nil
+}
+
+func normalizeOptions(opts Options) Options {
+	if opts.Root == "" {
+		opts.Root = "."
+	}
+	return opts
 }
 
 func (r *Runner) runRules(ctx context.Context, root string, selected []Rule, files []envfile.File, opts Options) ([]Finding, error) {

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -33,6 +33,18 @@ func (r countingRule) Run(lint.Context) ([]lint.Finding, error) {
 	return nil, nil
 }
 
+type rootRecordingRule struct {
+	root *string
+}
+
+func (r rootRecordingRule) ID() string          { return "root-recording" }
+func (r rootRecordingRule) Description() string { return "records the root option" }
+
+func (r rootRecordingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
+	*r.root = ctx.Options.Root
+	return nil, nil
+}
+
 func TestRunnerRuleSelection(t *testing.T) {
 	root := t.TempDir()
 
@@ -198,6 +210,20 @@ func TestRunnerInvalidRuleSelectionBeatsScopeErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown lint rule \"unknown-rule\"") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunnerDefaultsEmptyRootForRuleContext(t *testing.T) {
+	var gotRoot string
+	runner := lint.NewRunner(rootRecordingRule{root: &gotRoot})
+
+	_, err := runner.Run(context.Background(), lint.Options{})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if got, want := gotRoot, "."; got != want {
+		t.Fatalf("unexpected ctx.Options.Root: got %q want %q", got, want)
 	}
 }
 

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -180,6 +180,27 @@ func TestRunnerRuleSelectionErrors(t *testing.T) {
 	}
 }
 
+func TestRunnerInvalidRuleSelectionBeatsScopeErrors(t *testing.T) {
+	root := t.TempDir()
+	ruleset, _ := testRules()
+	runner := lint.NewRunner(ruleset...)
+
+	_, err := runner.Run(context.Background(), lint.Options{
+		Root:      root,
+		Target:    "missing.env",
+		OnlyRules: []string{"unknown-rule"},
+	})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if got := cli.ExitCode(err); got != cli.ExitInternal {
+		t.Fatalf("unexpected exit code: got %d want %d", got, cli.ExitInternal)
+	}
+	if !strings.Contains(err.Error(), "unknown lint rule \"unknown-rule\"") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunnerOnlySelectionStillUsesRealRules(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, ".env")

--- a/internal/scope/root_unix_test.go
+++ b/internal/scope/root_unix_test.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scope
+
+import "os"
+
+func isPrivilegedUser() bool {
+	return os.Geteuid() == 0
+}

--- a/internal/scope/root_windows_test.go
+++ b/internal/scope/root_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scope
+
+func isPrivilegedUser() bool {
+	return false
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -99,8 +99,9 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 	return paths, nil
 }
 
-// resolvePath turns a user-supplied relative or absolute path into an
-// absolute path anchored to root.
+// resolvePath turns a user-supplied path into an absolute path. Relative
+// inputs are joined to root, while absolute inputs are cleaned and returned
+// unchanged.
 func resolvePath(root, path string) string {
 	if filepath.IsAbs(path) {
 		return filepath.Clean(path)

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -45,6 +45,7 @@ func Resolve(opts Options) (Selection, error) {
 	if err != nil {
 		return Selection{}, fmt.Errorf("resolve root %q: %w", rootLabel, err)
 	}
+	absRoot = canonicalizeExisting(absRoot)
 
 	paths, err := discoverPaths(absRoot, rootLabel, opts.Target, opts.TargetDir)
 	if err != nil {
@@ -80,7 +81,7 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 			if info.IsDir() {
 				return nil, fmt.Errorf("--target must point to a file: %s", target)
 			}
-			return []string{path}, nil
+			return []string{canonicalizeExisting(path)}, nil
 		case os.IsNotExist(err):
 			return nil, fmt.Errorf("--target path does not exist: %s", target)
 		default:
@@ -96,6 +97,7 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 			if !info.IsDir() {
 				return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
 			}
+			path = canonicalizeExisting(path)
 		case os.IsNotExist(err):
 			return nil, fmt.Errorf("--target-dir path does not exist: %s", targetDir)
 		default:
@@ -123,4 +125,14 @@ func resolvePath(root, path string) string {
 		return filepath.Clean(path)
 	}
 	return filepath.Join(root, path)
+}
+
+// canonicalizeExisting resolves symlinks for a path when possible. If the
+// path cannot be resolved, the original path is preserved.
+func canonicalizeExisting(path string) string {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path
+	}
+	return resolved
 }

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -45,7 +45,6 @@ func Resolve(opts Options) (Selection, error) {
 	if err != nil {
 		return Selection{}, fmt.Errorf("resolve root %q: %w", rootLabel, err)
 	}
-	absRoot = canonicalizeExisting(absRoot)
 
 	paths, err := discoverPaths(absRoot, rootLabel, opts.Target, opts.TargetDir)
 	if err != nil {
@@ -81,7 +80,7 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 			if info.IsDir() {
 				return nil, fmt.Errorf("--target must point to a file: %s", target)
 			}
-			return []string{canonicalizeExisting(path)}, nil
+			return []string{path}, nil
 		case os.IsNotExist(err):
 			return nil, fmt.Errorf("--target path does not exist: %s", target)
 		default:
@@ -97,7 +96,6 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 			if !info.IsDir() {
 				return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
 			}
-			path = canonicalizeExisting(path)
 		case os.IsNotExist(err):
 			return nil, fmt.Errorf("--target-dir path does not exist: %s", targetDir)
 		default:
@@ -125,14 +123,4 @@ func resolvePath(root, path string) string {
 		return filepath.Clean(path)
 	}
 	return filepath.Join(root, path)
-}
-
-// canonicalizeExisting resolves symlinks for a path when possible. If the
-// path cannot be resolved, the original path is preserved.
-func canonicalizeExisting(path string) string {
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return path
-	}
-	return resolved
 }

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -73,35 +73,18 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 	}
 
 	if target != "" {
-		path := resolvePath(root, target)
-		info, err := os.Stat(path)
-		switch {
-		case err == nil:
-			if info.IsDir() {
-				return nil, fmt.Errorf("--target must point to a file: %s", target)
-			}
-			return []string{path}, nil
-		case os.IsNotExist(err):
-			return nil, fmt.Errorf("--target path does not exist: %s", target)
-		default:
-			return nil, fmt.Errorf("--target path cannot be read: %s: %w", target, err)
+		path, err := statScopeArg(root, target, "--target", false)
+		if err != nil {
+			return nil, err
 		}
+		return []string{path}, nil
 	}
 
 	if targetDir != "" {
-		path := resolvePath(root, targetDir)
-		info, err := os.Stat(path)
-		switch {
-		case err == nil:
-			if !info.IsDir() {
-				return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
-			}
-		case os.IsNotExist(err):
-			return nil, fmt.Errorf("--target-dir path does not exist: %s", targetDir)
-		default:
-			return nil, fmt.Errorf("--target-dir path cannot be read: %s: %w", targetDir, err)
+		path, err := statScopeArg(root, targetDir, "--target-dir", true)
+		if err != nil {
+			return nil, err
 		}
-
 		paths, err := fs.Discover(path)
 		if err != nil {
 			return nil, fmt.Errorf("discovering files under %q: %w", targetDir, err)
@@ -123,4 +106,27 @@ func resolvePath(root, path string) string {
 		return filepath.Clean(path)
 	}
 	return filepath.Join(root, path)
+}
+
+// statScopeArg resolves a scope input relative to root, checks whether it
+// exists, verifies whether it is a file or directory, and returns the resolved
+// path when the input is usable.
+func statScopeArg(root, arg, flag string, wantDir bool) (string, error) {
+	path := resolvePath(root, arg)
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() != wantDir {
+			kind := "a file"
+			if wantDir {
+				kind = "a directory"
+			}
+			return "", fmt.Errorf("%s must point to %s: %s", flag, kind, arg)
+		}
+		return path, nil
+	case os.IsNotExist(err):
+		return "", fmt.Errorf("%s path does not exist: %s", flag, arg)
+	default:
+		return "", fmt.Errorf("%s path cannot be read: %s: %w", flag, arg, err)
+	}
 }

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -1,0 +1,126 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package scope resolves which dotenv files participate in a command.
+package scope
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+// Options describe the input scope for a command.
+type Options struct {
+	// Root is the repository root to scan.
+	Root string
+	// Target limits a run to one explicit file path.
+	Target string
+	// TargetDir limits a run to dotenv files discovered under one directory.
+	TargetDir string
+}
+
+// Selection is the resolved set of input files for one command run.
+type Selection struct {
+	// Root is the absolute repository root used to resolve relative paths.
+	Root string
+	// RootLabel preserves the original root label for diagnostics.
+	RootLabel string
+	// Paths contains the ordered absolute input paths.
+	Paths []string
+}
+
+// Resolve turns command scope options into a stable ordered selection.
+func Resolve(opts Options) (Selection, error) {
+	rootLabel := opts.Root
+	if rootLabel == "" {
+		rootLabel = "."
+	}
+
+	absRoot, err := filepath.Abs(rootLabel)
+	if err != nil {
+		return Selection{}, fmt.Errorf("resolve root %q: %w", rootLabel, err)
+	}
+
+	paths, err := discoverPaths(absRoot, rootLabel, opts.Target, opts.TargetDir)
+	if err != nil {
+		return Selection{}, err
+	}
+
+	return Selection{
+		Root:      absRoot,
+		RootLabel: rootLabel,
+		Paths:     paths,
+	}, nil
+}
+
+// DisplayPath keeps a path relative to the selected root when possible.
+func (s Selection) DisplayPath(path string) string {
+	rel, err := filepath.Rel(s.Root, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) {
+	if target != "" && targetDir != "" {
+		return nil, fmt.Errorf("--target and --target-dir cannot be used together")
+	}
+
+	if target != "" {
+		path := resolvePath(root, target)
+		info, err := os.Stat(path)
+		switch {
+		case err == nil:
+			if info.IsDir() {
+				return nil, fmt.Errorf("--target must point to a file: %s", target)
+			}
+			return []string{path}, nil
+		case os.IsNotExist(err):
+			return nil, fmt.Errorf("--target path does not exist: %s", target)
+		default:
+			return nil, fmt.Errorf("--target path cannot be read: %s: %w", target, err)
+		}
+	}
+
+	if targetDir != "" {
+		path := resolvePath(root, targetDir)
+		info, err := os.Stat(path)
+		switch {
+		case err == nil:
+			if !info.IsDir() {
+				return nil, fmt.Errorf("--target-dir must point to a directory: %s", targetDir)
+			}
+		case os.IsNotExist(err):
+			return nil, fmt.Errorf("--target-dir path does not exist: %s", targetDir)
+		default:
+			return nil, fmt.Errorf("--target-dir path cannot be read: %s: %w", targetDir, err)
+		}
+
+		paths, err := fs.Discover(path)
+		if err != nil {
+			return nil, fmt.Errorf("discovering files under %q: %w", targetDir, err)
+		}
+		return paths, nil
+	}
+
+	paths, err := fs.Discover(root)
+	if err != nil {
+		return nil, fmt.Errorf("discovering files under %q: %w", rootLabel, err)
+	}
+	return paths, nil
+}
+
+// resolvePath turns a user-supplied relative or absolute path into an
+// absolute path anchored to root.
+func resolvePath(root, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(root, path)
+}

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -8,7 +8,7 @@ package scope
 import (
 	"os"
 	"path/filepath"
-	reflect "reflect"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -17,6 +17,7 @@ import (
 func TestResolveDefaultDiscovery(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root)
+	wantRoot := canonicalizeExisting(root)
 
 	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
 	mustWrite(t, filepath.Join(root, ".env.preview-local"), "PREVIEW=value\n")
@@ -30,7 +31,7 @@ func TestResolveDefaultDiscovery(t *testing.T) {
 		t.Fatalf("resolve failed: %v", err)
 	}
 
-	if got, want := selection.Root, root; got != want {
+	if got, want := selection.Root, wantRoot; got != want {
 		t.Fatalf("unexpected root: got %q want %q", got, want)
 	}
 	if got, want := selection.RootLabel, "."; got != want {
@@ -38,10 +39,10 @@ func TestResolveDefaultDiscovery(t *testing.T) {
 	}
 
 	wantPaths := []string{
-		filepath.Join(root, ".env"),
-		filepath.Join(root, ".env.preview-local"),
-		filepath.Join(root, "src", "app", ".env.example"),
-		filepath.Join(root, "src", "examples", "broken", ".env.example"),
+		canonicalizeExisting(filepath.Join(root, ".env")),
+		canonicalizeExisting(filepath.Join(root, ".env.preview-local")),
+		canonicalizeExisting(filepath.Join(root, "src", "app", ".env.example")),
+		canonicalizeExisting(filepath.Join(root, "src", "examples", "broken", ".env.example")),
 	}
 	if !reflect.DeepEqual(selection.Paths, wantPaths) {
 		t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, wantPaths)
@@ -69,6 +70,7 @@ func TestResolveTargetFileSelection(t *testing.T) {
 	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
 	customPath := filepath.Join(root, "config", "custom.envfile")
 	mustWrite(t, customPath, "CUSTOM=value\n")
+	wantPath := canonicalizeExisting(customPath)
 
 	cases := []struct {
 		name        string
@@ -79,13 +81,13 @@ func TestResolveTargetFileSelection(t *testing.T) {
 		{
 			name:        "relative target path",
 			target:      filepath.Join("config", "custom.envfile"),
-			wantPath:    customPath,
+			wantPath:    wantPath,
 			wantDisplay: filepath.Join("config", "custom.envfile"),
 		},
 		{
 			name:        "absolute target path",
 			target:      customPath,
-			wantPath:    customPath,
+			wantPath:    wantPath,
 			wantDisplay: filepath.Join("config", "custom.envfile"),
 		},
 	}
@@ -119,20 +121,19 @@ func TestResolveTargetDirSelection(t *testing.T) {
 	mustWrite(t, filepath.Join(root, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
 	mustWrite(t, filepath.Join(root, "src", "dist", ".env.local"), "IGNORED=value\n")
 	mustWrite(t, filepath.Join(root, "src", "README.md"), "ignored\n")
+	wantPaths := []string{
+		canonicalizeExisting(filepath.Join(root, "src", "app", ".env.example")),
+		canonicalizeExisting(filepath.Join(root, "src", "examples", "broken", ".env.example")),
+	}
 
 	cases := []struct {
 		name        string
 		targetDir   string
-		wantPaths   []string
 		wantDisplay []string
 	}{
 		{
 			name:      "relative target dir",
 			targetDir: "src",
-			wantPaths: []string{
-				filepath.Join(root, "src", "app", ".env.example"),
-				filepath.Join(root, "src", "examples", "broken", ".env.example"),
-			},
 			wantDisplay: []string{
 				filepath.Join("src", "app", ".env.example"),
 				filepath.Join("src", "examples", "broken", ".env.example"),
@@ -141,10 +142,6 @@ func TestResolveTargetDirSelection(t *testing.T) {
 		{
 			name:      "absolute target dir",
 			targetDir: filepath.Join(root, "src"),
-			wantPaths: []string{
-				filepath.Join(root, "src", "app", ".env.example"),
-				filepath.Join(root, "src", "examples", "broken", ".env.example"),
-			},
 			wantDisplay: []string{
 				filepath.Join("src", "app", ".env.example"),
 				filepath.Join("src", "examples", "broken", ".env.example"),
@@ -159,8 +156,8 @@ func TestResolveTargetDirSelection(t *testing.T) {
 				t.Fatalf("resolve failed: %v", err)
 			}
 
-			if !reflect.DeepEqual(selection.Paths, tc.wantPaths) {
-				t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, tc.wantPaths)
+			if !reflect.DeepEqual(selection.Paths, wantPaths) {
+				t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, wantPaths)
 			}
 
 			gotDisplay := make([]string, len(selection.Paths))

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scope
+
+import (
+	"os"
+	"path/filepath"
+	reflect "reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveDefaultDiscovery(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
+	mustWrite(t, filepath.Join(root, ".env.preview-local"), "PREVIEW=value\n")
+	mustWrite(t, filepath.Join(root, "src", "app", ".env.example"), "APP=value\n")
+	mustWrite(t, filepath.Join(root, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
+	mustWrite(t, filepath.Join(root, "src", "dist", ".env.local"), "IGNORED=value\n")
+	mustWrite(t, filepath.Join(root, "vendor", ".env"), "IGNORED=value\n")
+
+	selection, err := Resolve(Options{Root: "."})
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+
+	if got, want := selection.Root, root; got != want {
+		t.Fatalf("unexpected root: got %q want %q", got, want)
+	}
+	if got, want := selection.RootLabel, "."; got != want {
+		t.Fatalf("unexpected root label: got %q want %q", got, want)
+	}
+
+	wantPaths := []string{
+		filepath.Join(root, ".env"),
+		filepath.Join(root, ".env.preview-local"),
+		filepath.Join(root, "src", "app", ".env.example"),
+		filepath.Join(root, "src", "examples", "broken", ".env.example"),
+	}
+	if !reflect.DeepEqual(selection.Paths, wantPaths) {
+		t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, wantPaths)
+	}
+
+	wantDisplay := []string{
+		".env",
+		".env.preview-local",
+		filepath.Join("src", "app", ".env.example"),
+		filepath.Join("src", "examples", "broken", ".env.example"),
+	}
+	gotDisplay := make([]string, len(selection.Paths))
+	for i, path := range selection.Paths {
+		gotDisplay[i] = selection.DisplayPath(path)
+	}
+	if !reflect.DeepEqual(gotDisplay, wantDisplay) {
+		t.Fatalf("unexpected display paths: got %#v want %#v", gotDisplay, wantDisplay)
+	}
+}
+
+func TestResolveTargetFileSelection(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
+	customPath := filepath.Join(root, "config", "custom.envfile")
+	mustWrite(t, customPath, "CUSTOM=value\n")
+
+	cases := []struct {
+		name        string
+		target      string
+		wantPath    string
+		wantDisplay string
+	}{
+		{
+			name:        "relative target path",
+			target:      filepath.Join("config", "custom.envfile"),
+			wantPath:    customPath,
+			wantDisplay: filepath.Join("config", "custom.envfile"),
+		},
+		{
+			name:        "absolute target path",
+			target:      customPath,
+			wantPath:    customPath,
+			wantDisplay: filepath.Join("config", "custom.envfile"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			selection, err := Resolve(Options{Root: ".", Target: tc.target})
+			if err != nil {
+				t.Fatalf("resolve failed: %v", err)
+			}
+
+			if got, want := len(selection.Paths), 1; got != want {
+				t.Fatalf("unexpected path count: got %d want %d", got, want)
+			}
+			if got, want := selection.Paths[0], tc.wantPath; got != want {
+				t.Fatalf("unexpected path: got %q want %q", got, want)
+			}
+			if got, want := selection.DisplayPath(selection.Paths[0]), tc.wantDisplay; got != want {
+				t.Fatalf("unexpected display path: got %q want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestResolveTargetDirSelection(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
+	mustWrite(t, filepath.Join(root, "src", "app", ".env.example"), "APP=value\n")
+	mustWrite(t, filepath.Join(root, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
+	mustWrite(t, filepath.Join(root, "src", "dist", ".env.local"), "IGNORED=value\n")
+	mustWrite(t, filepath.Join(root, "src", "README.md"), "ignored\n")
+
+	cases := []struct {
+		name        string
+		targetDir   string
+		wantPaths   []string
+		wantDisplay []string
+	}{
+		{
+			name:      "relative target dir",
+			targetDir: "src",
+			wantPaths: []string{
+				filepath.Join(root, "src", "app", ".env.example"),
+				filepath.Join(root, "src", "examples", "broken", ".env.example"),
+			},
+			wantDisplay: []string{
+				filepath.Join("src", "app", ".env.example"),
+				filepath.Join("src", "examples", "broken", ".env.example"),
+			},
+		},
+		{
+			name:      "absolute target dir",
+			targetDir: filepath.Join(root, "src"),
+			wantPaths: []string{
+				filepath.Join(root, "src", "app", ".env.example"),
+				filepath.Join(root, "src", "examples", "broken", ".env.example"),
+			},
+			wantDisplay: []string{
+				filepath.Join("src", "app", ".env.example"),
+				filepath.Join("src", "examples", "broken", ".env.example"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			selection, err := Resolve(Options{Root: ".", TargetDir: tc.targetDir})
+			if err != nil {
+				t.Fatalf("resolve failed: %v", err)
+			}
+
+			if !reflect.DeepEqual(selection.Paths, tc.wantPaths) {
+				t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, tc.wantPaths)
+			}
+
+			gotDisplay := make([]string, len(selection.Paths))
+			for i, path := range selection.Paths {
+				gotDisplay[i] = selection.DisplayPath(path)
+			}
+			if !reflect.DeepEqual(gotDisplay, tc.wantDisplay) {
+				t.Fatalf("unexpected display paths: got %#v want %#v", gotDisplay, tc.wantDisplay)
+			}
+		})
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
+	if err := os.Mkdir(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+
+	cases := []struct {
+		name    string
+		opts    Options
+		wantErr string
+	}{
+		{
+			name:    "conflicting target flags",
+			opts:    Options{Root: ".", Target: ".env", TargetDir: "src"},
+			wantErr: "--target and --target-dir cannot be used together",
+		},
+		{
+			name:    "missing target file",
+			opts:    Options{Root: ".", Target: "missing.env"},
+			wantErr: "--target path does not exist: missing.env",
+		},
+		{
+			name:    "missing target dir",
+			opts:    Options{Root: ".", TargetDir: "missing-dir"},
+			wantErr: "--target-dir path does not exist: missing-dir",
+		},
+		{
+			name:    "target points to directory",
+			opts:    Options{Root: ".", Target: "src"},
+			wantErr: "--target must point to a file: src",
+		},
+		{
+			name:    "target-dir points to file",
+			opts:    Options{Root: ".", TargetDir: ".env"},
+			wantErr: "--target-dir must point to a directory: .env",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Resolve(tc.opts)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("unexpected error: got %v want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolveUnreadableTargetPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-denied fixtures are not portable on windows")
+	}
+
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	locked := filepath.Join(root, "locked")
+	if err := os.Mkdir(locked, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	mustWrite(t, filepath.Join(locked, ".env.staging"), "KEY=value\n")
+	t.Cleanup(func() {
+		if err := os.Chmod(locked, 0o755); err != nil {
+			t.Errorf("restore permissions failed: %v", err)
+		}
+	})
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatalf("chmod failed: %v", err)
+	}
+
+	_, err := Resolve(Options{Root: ".", Target: filepath.Join("locked", ".env.staging")})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "--target path cannot be read: locked/.env.staging") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Errorf("restore working dir failed: %v", err)
+		}
+	})
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -17,21 +17,21 @@ import (
 func TestResolveDefaultDiscovery(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root)
-	wantRoot := canonicalizeExisting(root)
+	resolvedRoot := mustAbs(t, ".")
 
-	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
-	mustWrite(t, filepath.Join(root, ".env.preview-local"), "PREVIEW=value\n")
-	mustWrite(t, filepath.Join(root, "src", "app", ".env.example"), "APP=value\n")
-	mustWrite(t, filepath.Join(root, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
-	mustWrite(t, filepath.Join(root, "src", "dist", ".env.local"), "IGNORED=value\n")
-	mustWrite(t, filepath.Join(root, "vendor", ".env"), "IGNORED=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, ".env"), "ROOT=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, ".env.preview-local"), "PREVIEW=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "app", ".env.example"), "APP=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "dist", ".env.local"), "IGNORED=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "vendor", ".env"), "IGNORED=value\n")
 
 	selection, err := Resolve(Options{Root: "."})
 	if err != nil {
 		t.Fatalf("resolve failed: %v", err)
 	}
 
-	if got, want := selection.Root, wantRoot; got != want {
+	if got, want := selection.Root, resolvedRoot; got != want {
 		t.Fatalf("unexpected root: got %q want %q", got, want)
 	}
 	if got, want := selection.RootLabel, "."; got != want {
@@ -39,10 +39,10 @@ func TestResolveDefaultDiscovery(t *testing.T) {
 	}
 
 	wantPaths := []string{
-		canonicalizeExisting(filepath.Join(root, ".env")),
-		canonicalizeExisting(filepath.Join(root, ".env.preview-local")),
-		canonicalizeExisting(filepath.Join(root, "src", "app", ".env.example")),
-		canonicalizeExisting(filepath.Join(root, "src", "examples", "broken", ".env.example")),
+		filepath.Join(resolvedRoot, ".env"),
+		filepath.Join(resolvedRoot, ".env.preview-local"),
+		filepath.Join(resolvedRoot, "src", "app", ".env.example"),
+		filepath.Join(resolvedRoot, "src", "examples", "broken", ".env.example"),
 	}
 	if !reflect.DeepEqual(selection.Paths, wantPaths) {
 		t.Fatalf("unexpected paths: got %#v want %#v", selection.Paths, wantPaths)
@@ -66,11 +66,11 @@ func TestResolveDefaultDiscovery(t *testing.T) {
 func TestResolveTargetFileSelection(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root)
+	resolvedRoot := mustAbs(t, ".")
 
-	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
-	customPath := filepath.Join(root, "config", "custom.envfile")
+	mustWrite(t, filepath.Join(resolvedRoot, ".env"), "ROOT=value\n")
+	customPath := filepath.Join(resolvedRoot, "config", "custom.envfile")
 	mustWrite(t, customPath, "CUSTOM=value\n")
-	wantPath := canonicalizeExisting(customPath)
 
 	cases := []struct {
 		name        string
@@ -81,13 +81,13 @@ func TestResolveTargetFileSelection(t *testing.T) {
 		{
 			name:        "relative target path",
 			target:      filepath.Join("config", "custom.envfile"),
-			wantPath:    wantPath,
+			wantPath:    customPath,
 			wantDisplay: filepath.Join("config", "custom.envfile"),
 		},
 		{
 			name:        "absolute target path",
 			target:      customPath,
-			wantPath:    wantPath,
+			wantPath:    customPath,
 			wantDisplay: filepath.Join("config", "custom.envfile"),
 		},
 	}
@@ -115,15 +115,16 @@ func TestResolveTargetFileSelection(t *testing.T) {
 func TestResolveTargetDirSelection(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root)
+	resolvedRoot := mustAbs(t, ".")
 
-	mustWrite(t, filepath.Join(root, ".env"), "ROOT=value\n")
-	mustWrite(t, filepath.Join(root, "src", "app", ".env.example"), "APP=value\n")
-	mustWrite(t, filepath.Join(root, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
-	mustWrite(t, filepath.Join(root, "src", "dist", ".env.local"), "IGNORED=value\n")
-	mustWrite(t, filepath.Join(root, "src", "README.md"), "ignored\n")
+	mustWrite(t, filepath.Join(resolvedRoot, ".env"), "ROOT=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "app", ".env.example"), "APP=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "examples", "broken", ".env.example"), "BROKEN=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "dist", ".env.local"), "IGNORED=value\n")
+	mustWrite(t, filepath.Join(resolvedRoot, "src", "README.md"), "ignored\n")
 	wantPaths := []string{
-		canonicalizeExisting(filepath.Join(root, "src", "app", ".env.example")),
-		canonicalizeExisting(filepath.Join(root, "src", "examples", "broken", ".env.example")),
+		filepath.Join(resolvedRoot, "src", "app", ".env.example"),
+		filepath.Join(resolvedRoot, "src", "examples", "broken", ".env.example"),
 	}
 
 	cases := []struct {
@@ -141,7 +142,7 @@ func TestResolveTargetDirSelection(t *testing.T) {
 		},
 		{
 			name:      "absolute target dir",
-			targetDir: filepath.Join(root, "src"),
+			targetDir: filepath.Join(resolvedRoot, "src"),
 			wantDisplay: []string{
 				filepath.Join("src", "app", ".env.example"),
 				filepath.Join("src", "examples", "broken", ".env.example"),
@@ -229,6 +230,9 @@ func TestResolveUnreadableTargetPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("permission-denied fixtures are not portable on windows")
 	}
+	if isPrivilegedUser() {
+		t.Skip("permission-denied fixtures require a non-root POSIX user")
+	}
 
 	root := t.TempDir()
 	withWorkingDir(t, root)
@@ -282,4 +286,14 @@ func mustWrite(t *testing.T, path, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write failed: %v", err)
 	}
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("abs failed: %v", err)
+	}
+	return abs
 }


### PR DESCRIPTION
## Summary

Fixes #66. Extracts lint input selection into `internal/scope` so scope resolution is handled in one place for default discovery, `--target`, and `--target-dir`, while preserving the current lint behavior.

## Why

Refs #66 and Discussion #58. This PR takes the first step toward the layered architecture by moving scope resolution out of `internal/lint/runner.go` without changing lint output, fix behavior, or CLI semantics. The broader loading / analysis / engine layering is intentionally deferred to later tickets.

## Type

- [x] Internal refactor
- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/scope` to resolve lint input selection and produce deterministic selections plus display paths.
- Updated `internal/lint/runner.go` to consume the resolved selection for loading, fixing, and output-path validation instead of owning scope resolution itself.
- Added focused coverage for default discovery, relative and absolute targets, target directories, conflict errors, missing paths, and unreadable inputs.

## User-visible changes

None.

## Validation

Commands run:

- [ ] `gofmt -w <touched Go files>`
- [ ] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
git diff --check
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Extract lint input selection into `internal/scope` so lint uses a dedicated scope boundary for default discovery, `--target`, and `--target-dir`.

## Reviewer notes

Please focus on path-resolution parity and error-message parity with the current lint behavior.

This PR is intentionally scoped to ticket 01; the later analysis / typed-result layers are covered by subsequent tickets.

Absolute and relative display-path handling is covered by the new scope tests.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [ ] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Improved lint scoping with a consistent environment-file selection flow for default, single-file, and directory targets.

* **Bug Fixes**
  * Fix mode now reports only findings that actually disappeared after applying fixes.

* **Improvements**
  * Output-path validation is more robust, preventing writing output to any lint input file (including symlink-equivalent paths).
  * More accurate project-relative path display in errors and parsing contexts.
  * Rule selection validation and target scope resolution now follow the same selection logic, with correct error precedence.

* **Tests**
  * Added and updated coverage for scope resolution, path formatting, selector validation, unreadable targets, and lint argument-validation precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->