### PR TITLE
refactor(scope): centralize scope path validation

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -106,7 +106,7 @@ Use either --target or --target-dir, not both.`,
 			}
 
 			if lintOutput != "" {
-				if err := lint.ValidateOutputPath(scopeSelection, lintOutput); err != nil {
+				if err := scope.ValidateOutputPath(scopeSelection, lintOutput); err != nil {
 					return NewToolError(err.Error(), nil)
 				}
 			}

--- a/internal/fs/path.go
+++ b/internal/fs/path.go
@@ -1,0 +1,83 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrNotRegularFile indicates that a path does not identify a regular file.
+var ErrNotRegularFile = errors.New("path is not a regular file")
+
+// ResolvePath returns path as a cleaned absolute path. Relative paths are
+// anchored to root, while an empty root uses the current working directory.
+func ResolvePath(root, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+
+	if root == "" {
+		root = "."
+	}
+	absoluteRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(absoluteRoot, path), nil
+}
+
+// CanonicalPath returns a stable absolute form of path. It resolves symlinks
+// and cleans . and .. segments. If path does not exist yet, the parent
+// directory is canonicalized and the base name is rejoined so the result can
+// still be compared with existing files.
+func CanonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+
+	dir := filepath.Dir(abs)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(resolvedDir, filepath.Base(abs)), nil
+}
+
+// ValidateRegularFile returns metadata for a readable regular file.
+func ValidateRegularFile(path string) (os.FileInfo, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s", ErrNotRegularFile, path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := file.Close(); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// ReadFile validates path as a regular file and returns its original bytes.
+func ReadFile(path string) ([]byte, error) {
+	if _, err := ValidateRegularFile(path); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}

--- a/internal/fs/path.go
+++ b/internal/fs/path.go
@@ -42,8 +42,12 @@ func CanonicalPath(path string) (string, error) {
 		return "", err
 	}
 
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
 		return resolved, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", err
 	}
 
 	dir := filepath.Dir(abs)

--- a/internal/fs/path_test.go
+++ b/internal/fs/path_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+func TestResolvePathAnchorsRelativePathsAndCleansAbsolutePaths(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := fs.ResolvePath(root, filepath.Join("nested", "..", "config.env"))
+	if err != nil {
+		t.Fatalf("resolve relative path failed: %v", err)
+	}
+	if want := filepath.Join(root, "config.env"); got != want {
+		t.Fatalf("unexpected relative path: got %q want %q", got, want)
+	}
+
+	absolute := filepath.Join(root, "nested", "..", "absolute.env")
+	got, err = fs.ResolvePath(root, absolute)
+	if err != nil {
+		t.Fatalf("resolve absolute path failed: %v", err)
+	}
+	if want := filepath.Join(root, "absolute.env"); got != want {
+		t.Fatalf("unexpected absolute path: got %q want %q", got, want)
+	}
+}
+
+func TestResolvePathUsesWorkingDirectoryForEmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	got, err := fs.ResolvePath("", "config.env")
+	if err != nil {
+		t.Fatalf("resolve empty-root path failed: %v", err)
+	}
+	if want := filepath.Join(root, "config.env"); got != want {
+		t.Fatalf("unexpected empty-root path: got %q want %q", got, want)
+	}
+}
+
+func TestCanonicalPathResolvesExistingAndMissingPaths(t *testing.T) {
+	root := t.TempDir()
+	input := filepath.Join(root, "config.env")
+	if err := os.WriteFile(input, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write input failed: %v", err)
+	}
+
+	got, err := fs.CanonicalPath(filepath.Join(root, "nested", "..", "config.env"))
+	if err != nil {
+		t.Fatalf("canonicalize existing path failed: %v", err)
+	}
+	if want := input; got != want {
+		t.Fatalf("unexpected existing canonical path: got %q want %q", got, want)
+	}
+
+	reports := filepath.Join(root, "reports")
+	if err := os.Mkdir(reports, 0o755); err != nil {
+		t.Fatalf("create reports directory failed: %v", err)
+	}
+	missing := filepath.Join(reports, "lint.json")
+	got, err = fs.CanonicalPath(missing)
+	if err != nil {
+		t.Fatalf("canonicalize missing path failed: %v", err)
+	}
+	if want := missing; got != want {
+		t.Fatalf("unexpected missing canonical path: got %q want %q", got, want)
+	}
+}
+
+func TestCanonicalPathResolvesSymlinkEquivalentPaths(t *testing.T) {
+	root := t.TempDir()
+	input := filepath.Join(root, "config.env")
+	if err := os.WriteFile(input, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write input failed: %v", err)
+	}
+
+	alias := filepath.Join(root, "alias.env")
+	if err := os.Symlink(input, alias); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create symlink failed: %v", err)
+	}
+
+	got, err := fs.CanonicalPath(alias)
+	if err != nil {
+		t.Fatalf("canonicalize symlink failed: %v", err)
+	}
+	if want := input; got != want {
+		t.Fatalf("unexpected symlink canonical path: got %q want %q", got, want)
+	}
+}
+
+func TestCanonicalPathReportsMissingParent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "lint.json")
+
+	_, err := fs.CanonicalPath(path)
+	if err == nil {
+		t.Fatal("expected canonicalization to fail for a missing parent")
+	}
+}
+
+func TestValidateRegularFileReturnsMetadataForReadableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.env")
+	if err := os.WriteFile(path, []byte("KEY=value\n"), 0o640); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+
+	info, err := fs.ValidateRegularFile(path)
+	if err != nil {
+		t.Fatalf("validate regular file failed: %v", err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("validated mode is not regular: %v", info.Mode())
+	}
+}
+
+func TestValidateRegularFileRejectsDirectory(t *testing.T) {
+	path := t.TempDir()
+
+	_, err := fs.ValidateRegularFile(path)
+	if !errors.Is(err, fs.ErrNotRegularFile) {
+		t.Fatalf("unexpected directory error: %v", err)
+	}
+}
+
+func TestValidateRegularFileRejectsNonRegularFileWhereSupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("device files are not portable on windows")
+	}
+
+	if _, err := os.Stat("/dev/null"); err != nil {
+		t.Skipf("device file is unavailable: %v", err)
+	}
+
+	_, err := fs.ValidateRegularFile("/dev/null")
+	if !errors.Is(err, fs.ErrNotRegularFile) {
+		t.Fatalf("unexpected non-regular-file error: %v", err)
+	}
+}
+
+func TestValidateRegularFileReportsUnreadableFileWhereSupported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission fixtures are not portable on windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "locked.env")
+	if err := os.WriteFile(path, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write file failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Errorf("restore permissions failed: %v", err)
+		}
+	})
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatalf("lock file failed: %v", err)
+	}
+
+	_, err := fs.ValidateRegularFile(path)
+	if err == nil {
+		t.Skip("file permissions are not enforceable for this test user")
+	}
+	if !os.IsPermission(err) {
+		t.Fatalf("unexpected unreadable-file error: %v", err)
+	}
+}
+
+func TestReadFilePreservesBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{name: "normal", data: []byte("KEY=value\r\nSECOND=\"quoted\"\n")},
+		{name: "empty", data: []byte{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.env")
+			if err := os.WriteFile(path, tc.data, 0o644); err != nil {
+				t.Fatalf("write file failed: %v", err)
+			}
+
+			got, err := fs.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read file failed: %v", err)
+			}
+			if string(got) != string(tc.data) {
+				t.Fatalf("bytes changed: got %q want %q", got, tc.data)
+			}
+		})
+	}
+}
+
+func TestReadFileRejectsDirectory(t *testing.T) {
+	_, err := fs.ReadFile(t.TempDir())
+	if !errors.Is(err, fs.ErrNotRegularFile) {
+		t.Fatalf("unexpected directory read error: %v", err)
+	}
+}
+
+func withWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd failed: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Errorf("restore working dir failed: %v", err)
+		}
+	})
+}

--- a/internal/fs/path_test.go
+++ b/internal/fs/path_test.go
@@ -44,11 +44,11 @@ func TestResolvePathUsesWorkingDirectoryForEmptyRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve empty-root path failed: %v", err)
 	}
-	canonicalRoot, err := filepath.EvalSymlinks(root)
+	want, err := filepath.Abs("config.env")
 	if err != nil {
-		t.Fatalf("resolve test root symlinks failed: %v", err)
+		t.Fatalf("resolve expected empty-root path failed: %v", err)
 	}
-	if want := filepath.Join(canonicalRoot, "config.env"); got != want {
+	if got != want {
 		t.Fatalf("unexpected empty-root path: got %q want %q", got, want)
 	}
 }

--- a/internal/fs/path_test.go
+++ b/internal/fs/path_test.go
@@ -18,7 +18,7 @@ import (
 func TestResolvePathAnchorsRelativePathsAndCleansAbsolutePaths(t *testing.T) {
 	root := t.TempDir()
 
-	got, err := fs.ResolvePath(root, filepath.Join("nested", "..", "config.env"))
+	got, err := fs.ResolvePath(root, filepath.FromSlash("nested/../config.env"))
 	if err != nil {
 		t.Fatalf("resolve relative path failed: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestResolvePathAnchorsRelativePathsAndCleansAbsolutePaths(t *testing.T) {
 		t.Fatalf("unexpected relative path: got %q want %q", got, want)
 	}
 
-	absolute := filepath.Join(root, "nested", "..", "absolute.env")
+	absolute := filepath.FromSlash(filepath.ToSlash(root) + "/nested/../absolute.env")
 	got, err = fs.ResolvePath(root, absolute)
 	if err != nil {
 		t.Fatalf("resolve absolute path failed: %v", err)
@@ -116,6 +116,33 @@ func TestCanonicalPathResolvesSymlinkEquivalentPaths(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("unexpected symlink canonical path: got %q want %q", got, want)
+	}
+}
+
+func TestCanonicalPathReportsSymlinkResolutionErrors(t *testing.T) {
+	root := t.TempDir()
+	first := filepath.Join(root, "first.env")
+	second := filepath.Join(root, "second.env")
+
+	if err := os.Symlink(second, first); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create first symlink failed: %v", err)
+	}
+	if err := os.Symlink(first, second); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create second symlink failed: %v", err)
+	}
+
+	_, err := fs.CanonicalPath(first)
+	if err == nil {
+		t.Fatal("expected symlink-loop canonicalization error")
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected symlink-loop error, got missing-path error: %v", err)
 	}
 }
 

--- a/internal/fs/path_test.go
+++ b/internal/fs/path_test.go
@@ -44,7 +44,11 @@ func TestResolvePathUsesWorkingDirectoryForEmptyRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolve empty-root path failed: %v", err)
 	}
-	if want := filepath.Join(root, "config.env"); got != want {
+	canonicalRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve test root symlinks failed: %v", err)
+	}
+	if want := filepath.Join(canonicalRoot, "config.env"); got != want {
 		t.Fatalf("unexpected empty-root path: got %q want %q", got, want)
 	}
 }
@@ -60,7 +64,11 @@ func TestCanonicalPathResolvesExistingAndMissingPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonicalize existing path failed: %v", err)
 	}
-	if want := input; got != want {
+	want, err := filepath.EvalSymlinks(input)
+	if err != nil {
+		t.Fatalf("resolve expected existing path symlinks failed: %v", err)
+	}
+	if got != want {
 		t.Fatalf("unexpected existing canonical path: got %q want %q", got, want)
 	}
 
@@ -73,7 +81,12 @@ func TestCanonicalPathResolvesExistingAndMissingPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonicalize missing path failed: %v", err)
 	}
-	if want := missing; got != want {
+	resolvedParent, err := filepath.EvalSymlinks(filepath.Dir(missing))
+	if err != nil {
+		t.Fatalf("resolve expected missing parent symlinks failed: %v", err)
+	}
+	want = filepath.Join(resolvedParent, filepath.Base(missing))
+	if got != want {
 		t.Fatalf("unexpected missing canonical path: got %q want %q", got, want)
 	}
 }
@@ -97,7 +110,11 @@ func TestCanonicalPathResolvesSymlinkEquivalentPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("canonicalize symlink failed: %v", err)
 	}
-	if want := input; got != want {
+	want, err := filepath.EvalSymlinks(input)
+	if err != nil {
+		t.Fatalf("resolve expected symlink target failed: %v", err)
+	}
+	if got != want {
 		t.Fatalf("unexpected symlink canonical path: got %q want %q", got, want)
 	}
 }

--- a/internal/fs/walk.go
+++ b/internal/fs/walk.go
@@ -3,8 +3,8 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package fs finds dotenv files in a repository and skips generated, vendored,
-// and fixture directories that should not influence lint output.
+// Package fs provides reusable filesystem mechanics and deterministic dotenv
+// discovery that skips generated, vendored and fixture directories.
 package fs
 
 import (

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -179,51 +178,6 @@ func markFixedFindings(original, remaining []Finding) []Finding {
 	}
 
 	return append(findings, remaining...)
-}
-
-// ValidateOutputPath reports an error if outputPath resolves to the same file
-// as any input path in the resolved selection. The comparison uses canonical
-// absolute paths so relative, cleaned and symlink-equivalent forms are
-// detected.
-func ValidateOutputPath(selection scope.Selection, outputPath string) error {
-	out, err := canonicalPath(outputPath)
-	if err != nil {
-		return fmt.Errorf("resolve output path %q: %w", outputPath, err)
-	}
-
-	for _, input := range selection.Paths {
-		in, err := canonicalPath(input)
-		if err != nil {
-			return fmt.Errorf("resolve input path %q: %w", input, err)
-		}
-		if out == in {
-			return fmt.Errorf("cannot write lint output to %q: the path is also a lint input file", outputPath)
-		}
-	}
-
-	return nil
-}
-
-// canonicalPath returns a stable absolute form of path. It resolves symlinks
-// and cleans . and .. segments. If path does not exist yet (typical for an
-// --output destination), the parent directory is canonicalized and the base
-// name is rejoined so the result can still be compared with existing files.
-func canonicalPath(path string) (string, error) {
-	abs, err := filepath.Abs(path)
-	if err != nil {
-		return "", err
-	}
-
-	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
-		return resolved, nil
-	}
-
-	dir := filepath.Dir(abs)
-	resolvedDir, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(resolvedDir, filepath.Base(abs)), nil
 }
 
 // loadFiles reads each selected path and parses it relative to the configured

--- a/internal/scope/output.go
+++ b/internal/scope/output.go
@@ -7,14 +7,15 @@ package scope
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/envaar/vaar/internal/fs"
 )
 
 // ValidateOutputPath reports an error if outputPath resolves to the same file
 // as any input path in the resolved selection. The comparison uses canonical
-// absolute paths so relative, cleaned and symlink-equivalent forms are
-// detected.
+// absolute paths and file identity so relative, cleaned, symlink-equivalent
+// and case-insensitive aliases are detected.
 func ValidateOutputPath(selection Selection, outputPath string) error {
 	out, err := fs.CanonicalPath(outputPath)
 	if err != nil {
@@ -26,10 +27,25 @@ func ValidateOutputPath(selection Selection, outputPath string) error {
 		if err != nil {
 			return fmt.Errorf("resolve input path %q: %w", input, err)
 		}
-		if out == in {
+		if out == in || sameExistingFile(outputPath, input) {
 			return fmt.Errorf("cannot write lint output to %q: the path is also a lint input file", outputPath)
 		}
 	}
 
 	return nil
+}
+
+// sameExistingFile reports whether two existing paths identify the same file.
+// It intentionally ignores stat errors: CanonicalPath already owns path
+// resolution errors, while a not-yet-created output is a valid destination.
+func sameExistingFile(firstPath, secondPath string) bool {
+	first, err := os.Stat(firstPath)
+	if err != nil {
+		return false
+	}
+	second, err := os.Stat(secondPath)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(first, second)
 }

--- a/internal/scope/output.go
+++ b/internal/scope/output.go
@@ -1,0 +1,35 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scope
+
+import (
+	"fmt"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+// ValidateOutputPath reports an error if outputPath resolves to the same file
+// as any input path in the resolved selection. The comparison uses canonical
+// absolute paths so relative, cleaned and symlink-equivalent forms are
+// detected.
+func ValidateOutputPath(selection Selection, outputPath string) error {
+	out, err := fs.CanonicalPath(outputPath)
+	if err != nil {
+		return fmt.Errorf("resolve output path %q: %w", outputPath, err)
+	}
+
+	for _, input := range selection.Paths {
+		in, err := fs.CanonicalPath(input)
+		if err != nil {
+			return fmt.Errorf("resolve input path %q: %w", input, err)
+		}
+		if out == in {
+			return fmt.Errorf("cannot write lint output to %q: the path is also a lint input file", outputPath)
+		}
+	}
+
+	return nil
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -3,10 +3,12 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package scope resolves which dotenv files participate in a command.
+// Package scope resolves command input selections and validates paths that
+// depend on those selections.
 package scope
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +43,7 @@ func Resolve(opts Options) (Selection, error) {
 		rootLabel = "."
 	}
 
-	absRoot, err := filepath.Abs(rootLabel)
+	absRoot, err := fs.ResolvePath("", rootLabel)
 	if err != nil {
 		return Selection{}, fmt.Errorf("resolve root %q: %w", rootLabel, err)
 	}
@@ -99,29 +101,34 @@ func discoverPaths(root, rootLabel, target, targetDir string) ([]string, error) 
 	return paths, nil
 }
 
-// resolvePath turns a user-supplied path into an absolute path. Relative
-// inputs are joined to root, while absolute inputs are cleaned and returned
-// unchanged.
-func resolvePath(root, path string) string {
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-	return filepath.Join(root, path)
-}
-
 // statScopeArg resolves a scope input relative to root, checks whether it
 // exists, verifies whether it is a file or directory, and returns the resolved
 // path when the input is usable.
 func statScopeArg(root, arg, flag string, wantDir bool) (string, error) {
-	path := resolvePath(root, arg)
+	path, err := fs.ResolvePath(root, arg)
+	if err != nil {
+		return "", fmt.Errorf("%s path cannot be read: %s: %w", flag, arg, err)
+	}
+
+	if !wantDir {
+		_, err := fs.ValidateRegularFile(path)
+		switch {
+		case err == nil:
+			return path, nil
+		case os.IsNotExist(err):
+			return "", fmt.Errorf("%s path does not exist: %s", flag, arg)
+		case errors.Is(err, fs.ErrNotRegularFile):
+			return "", fmt.Errorf("%s must point to a file: %s", flag, arg)
+		default:
+			return "", fmt.Errorf("%s path cannot be read: %s: %w", flag, arg, err)
+		}
+	}
+
 	info, err := os.Stat(path)
 	switch {
 	case err == nil:
-		if info.IsDir() != wantDir {
-			kind := "a file"
-			if wantDir {
-				kind = "a directory"
-			}
+		if !info.IsDir() {
+			kind := "a directory"
 			return "", fmt.Errorf("%s must point to %s: %s", flag, kind, arg)
 		}
 		return path, nil

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -337,6 +337,30 @@ func TestValidateOutputPathDetectsSymlinkCollision(t *testing.T) {
 	}
 }
 
+func TestValidateOutputPathDetectsCaseInsensitiveCollision(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	input := filepath.Join(root, "config.env")
+	mustWrite(t, input, "KEY=value\n")
+	output := filepath.Join(root, "CONFIG.ENV")
+	if _, err := os.Stat(output); err != nil {
+		if os.IsNotExist(err) {
+			t.Skip("test filesystem is case-sensitive")
+		}
+		t.Fatalf("stat case-variant output failed: %v", err)
+	}
+
+	err := ValidateOutputPath(Selection{Paths: []string{input}}, output)
+	if err == nil {
+		t.Fatal("expected case-insensitive collision")
+	}
+	want := fmt.Sprintf("cannot write lint output to %q: the path is also a lint input file", output)
+	if err.Error() != want {
+		t.Fatalf("unexpected collision error: got %q want %q", err, want)
+	}
+}
+
 func TestValidateOutputPathReportsUnresolvableParent(t *testing.T) {
 	root := t.TempDir()
 	withWorkingDir(t, root)

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package scope
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -283,7 +284,7 @@ func TestValidateOutputPathDetectsCanonicalInputCollisions(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected output/input collision")
 			}
-			want := "cannot write lint output to " + quote(tc.output) + ": the path is also a lint input file"
+			want := fmt.Sprintf("cannot write lint output to %q: the path is also a lint input file", tc.output)
 			if err.Error() != want {
 				t.Fatalf("unexpected collision error: got %q want %q", err, want)
 			}
@@ -352,13 +353,9 @@ func TestValidateOutputPathReportsUnresolvableParent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected output-path resolution error")
 	}
-	if want := "resolve output path " + quote(filepath.Join("missing", "lint.json")); !strings.Contains(err.Error(), want) {
+	if want := fmt.Sprintf("resolve output path %q", filepath.Join("missing", "lint.json")); !strings.Contains(err.Error(), want) {
 		t.Fatalf("unexpected output-path error: got %q want substring %q", err, want)
 	}
-}
-
-func quote(value string) string {
-	return `"` + value + `"`
 }
 
 func withWorkingDir(t *testing.T, dir string) {

--- a/internal/scope/scope_test.go
+++ b/internal/scope/scope_test.go
@@ -260,6 +260,107 @@ func TestResolveUnreadableTargetPath(t *testing.T) {
 	}
 }
 
+func TestValidateOutputPathDetectsCanonicalInputCollisions(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	input := filepath.Join(root, ".env")
+	mustWrite(t, input, "KEY=value\n")
+	selection := Selection{Paths: []string{input}}
+
+	cases := []struct {
+		name   string
+		output string
+	}{
+		{name: "relative input", output: ".env"},
+		{name: "parent traversal", output: filepath.Join("nested", "..", ".env")},
+		{name: "absolute input", output: input},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOutputPath(selection, tc.output)
+			if err == nil {
+				t.Fatal("expected output/input collision")
+			}
+			want := "cannot write lint output to " + quote(tc.output) + ": the path is also a lint input file"
+			if err.Error() != want {
+				t.Fatalf("unexpected collision error: got %q want %q", err, want)
+			}
+		})
+	}
+}
+
+func TestValidateOutputPathAllowsDistinctAndMissingOutputPaths(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	input := filepath.Join(root, ".env")
+	mustWrite(t, input, "KEY=value\n")
+	selection := Selection{Paths: []string{input}}
+
+	if err := ValidateOutputPath(selection, "lint-report.json"); err != nil {
+		t.Fatalf("distinct output rejected: %v", err)
+	}
+
+	reports := filepath.Join(root, "reports")
+	if err := os.Mkdir(reports, 0o755); err != nil {
+		t.Fatalf("create reports directory failed: %v", err)
+	}
+	if err := ValidateOutputPath(selection, filepath.Join("reports", "lint.json")); err != nil {
+		t.Fatalf("missing output path rejected: %v", err)
+	}
+}
+
+func TestValidateOutputPathDetectsSymlinkCollision(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	input := filepath.Join(root, ".env")
+	mustWrite(t, input, "KEY=value\n")
+	alias := filepath.Join(root, "alias.env")
+	if err := os.Symlink(input, alias); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create symlink failed: %v", err)
+	}
+
+	err := ValidateOutputPath(Selection{Paths: []string{input}}, "alias.env")
+	if err == nil {
+		t.Fatal("expected symlink collision")
+	}
+	want := "cannot write lint output to \"alias.env\": the path is also a lint input file"
+	if err.Error() != want {
+		t.Fatalf("unexpected collision error: got %q want %q", err, want)
+	}
+}
+
+func TestValidateOutputPathReportsUnresolvableParent(t *testing.T) {
+	root := t.TempDir()
+	withWorkingDir(t, root)
+
+	input := filepath.Join(root, ".env")
+	mustWrite(t, input, "KEY=value\n")
+
+	_, err := os.Stat(filepath.Join(root, "missing"))
+	if !os.IsNotExist(err) {
+		t.Fatalf("expected missing parent fixture: %v", err)
+	}
+
+	err = ValidateOutputPath(Selection{Paths: []string{input}}, filepath.Join("missing", "lint.json"))
+	if err == nil {
+		t.Fatal("expected output-path resolution error")
+	}
+	if want := "resolve output path " + quote(filepath.Join("missing", "lint.json")); !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected output-path error: got %q want substring %q", err, want)
+	}
+}
+
+func quote(value string) string {
+	return `"` + value + `"`
+}
+
 func withWorkingDir(t *testing.T, dir string) {
 	t.Helper()
 


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Centralize scope-dependent path resolution and output/input collision validation in `internal/scope`, while extracting reusable filesystem mechanics into `internal/fs`.

## Why

This implements [#69](https://github.com/envaar/vaar/issues/69) and advances the layered architecture described in [Discussion #58](https://github.com/envaar/vaar/discussions/58).

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added reusable filesystem helpers for path resolution, canonicalization, regular-file validation and byte reads.
- Moved output/input collision semantics from `internal/lint` to `internal/scope`.
- Updated scope resolution to use shared filesystem path and file validation helpers.
- Removed the lint-side `ValidateOutputPath` and `canonicalPath` bridge.
- Preserved target precedence, discovery ordering, ignored-directory behavior and existing error messages.
- Updated affected package comments.

## User-visible changes

**None.**

Existing CLI behavior, output formats, exit codes, target handling and rule behavior remain unchanged.

## Validation

Commands run:

- [x] `gofmt -w internal/fs/path.go internal/fs/path_test.go internal/fs/walk.go internal/scope/output.go internal/scope/scope.go internal/scope/scope_test.go internal/lint/runner.go internal/cli/lint.go`
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...` via the `make lint` smoke test

