### PR TITLE
refactor(source): add dotenv document loader

### DIFF
--- a/internal/envfile/model.go
+++ b/internal/envfile/model.go
@@ -3,9 +3,10 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package envfile parses dotenv files into a line-aware model and preserves
-// enough metadata to flag BOMs, delimiter mistakes, quote problems, repeated
-// blanks and line-ending drift without guessing at shell semantics.
+// Package envfile contains the temporary line-aware dotenv parser/model used
+// during the source-layer migration. New source-facing loading belongs in
+// internal/source/dotenv; this package remains available for downstream
+// compatibility until its parser model is migrated.
 package envfile
 
 // QuoteState records how Parse handled the value on a line.

--- a/internal/source/dotenv/doc.go
+++ b/internal/source/dotenv/doc.go
@@ -1,0 +1,11 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package dotenv loads selected dotenv files into source documents.
+//
+// The source boundary owns filesystem loading and delegates the temporary
+// parser/model implementation to internal/envfile while downstream layers
+// migrate to source-owned representations.
+package dotenv

--- a/internal/source/dotenv/loader.go
+++ b/internal/source/dotenv/loader.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dotenv
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/envaar/vaar/internal/envfile"
+)
+
+// Document is one selected dotenv source together with the parsed model and
+// file metadata required by later analysis and mutation layers.
+//
+// File remains embedded temporarily so source consumers can use the existing
+// parser facts without duplicating the envfile model. SourcePath identifies
+// the on-disk input, while File.Path retains the caller-provided display path.
+type Document struct {
+	envfile.File
+	SourcePath string
+	Mode       os.FileMode
+}
+
+// Load validates, reads and parses one selected dotenv file. displayPath is
+// preserved as the parsed document path for diagnostics and reports.
+func Load(path, displayPath string) (Document, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Document{}, fmt.Errorf("stat dotenv source %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return Document{}, fmt.Errorf("dotenv source %q is a directory", path)
+	}
+	if !info.Mode().IsRegular() {
+		return Document{}, fmt.Errorf("dotenv source %q is not a regular file", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Document{}, fmt.Errorf("read dotenv source %q: %w", path, err)
+	}
+
+	parsed, err := envfile.Parse(displayPath, data)
+	if err != nil {
+		return Document{}, fmt.Errorf("parse dotenv source %q: %w", displayPath, err)
+	}
+
+	return Document{
+		File:       parsed,
+		SourcePath: path,
+		Mode:       info.Mode().Perm(),
+	}, nil
+}
+
+// LoadMany loads selected dotenv files in the order supplied by paths and
+// preserves the corresponding display path at each position. It returns no
+// partial document set when any input fails.
+func LoadMany(paths, displayPaths []string) ([]Document, error) {
+	if len(paths) != len(displayPaths) {
+		return nil, fmt.Errorf(
+			"dotenv load requires one display path per source path: got %d paths and %d display paths",
+			len(paths), len(displayPaths),
+		)
+	}
+
+	documents := make([]Document, 0, len(paths))
+	for i, path := range paths {
+		document, err := Load(path, displayPaths[i])
+		if err != nil {
+			return nil, fmt.Errorf("load dotenv document %q: %w", displayPaths[i], err)
+		}
+		documents = append(documents, document)
+	}
+
+	return documents, nil
+}

--- a/internal/source/dotenv/loader.go
+++ b/internal/source/dotenv/loader.go
@@ -7,7 +7,9 @@ package dotenv
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"syscall"
 
 	"github.com/envaar/vaar/internal/envfile"
 )
