### PR TITLE
refactor(analysis): add key inventory and declaration

### DIFF
--- a/internal/analysis/doc.go
+++ b/internal/analysis/doc.go
@@ -2,15 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package analysis owns value-free, ordered document and line facts with ordered
-// provenance.
+// provenance, plus narrow document-local key inventories and declaration
+// locations.
 // Engines consume these facts, but analysis does not decide lint severity,
-// diff output, query status, or mutation behavior. internal/analysis performs
-// no file reads/I/O, parsing, discovery, rule execution, diff comparison,
-// query evaluation, file writes, output rendering, serialization/JSON,
-// exit-code mapping, source conversion, or caller integration. Source
-// conversion lives outside this package. This package must not depend on or
-// integrate with internal/envfile, internal/source/dotenv, internal/fs,
-// internal/scope, internal/lint, internal/diff, internal/output, internal/cli,
-// or Cobra. Raw values, raw lines, raw bytes,
-// lengths, hashes, masks, and secret-bearing errors are prohibited.
+// diff output, query status, or mutation behavior. Key inventories record only
+// valid assignment-key presence and declaration locations; engines apply all
+// command meaning. internal/analysis performs no file reads/I/O, parsing,
+// discovery, rule execution, diff comparison, query evaluation, file writes,
+// output rendering, serialization/JSON, exit-code mapping, source conversion,
+// or caller integration. Source conversion lives outside this package. This
+// package must not depend on or integrate with internal/envfile,
+// internal/source/dotenv, internal/fs, internal/scope, internal/lint,
+// internal/diff, internal/output, internal/cli, or Cobra. Raw values, raw
+// lines, raw bytes, lengths, hashes, masks, and secret-bearing errors are
+// prohibited.
 package analysis

--- a/internal/analysis/model.go
+++ b/internal/analysis/model.go
@@ -3,6 +3,11 @@
 
 package analysis
 
+import (
+	"sort"
+	"strings"
+)
+
 type DocumentID string
 
 type QuoteState string
