### PR TITLE
refactor(output): move lint rendering into internal/output/lint

### DIFF
--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/envaar/vaar/internal/lint"
 	"github.com/envaar/vaar/internal/lint/rules"
-	"github.com/envaar/vaar/internal/report"
+	lintoutput "github.com/envaar/vaar/internal/output/lint"
 	"github.com/envaar/vaar/internal/scope"
 	"github.com/spf13/cobra"
 )
@@ -121,7 +121,7 @@ Use either --target or --target-dir, not both.`,
 			case lintJSON:
 				// JSON output uses the same findings slice as the text path so both
 				// formats stay in lockstep.
-				payload, err := report.JSON(result.Findings)
+				payload, err := lintoutput.JSON(result.Findings)
 				if err != nil {
 					return NewToolError("rendering JSON output failed", err)
 				}
@@ -142,7 +142,7 @@ Use either --target or --target-dir, not both.`,
 					fmt.Fprintln(cmd.OutOrStdout(), string(payload))
 				}
 			default:
-				text := report.Text(result.Findings)
+				text := lintoutput.Text(result.Findings)
 				if text != "" {
 					fmt.Fprint(cmd.OutOrStdout(), text)
 				}

--- a/internal/output/doc.go
+++ b/internal/output/doc.go
@@ -1,0 +1,7 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package output contains typed output adapters for Vaar command results.
+package output

--- a/internal/output/lint/lint.go
+++ b/internal/output/lint/lint.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package lint renders typed lint findings for humans and machines.
+package lint
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	model "github.com/envaar/vaar/internal/lint"
+)
+
+// Text renders findings one per line in a stable, grep-friendly format and
+// returns an empty string for clean runs.
+func Text(findings []model.Finding) string {
+	if len(findings) == 0 {
+		return ""
+	}
+
+	var builder strings.Builder
+	for i, finding := range findings {
+		if i > 0 {
+			builder.WriteByte('\n')
+		}
+		if finding.Fixed {
+			builder.WriteString("[fixed] ")
+		}
+		builder.WriteString(fmt.Sprintf("%s %s %s:%d %s", finding.Severity, finding.Rule, finding.File, finding.Line, finding.Message))
+	}
+	builder.WriteByte('\n')
+	return builder.String()
+}
+
+type payload struct {
+	Findings []model.Finding `json:"findings"`
+}
+
+// JSON renders findings as indented machine-readable output with an explicit
+// findings array, even when the run found nothing.
+func JSON(findings []model.Finding) ([]byte, error) {
+	if findings == nil {
+		findings = []model.Finding{}
+	}
+
+	return json.MarshalIndent(payload{Findings: findings}, "", "  ")
+}

--- a/internal/output/lint/lint.go
+++ b/internal/output/lint/lint.go
@@ -29,7 +29,7 @@ func Text(findings []model.Finding) string {
 		if finding.Fixed {
 			builder.WriteString("[fixed] ")
 		}
-		builder.WriteString(fmt.Sprintf("%s %s %s:%d %s", finding.Severity, finding.Rule, finding.File, finding.Line, finding.Message))
+		fmt.Fprintf(&builder, "%s %s %s:%d %s", finding.Severity, finding.Rule, finding.File, finding.Line, finding.Message)
 	}
 	builder.WriteByte('\n')
 	return builder.String()