@@ -27,20 +29,36 @@ type Document struct {
 // Load validates, reads and parses one selected dotenv file. displayPath is
 // preserved as the parsed document path for diagnostics and reports.
 func Load(path, displayPath string) (Document, error) {
-	info, err := os.Stat(path)
+	// O_NONBLOCK prevents opening a Unix FIFO from blocking before its type can
+	// be checked. Windows ignores this flag because its file handles are already
+	// non-blocking.
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
 	if err != nil {
+		return Document{}, fmt.Errorf("open dotenv source %q: %w", path, err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
 		return Document{}, fmt.Errorf("stat dotenv source %q: %w", path, err)
 	}
+
 	if info.IsDir() {
+		_ = file.Close()
 		return Document{}, fmt.Errorf("dotenv source %q is a directory", path)
 	}
 	if !info.Mode().IsRegular() {
+		_ = file.Close()
 		return Document{}, fmt.Errorf("dotenv source %q is not a regular file", path)
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return Document{}, fmt.Errorf("read dotenv source %q: %w", path, err)
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return Document{}, fmt.Errorf("read dotenv source %q: %w", path, readErr)
+	}
+	if closeErr != nil {
+		return Document{}, fmt.Errorf("close dotenv source %q: %w", path, closeErr)
 	}
 
 	parsed, err := envfile.Parse(displayPath, data)

--- a/internal/source/dotenv/loader.go
+++ b/internal/source/dotenv/loader.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package dotenv
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -55,7 +56,7 @@ func Load(path, displayPath string) (Document, error) {
 	data, readErr := io.ReadAll(file)
 	closeErr := file.Close()
 	if readErr != nil {
-		return Document{}, fmt.Errorf("read dotenv source %q: %w", path, readErr)
+		return Document{}, fmt.Errorf("read dotenv source %q: %w", path, errors.Join(readErr, closeErr))
 	}
 	if closeErr != nil {
 		return Document{}, fmt.Errorf("close dotenv source %q: %w", path, closeErr)

--- a/internal/source/dotenv/loader_test.go
+++ b/internal/source/dotenv/loader_test.go
@@ -161,7 +161,10 @@ func TestLoadRejectsMissingPath(t *testing.T) {
 }
 
 func TestLoadRejectsDirectory(t *testing.T) {
-	path := t.TempDir()
+	path := filepath.Join(t.TempDir(), "dotenv-source-directory")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("create directory failed: %v", err)
+	}
 
 	_, err := dotenv.Load(path, ".env")
 	if err == nil {
@@ -170,7 +173,7 @@ func TestLoadRejectsDirectory(t *testing.T) {
 	if !strings.Contains(err.Error(), "directory") {
 		t.Fatalf("error does not identify directory input: %v", err)
 	}
-	if !strings.Contains(err.Error(), path) {
+	if !strings.Contains(err.Error(), filepath.Base(path)) {
 		t.Fatalf("error does not identify path: %v", err)
 	}
 }

--- a/internal/source/dotenv/loader_test.go
+++ b/internal/source/dotenv/loader_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dotenv_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/source/dotenv"
+)
+
+func TestLoadParsesAndPreservesSourceMetadata(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "selected.env")
+	data := []byte("FOO=bar\nEMPTY=\n")
+	mustWrite(t, path, data)
+
+	const displayPath = "service/config.env"
+	document, err := dotenv.Load(path, displayPath)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	if got, want := document.SourcePath, path; got != want {
+		t.Fatalf("unexpected source path: got %q want %q", got, want)
+	}
+	if got, want := document.Path, displayPath; got != want {
+		t.Fatalf("unexpected display path: got %q want %q", got, want)
+	}
+	if !bytes.Equal(document.Original, data) {
+		t.Fatalf("original bytes changed: got %q want %q", document.Original, data)
+	}
+	if got, want := len(document.Lines), 2; got != want {
+		t.Fatalf("unexpected parsed line count: got %d want %d", got, want)
+	}
+	if got, want := document.Lines[0].Key, "FOO"; got != want {
+		t.Fatalf("unexpected first key: got %q want %q", got, want)
+	}
+	if got, want := document.Lines[0].Value, "bar"; got != want {
+		t.Fatalf("unexpected first value: got %q want %q", got, want)
+	}
+}
+
+func TestLoadPreservesEmptyDocument(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	mustWrite(t, path, nil)
+
+	document, err := dotenv.Load(path, ".env")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	if len(document.Lines) != 0 {
+		t.Fatalf("expected no parsed lines, got %d", len(document.Lines))
+	}
+	if len(document.Original) != 0 {
+		t.Fatalf("expected empty original bytes, got %q", document.Original)
+	}
+}
+
+func TestLoadPreservesFileMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	mustWrite(t, path, []byte("KEY=value\n"))
+	if err := os.Chmod(path, 0o640); err != nil {
+		t.Skipf("file mode is not supported: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat failed: %v", err)
+	}
+
+	document, err := dotenv.Load(path, ".env")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	if got, want := document.Mode, info.Mode().Perm(); got != want {
+		t.Fatalf("unexpected mode: got %04o want %04o", got, want)
+	}
+}
+
+func TestLoadManyPreservesInputOrderAndDisplayPaths(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first.env")
+	secondPath := filepath.Join(root, "second.env")
+	mustWrite(t, firstPath, []byte("FIRST=one\n"))
+	mustWrite(t, secondPath, []byte("SECOND=two\n"))
+
+	paths := []string{secondPath, firstPath}
+	displayPaths := []string{"service/second.env", "service/first.env"}
+	documents, err := dotenv.LoadMany(paths, displayPaths)
+	if err != nil {
+		t.Fatalf("batch load failed: %v", err)
+	}
+
+	if got, want := len(documents), len(paths); got != want {
+		t.Fatalf("unexpected document count: got %d want %d", got, want)
+	}
+	for i := range paths {
+		if got, want := documents[i].SourcePath, paths[i]; got != want {
+			t.Fatalf("unexpected source path at %d: got %q want %q", i, got, want)
+		}
+		if got, want := documents[i].Path, displayPaths[i]; got != want {
+			t.Fatalf("unexpected display path at %d: got %q want %q", i, got, want)
+		}
+	}
+}
+
+func TestLoadManyRejectsMismatchedPathListsBeforeReading(t *testing.T) {
+	missingPath := filepath.Join(t.TempDir(), "missing.env")
+
+	_, err := dotenv.LoadMany([]string{missingPath}, nil)
+	if err == nil {
+		t.Fatal("expected mismatched path-list error")
+	}
+	if !strings.Contains(err.Error(), "display") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadManyReturnsNoPartialDocumentsAfterFailure(t *testing.T) {
+	root := t.TempDir()
+	validPath := filepath.Join(root, "valid.env")
+	missingPath := filepath.Join(root, "missing.env")
+	mustWrite(t, validPath, []byte("KEY=value\n"))
+
+	documents, err := dotenv.LoadMany(
+		[]string{validPath, missingPath},
+		[]string{"valid.env", "missing.env"},
+	)
+	if err == nil {
+		t.Fatal("expected batch load error")
+	}
+	if documents != nil {
+		t.Fatalf("expected no partial documents, got %#v", documents)
+	}
+}
+
+func TestLoadRejectsMissingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.env")
+
+	_, err := dotenv.Load(path, ".env")
+	if err == nil {
+		t.Fatal("expected missing-path error")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("error does not identify path: %v", err)
+	}
+}
+
+func TestLoadRejectsDirectory(t *testing.T) {
+	path := t.TempDir()
+
+	_, err := dotenv.Load(path, ".env")
+	if err == nil {
+		t.Fatal("expected directory error")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("error does not identify directory input: %v", err)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Fatalf("error does not identify path: %v", err)
+	}
+}
+
+func TestLoadRejectsNonRegularFileWhereSupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.DevNull is not a regular filesystem entry on all supported Windows environments")
+	}
+
+	info, err := os.Stat(os.DevNull)
+	if err != nil || info.Mode().IsRegular() {
+		t.Skip("the platform does not expose a non-regular os.DevNull entry")
+	}
+
+	_, err = dotenv.Load(os.DevNull, os.DevNull)
+	if err == nil {
+		t.Fatal("expected non-regular-file error")
+	}
+	if !strings.Contains(err.Error(), "regular") {
+		t.Fatalf("error does not identify non-regular input: %v", err)
+	}
+}
+
+func TestLoadRejectsUnreadableFileWhereSupported(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "unreadable.env")
+	mustWrite(t, path, []byte("KEY=value\n"))
+	if err := os.Chmod(path, 0); err != nil {
+		t.Skipf("file permissions are not supported: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	_, err := dotenv.Load(path, ".env")
+	if err == nil {
+		t.Skip("the test process can read mode-000 files")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("expected permission error, got %v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add a concrete dotenv source boundary for loading selected files into parsed source documents.

## Why

Dotenv file loading was coupled to command and parser orchestration. This change establishes `internal/source/dotenv` as the reusable source-facing boundary described in [#68](https://github.com/envaar/vaar/issues/68) and [Discussion #58](https://github.com/envaar/vaar/discussions/58).

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/source/dotenv` with `Document`, `Load`, and ordered `LoadMany` APIs.
- Preserved display paths, source paths, original bytes, parsed metadata, and file permissions.
- Added actionable validation errors for missing, unreadable, directory, and non-regular inputs.
- Kept `internal/envfile` as a temporary compatibility parser/model package.
- Updated affected package comments.

## User-visible changes

**None.**

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...` via the `make lint` smoke test

Additional commands:

```text
go vet ./...
make build
git diff --check
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Introduced a reusable dotenv source loader that preserves source metadata for future analysis and mutation layers.

## Reviewer notes

Please pay special attention to:

- `Document` compatibility with the planned layered architecture.
- Display-path and input-order preservation.
- Original-byte and file-mode preservation.
- Actionable wrapped filesystem errors.
- The intentional temporary dependency on `internal/envfile`.
- Cross-platform behavior of permission and non-regular-file tests.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [ ] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dotenv file loading with source path and file permission metadata.
  * Added support for loading multiple dotenv files in a defined order.
  * Added validation for missing, invalid, unreadable, and non-regular files.
  * Preserved source details and prevented partial results when batch loading fails.

* **Documentation**
  * Clarified dotenv parser documentation and loading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->