@@ -66,6 +71,77 @@ type Document struct {
 	MixedLineEndings bool
 	EndsWithNewline  bool
 	Lines            []Line
+}
+
+// Declaration identifies one value-free assignment occurrence in a document.
+// It preserves only the document identity, user-facing path, and source line.
+type Declaration struct {
+	DocumentID  DocumentID
+	DisplayPath string
+	LineNumber  int
+}
+
+// KeyInventory is a read-only, document-local index of valid assignment keys
+// and their declaration locations.
+//
+// A key is valid when its analysis line has both HasAssignment and HasKey set.
+// This preserves the existing diff semantics: empty assignments count, while
+// comments, blank lines, bare keys, and malformed declarations do not.
+type KeyInventory struct {
+	keys         []string
+	declarations map[string][]Declaration
+}
+
+// NewKeyInventory builds a value-free inventory from one analysis document.
+// The inventory retains no reference to the document's line slice. Keys are
+// listed deterministically, while declarations retain source line order.
+func NewKeyInventory(document Document) KeyInventory {
+	declarations := make(map[string][]Declaration)
+
+	for _, line := range document.Lines {
+		if !line.HasAssignment || !line.HasKey {
+			continue
+		}
+
+		key := strings.Clone(line.Key)
+		declarations[key] = append(declarations[key], Declaration{
+			DocumentID:  document.ID,
+			DisplayPath: document.DisplayPath,
+			LineNumber:  line.Number,
+		})
+	}
+
+	keys := make([]string, 0, len(declarations))
+	for key := range declarations {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return KeyInventory{
+		keys:         keys,
+		declarations: declarations,
+	}
+}
+
+// Contains reports whether key is present as a valid assignment key.
+func (i KeyInventory) Contains(key string) bool {
+	_, ok := i.declarations[key]
+	return ok
+}
+
+// Keys returns all valid assignment keys in deterministic lexical order.
+func (i KeyInventory) Keys() []string {
+	keys := make([]string, len(i.keys))
+	copy(keys, i.keys)
+	return keys
+}
+
+// Declarations returns all source-order occurrences of key. The returned
+// slice is independent of the inventory and is empty when key is absent.
+func (i KeyInventory) Declarations(key string) []Declaration {
+	declarations := make([]Declaration, len(i.declarations[key]))
+	copy(declarations, i.declarations[key])
+	return declarations
 }
 
 type Snapshot struct {

--- a/internal/analysis/model_test.go
+++ b/internal/analysis/model_test.go
@@ -6,6 +6,7 @@ package analysis_test
 import (
 	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/envaar/vaar/internal/analysis"
 )
@@ -334,6 +335,256 @@ func TestSnapshotHasNoExportedCollectionFields(t *testing.T) {
 		if field.IsExported() {
 			t.Fatalf("Snapshot exposes exported field %q; want no exported fields", field.Name)
 		}
+	}
+}
+
+func TestNewKeyInventoryEmpty(t *testing.T) {
+	inventory := analysis.NewKeyInventory(analysis.Document{})
+
+	keys := inventory.Keys()
+	if keys == nil {
+		t.Fatal("Keys() returned nil; want non-nil empty slice")
+	}
+	if len(keys) != 0 {
+		t.Fatalf("Keys() returned %d keys; want 0", len(keys))
+	}
+
+	declarations := inventory.Declarations("MISSING")
+	if declarations == nil {
+		t.Fatal("Declarations() returned nil; want non-nil empty slice")
+	}
+	if len(declarations) != 0 {
+		t.Fatalf("Declarations() returned %d declarations; want 0", len(declarations))
+	}
+	if inventory.Contains("MISSING") {
+		t.Fatal("Contains(MISSING) = true; want false")
+	}
+}
+
+func TestKeyInventoryCountsPopulatedAndEmptyAssignments(t *testing.T) {
+	document := analysis.Document{Lines: []analysis.Line{
+		{
+			Number:        1,
+			Key:           "POPULATED",
+			HasKey:        true,
+			HasValue:      true,
+			HasAssignment: true,
+		},
+		{
+			Number:        2,
+			Key:           "EMPTY",
+			HasKey:        true,
+			HasValue:      false,
+			HasAssignment: true,
+		},
+	}}
+
+	inventory := analysis.NewKeyInventory(document)
+
+	if !inventory.Contains("POPULATED") {
+		t.Fatal("Contains(POPULATED) = false; want true")
+	}
+	if !inventory.Contains("EMPTY") {
+		t.Fatal("Contains(EMPTY) = false; want true")
+	}
+	if got, want := inventory.Keys(), []string{"EMPTY", "POPULATED"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() = %#v; want %#v", got, want)
+	}
+}
+
+func TestKeyInventoryExcludesNonAssignmentLines(t *testing.T) {
+	document := analysis.Document{Lines: []analysis.Line{
+		{
+			Number:               1,
+			Key:                  "SPACED",
+			HasKey:               true,
+			HasAssignment:        true,
+			SpaceBeforeDelimiter: true,
+			SpaceAfterDelimiter:  true,
+		},
+		{
+			Number:         2,
+			Key:            "COMMENT",
+			HasKey:         false,
+			IsComment:      true,
+			DelimiterState: analysis.DelimiterNone,
+		},
+		{
+			Number:         3,
+			IsBlank:        true,
+			DelimiterState: analysis.DelimiterNone,
+		},
+		{
+			Number:         4,
+			Key:            "BARE",
+			HasKey:         true,
+			DelimiterState: analysis.DelimiterMissing,
+		},
+		{
+			Number:         5,
+			Key:            "COLON",
+			HasKey:         true,
+			DelimiterState: analysis.DelimiterColon,
+		},
+		{
+			Number:        6,
+			Key:           "NO_KEY",
+			HasKey:        false,
+			HasAssignment: true,
+		},
+	}}
+
+	inventory := analysis.NewKeyInventory(document)
+
+	if got, want := inventory.Keys(), []string{"SPACED"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() = %#v; want %#v", got, want)
+	}
+	for _, key := range []string{"COMMENT", "BARE", "COLON", "NO_KEY"} {
+		if inventory.Contains(key) {
+			t.Fatalf("Contains(%q) = true; want false", key)
+		}
+	}
+}
+
+func TestKeyInventoryPreservesCaseAndOrdering(t *testing.T) {
+	document := analysis.Document{Lines: []analysis.Line{
+		{Number: 1, Key: "z_key", HasKey: true, HasAssignment: true},
+		{Number: 2, Key: "TOKEN", HasKey: true, HasAssignment: true},
+		{Number: 3, Key: "a_key", HasKey: true, HasAssignment: true},
+		{Number: 4, Key: "A_KEY", HasKey: true, HasAssignment: true},
+		{Number: 5, Key: "TOKEN", HasKey: true, HasAssignment: true},
+		{Number: 6, Key: "token", HasKey: true, HasAssignment: true},
+	}}
+
+	inventory := analysis.NewKeyInventory(document)
+
+	if got, want := inventory.Keys(), []string{"A_KEY", "TOKEN", "a_key", "token", "z_key"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() = %#v; want %#v", got, want)
+	}
+	if !inventory.Contains("TOKEN") || !inventory.Contains("token") {
+		t.Fatal("case-sensitive keys were not both indexed")
+	}
+	if got := inventory.Declarations("TOKEN"); len(got) != 2 || got[0].LineNumber != 2 || got[1].LineNumber != 5 {
+		t.Fatalf("TOKEN declarations = %#v; want source-order lines 2 and 5", got)
+	}
+	if got := inventory.Declarations("token"); len(got) != 1 || got[0].LineNumber != 6 {
+		t.Fatalf("token declarations = %#v; want line 6", got)
+	}
+}
+
+func TestKeyInventoryPreservesDeclarationProvenance(t *testing.T) {
+	document := analysis.Document{
+		ID:          analysis.DocumentID("dotenv:staging"),
+		DisplayPath: "deploy/.env",
+		Lines: []analysis.Line{
+			{Number: 2, Key: "TOKEN", HasKey: true, HasAssignment: true},
+			{Number: 7, Key: "TOKEN", HasKey: true, HasAssignment: true},
+		},
+	}
+
+	got := analysis.NewKeyInventory(document).Declarations("TOKEN")
+	want := []analysis.Declaration{
+		{DocumentID: document.ID, DisplayPath: document.DisplayPath, LineNumber: 2},
+		{DocumentID: document.ID, DisplayPath: document.DisplayPath, LineNumber: 7},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Declarations(TOKEN) = %#v; want %#v", got, want)
+	}
+}
+
+func TestKeyInventoryIsDocumentLocal(t *testing.T) {
+	first := analysis.NewKeyInventory(analysis.Document{
+		ID:          analysis.DocumentID("first"),
+		DisplayPath: "first.env",
+		Lines:       []analysis.Line{{Number: 1, Key: "SHARED", HasKey: true, HasAssignment: true}},
+	})
+	second := analysis.NewKeyInventory(analysis.Document{
+		ID:          analysis.DocumentID("second"),
+		DisplayPath: "second.env",
+		Lines:       []analysis.Line{{Number: 8, Key: "SHARED", HasKey: true, HasAssignment: true}},
+	})
+
+	if got := first.Declarations("SHARED"); len(got) != 1 || got[0].DocumentID != "first" || got[0].DisplayPath != "first.env" || got[0].LineNumber != 1 {
+		t.Fatalf("first inventory declarations = %#v; want only first document", got)
+	}
+	if got := second.Declarations("SHARED"); len(got) != 1 || got[0].DocumentID != "second" || got[0].DisplayPath != "second.env" || got[0].LineNumber != 8 {
+		t.Fatalf("second inventory declarations = %#v; want only second document", got)
+	}
+}
+
+func TestKeyInventoryDoesNotExposeForbiddenValueFields(t *testing.T) {
+	forbidden := []string{
+		"Raw",
+		"Content",
+		"Value",
+		"ValueRaw",
+		"KeyRaw",
+		"Original",
+		"ValuePreview",
+		"ValueLength",
+		"Hash",
+		"Mask",
+	}
+
+	assertFieldsAbsent(t, reflect.TypeOf(analysis.Declaration{}), forbidden)
+	assertFieldsAbsent(t, reflect.TypeOf(analysis.KeyInventory{}), forbidden)
+}
+
+func TestKeyInventoryReturnsDefensiveCopies(t *testing.T) {
+	document := analysis.Document{
+		ID:          analysis.DocumentID("original"),
+		DisplayPath: "original.env",
+		Lines: []analysis.Line{
+			{Number: 1, Key: "TOKEN", HasKey: true, HasAssignment: true},
+			{Number: 2, Key: "KEEP", HasKey: true, HasAssignment: true},
+		},
+	}
+	inventory := analysis.NewKeyInventory(document)
+
+	document.ID = "mutated"
+	document.DisplayPath = "mutated.env"
+	document.Lines[0].Number = 99
+	document.Lines[0].Key = "MUTATED"
+	document.Lines = document.Lines[:1]
+
+	keys := inventory.Keys()
+	keys[0] = "MUTATED"
+	declarations := inventory.Declarations("TOKEN")
+	declarations[0].DocumentID = "mutated"
+	declarations[0].DisplayPath = "mutated.env"
+	declarations[0].LineNumber = 99
+	declarations = declarations[:0]
+
+	if got, want := inventory.Keys(), []string{"KEEP", "TOKEN"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Keys() after mutation = %#v; want %#v", got, want)
+	}
+	wantDeclarations := []analysis.Declaration{{
+		DocumentID:  "original",
+		DisplayPath: "original.env",
+		LineNumber:  1,
+	}}
+	if got := inventory.Declarations("TOKEN"); !reflect.DeepEqual(got, wantDeclarations) {
+		t.Fatalf("Declarations(TOKEN) after mutation = %#v; want %#v", got, wantDeclarations)
+	}
+}
+
+func TestKeyInventoryCopiesKeyStorage(t *testing.T) {
+	backing := "TOKEN-storage-sentinel"
+	key := backing[:len("TOKEN")]
+
+	inventory := analysis.NewKeyInventory(analysis.Document{Lines: []analysis.Line{{
+		Key:           key,
+		HasKey:        true,
+		HasAssignment: true,
+	}}})
+	keys := inventory.Keys()
+
+	if len(keys) != 1 {
+		t.Fatalf("Keys() returned %d keys; want 1", len(keys))
+	}
+	if unsafe.StringData(keys[0]) == unsafe.StringData(key) {
+		t.Fatal("inventory key retains input string backing storage")
 	}
 }
 

--- a/internal/analysis/model_test.go
+++ b/internal/analysis/model_test.go
@@ -554,7 +554,6 @@ func TestKeyInventoryReturnsDefensiveCopies(t *testing.T) {
 	declarations[0].DocumentID = "mutated"
 	declarations[0].DisplayPath = "mutated.env"
 	declarations[0].LineNumber = 99
-	declarations = declarations[:0]
 
 	if got, want := inventory.Keys(), []string{"KEEP", "TOKEN"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Keys() after mutation = %#v; want %#v", got, want)


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add a value-free, document-local key inventory and declaration provenance API to `internal/analysis`.

## Why

Closes #86 and supports the layered analysis architecture described in [Discussion #58](https://github.com/envaar/vaar/discussions/58).

Diff needs shared key-presence data without reading parser models. Future query functionality needs declaration locations without exposing values. This capability belongs in the analysis layer.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added document-local `KeyInventory` with case-sensitive key lookup and deterministic key ordering.
- Added declaration provenance containing only document ID, display path, and line number.
- Preserved duplicate declarations in source order.
- Preserved existing assignment semantics: `KEY=value` and `KEY=` count; comments, blanks, bare keys, and malformed declarations do not.
- Added defensive-copy and value-safety protections.

## User-visible changes

**None.**

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
go test -race ./internal/analysis/...
go vet ./...
make build
git diff --check
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Added a value-free analysis key inventory with declaration location provenance.

## Reviewer notes

Please verify:

- Inventory eligibility uses `HasAssignment && HasKey`.
- Empty assignments remain present.
- Duplicate declarations retain source order.
- Keys remain case-sensitive and deterministic.
- Provenance contains no values or raw source data.
- `strings.Clone` prevents input string backing storage from crossing the analysis boundary.
- No diff, query, lint, parser, CLI, output, or mutation behavior was migrated in this ticket.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analysis results now track valid assignment keys and their source locations, including document paths and line numbers.
  * Key listings are consistently ordered and can be queried without exposing underlying values.

* **Documentation**
  * Clarified analysis metadata, assignment-key provenance, and data-handling boundaries.

* **Tests**
  * Added comprehensive coverage for key discovery, ordering, source tracking, isolation, and data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->