--- a/internal/output/lint/lint_test.go
+++ b/internal/output/lint/lint_test.go
@@ -6,6 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 package lint_test
 
 import (
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 
 	model "github.com/envaar/vaar/internal/lint"
@@ -14,7 +19,38 @@ import (
 
 func TestTextReturnsEmptyForNoFindings(t *testing.T) {
 	if got := lintoutput.Text(nil); got != "" {
-		t.Fatalf("unexpected empty text output: got %q", got)
+		t.Fatalf("unexpected text output for no findings: got %q", got)
+	}
+}
+
+func TestLintCLIUsesOutputLintPackage(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to locate the output package test file")
+	}
+
+	repositoryRoot := filepath.Join(filepath.Dir(testFile), "..", "..", "..")
+	cliPath := filepath.Join(repositoryRoot, "internal", "cli", "lint.go")
+	file, err := parser.ParseFile(token.NewFileSet(), cliPath, nil, 0)
+	if err != nil {
+		t.Fatalf("parse lint CLI imports: %v", err)
+	}
+
+	imports := make(map[string]bool, len(file.Imports))
+	for _, imported := range file.Imports {
+		path, err := strconv.Unquote(imported.Path.Value)
+		if err != nil {
+			t.Fatalf("unquote lint CLI import %q: %v", imported.Path.Value, err)
+		}
+		imports[path] = true
+	}
+
+	const outputLintPath = "github.com/envaar/vaar/internal/output/lint"
+	if !imports[outputLintPath] {
+		t.Fatalf("lint CLI must import %q", outputLintPath)
+	}
+	if imports["github.com/envaar/vaar/internal/report"] {
+		t.Fatal("lint CLI must not import internal/report")
 	}
 }
 

--- a/internal/output/lint/lint_test.go
+++ b/internal/output/lint/lint_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint_test
+
+import (
+	"testing"
+
+	model "github.com/envaar/vaar/internal/lint"
+	lintoutput "github.com/envaar/vaar/internal/output/lint"
+)
+
+func TestTextReturnsEmptyForNoFindings(t *testing.T) {
+	if got := lintoutput.Text(nil); got != "" {
+		t.Fatalf("unexpected empty text output: got %q", got)
+	}
+}
+
+func TestTextRendersFindingExactly(t *testing.T) {
+	findings := []model.Finding{{
+		Rule:     "duplicate-key",
+		Severity: model.SeverityError,
+		File:     ".env",
+		Line:     4,
+		Message:  "DATABASE_URL is defined more than once",
+	}}
+
+	want := "error duplicate-key .env:4 DATABASE_URL is defined more than once\n"
+	if got := lintoutput.Text(findings); got != want {
+		t.Fatalf("unexpected text output: got %q want %q", got, want)
+	}
+}
+
+func TestTextMarksFixedFindingExactly(t *testing.T) {
+	findings := []model.Finding{{
+		Rule:     "trailing-whitespace",
+		Severity: model.SeverityWarn,
+		File:     ".env",
+		Line:     1,
+		Message:  "line has trailing whitespace",
+		Fixed:    true,
+	}}
+
+	want := "[fixed] warn trailing-whitespace .env:1 line has trailing whitespace\n"
+	if got := lintoutput.Text(findings); got != want {
+		t.Fatalf("unexpected fixed text output: got %q want %q", got, want)
+	}
+}
+
+func TestJSONRendersFindingExactly(t *testing.T) {
+	findings := []model.Finding{{
+		Rule:     "duplicate-key",
+		Severity: model.SeverityError,
+		File:     ".env",
+		Line:     4,
+		Message:  "DATABASE_URL is defined more than once",
+	}}
+
+	want := "{\n  \"findings\": [\n    {\n      \"rule\": \"duplicate-key\",\n      \"severity\": \"error\",\n      \"file\": \".env\",\n      \"line\": 4,\n      \"message\": \"DATABASE_URL is defined more than once\"\n    }\n  ]\n}"
+	got, err := lintoutput.JSON(findings)
+	if err != nil {
+		t.Fatalf("json render failed: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("unexpected JSON output: got %q want %q", got, want)
+	}
+}
+
+func TestJSONRendersNilFindingsAsEmptyArray(t *testing.T) {
+	want := "{\n  \"findings\": []\n}"
+	got, err := lintoutput.JSON(nil)
+	if err != nil {
+		t.Fatalf("json render failed: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("unexpected empty JSON: got %q want %q", got, want)
+	}
+}

--- a/internal/output/lint/lint_test.go
+++ b/internal/output/lint/lint_test.go
@@ -8,8 +8,8 @@ package lint_test
 import (
 	"go/parser"
 	"go/token"
+	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"testing"
 
@@ -24,12 +24,7 @@ func TestTextReturnsEmptyForNoFindings(t *testing.T) {
 }
 
 func TestLintCLIUsesOutputLintPackage(t *testing.T) {
-	_, testFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("failed to locate the output package test file")
-	}
-
-	repositoryRoot := filepath.Join(filepath.Dir(testFile), "..", "..", "..")
+	repositoryRoot := findRepositoryRoot(t)
 	cliPath := filepath.Join(repositoryRoot, "internal", "cli", "lint.go")
 	file, err := parser.ParseFile(token.NewFileSet(), cliPath, nil, 0)
 	if err != nil {
@@ -52,6 +47,38 @@ func TestLintCLIUsesOutputLintPackage(t *testing.T) {
 	if imports["github.com/envaar/vaar/internal/report"] {
 		t.Fatal("lint CLI must not import internal/report")
 	}
+}
+
+func findRepositoryRoot(t *testing.T) string {
+	t.Helper()
+
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get test working directory: %v", err)
+	}
+
+	directory, err := filepath.Abs(workingDirectory)
+	if err != nil {
+		t.Fatalf("resolve test working directory: %v", err)
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(directory, "go.mod")); err == nil {
+			cliPath := filepath.Join(directory, "internal", "cli", "lint.go")
+			if _, err := os.Stat(cliPath); err == nil {
+				return directory
+			}
+		}
+
+		parent := filepath.Dir(directory)
+		if parent == directory {
+			break
+		}
+		directory = parent
+	}
+
+	t.Fatalf("could not find repository root from %q", workingDirectory)
+	return ""
 }
 
 func TestTextRendersFindingExactly(t *testing.T) {

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -3,25 +3,19 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package report renders lint findings for humans and machines.
+// Package report is a temporary compatibility facade for lint output.
+//
+// New code should use internal/output/lint directly. The forwarding functions
+// remain until the diff output migration removes this package in #71.
 package report
 
 import (
-	"encoding/json"
-
-	"github.com/envaar/vaar/internal/lint"
+	model "github.com/envaar/vaar/internal/lint"
+	lintoutput "github.com/envaar/vaar/internal/output/lint"
 )
-
-type payload struct {
-	Findings []lint.Finding `json:"findings"`
-}
 
 // JSON renders findings as indented machine-readable output with an explicit
 // findings array, even when the run found nothing.
-func JSON(findings []lint.Finding) ([]byte, error) {
-	if findings == nil {
-		findings = []lint.Finding{}
-	}
-
-	return json.MarshalIndent(payload{Findings: findings}, "", "  ")
+func JSON(findings []model.Finding) ([]byte, error) {
+	return lintoutput.JSON(findings)
 }

--- a/internal/report/text.go
+++ b/internal/report/text.go
@@ -6,29 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 package report
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/envaar/vaar/internal/lint"
+	model "github.com/envaar/vaar/internal/lint"
+	lintoutput "github.com/envaar/vaar/internal/output/lint"
 )
 
 // Text renders findings one per line in a stable, grep-friendly format and
 // returns an empty string for clean runs.
-func Text(findings []lint.Finding) string {
-	if len(findings) == 0 {
-		return ""
-	}
-
-	var builder strings.Builder
-	for i, finding := range findings {
-		if i > 0 {
-			builder.WriteByte('\n')
-		}
-		if finding.Fixed {
-			builder.WriteString("[fixed] ")
-		}
-		builder.WriteString(fmt.Sprintf("%s %s %s:%d %s", finding.Severity, finding.Rule, finding.File, finding.Line, finding.Message))
-	}
-	builder.WriteByte('\n')
-	return builder.String()
+func Text(findings []model.Finding) string {
+	return lintoutput.Text(findings)
 }


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Move lint text and JSON rendering into the layered `internal/output/lint` package.

## Why

This establishes the output boundary described in Discussion #58 and keeps CLI orchestration separate from typed result rendering.

Closes #70.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/output/lint` for lint text and JSON rendering.
- Updated the lint CLI to use the new output adapter.
- Converted `internal/report` into a temporary forwarding compatibility facade.
- Added exact-output tests for text, fixed findings, JSON, and empty results.

## User-visible changes

**None.** Existing lint output, JSON schema, exit codes, fix markers, and output-file behavior are unchanged.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
go vet ./...
make build
go test ./internal/output/lint ./internal/report ./internal/cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint result formatting for text and JSON output.
  * Fixed JSON output to consistently represent no findings as an empty array.
  * Clearly marks findings that were fixed in text output.
  * Ensured lint findings render consistently across supported output formats.

* **Tests**
  * Added coverage for empty, populated, fixed, and JSON-formatted lint results.
  * Verified output behavior for cases with no findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->