Additional commands:

```text
go test ./internal/fs ./internal/scope ./internal/lint ./internal/cli
go vet ./...
make build
git diff --check
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

New coverage includes:

- Shared path resolution and canonicalization.
- Regular-file validation and byte preservation.
- Missing, directory and non-regular path handling.
- Direct, traversal-equivalent and symlink-equivalent output/input collisions.
- Distinct and not-yet-created output paths.
- Existing scope precedence and target behavior.

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Updated package comments for `internal/fs` and `internal/scope`.

## Release notes

Centralized scope path validation and reusable filesystem path mechanics without changing CLI behavior.

## Reviewer notes

Please pay special attention to:

- `internal/scope` owning scope-dependent semantics.
- `internal/fs` remaining limited to reusable filesystem mechanics and existing discovery behavior.
- Preservation of exact target validation messages and precedence.
- Canonical collision detection across relative, cleaned, absolute and symlink-equivalent paths.
- `internal/lint` no longer containing scope-specific output collision helpers.
- `internal/source/dotenv`, diff orchestration and `internal/envfile` intentionally remaining unchanged for follow-up tickets.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint output-path validation to reliably detect conflicts with selected input files, including symlink and relative-path aliases.
  * Added clearer handling for missing, unreadable, non-regular, and invalid file paths.
  * Prevented directories and other unsupported filesystem entries from being treated as files.

* **Reliability**
  * Improved path resolution and file reading consistency across commands.
  * Added comprehensive coverage for path, symlink, and filesystem edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->