### PR TITLE
refactor(fs): extract atomic file replacement helpers

### DIFF
--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -56,10 +56,12 @@ func outputTempDir(path string) string {
 	return fs.TempDirForPath(path)
 }
 
+// outputDirectoryError formats the lint-specific error for directory targets.
 func outputDirectoryError(path string) error {
 	return NewToolError(fmt.Sprintf("cannot write lint output to %q: the path is a directory", path), nil)
 }
 
+// outputWriteError formats the lint-specific error for replacement failures.
 func outputWriteError(path string, err error) error {
 	return NewToolError(fmt.Sprintf("writing JSON output to %s failed", path), err)
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -6,141 +6,54 @@ SPDX-License-Identifier: Apache-2.0
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"runtime"
+
+	"github.com/envaar/vaar/internal/fs"
 )
 
-// validateOutputDestination rejects --output values that name a directory: a
-// trailing path separator or a path that already exists as a directory. Without
-// this guard the write path below creates a temporary file, fails to rename it
-// onto the directory and then removes the directory, destroying it.
+// validateOutputDestination rejects --output values that name a directory and
+// preserves the CLI-specific directory error before lint execution begins.
+// The filesystem transaction repeats this safety check at finalization for
+// destinations that change after this preflight.
 func validateOutputDestination(output string) error {
-	if hasTrailingSeparator(output) {
-		return outputDirectoryError(output)
-	}
-
-	info, err := os.Stat(output)
-	switch {
-	case err == nil:
-		if info.IsDir() {
+	if err := fs.ValidateFileDestination(output); err != nil {
+		if errors.Is(err, fs.ErrIsDirectory) {
 			return outputDirectoryError(output)
 		}
-		return nil
-	case os.IsNotExist(err):
-		return nil
-	default:
 		return NewToolError(fmt.Sprintf("checking output destination %q failed", output), err)
 	}
+	return nil
 }
 
-// writeJSONOutput writes data to path via a temporary file in the destination
-// directory followed by an atomic rename. filepath.Dir keeps the temporary file
-// on the same volume as the destination so the rename stays atomic. If the
-// destination is a regular file on Windows and a direct rename fails, the file
-// is moved to a unique backup path, the replacement is retried, and the
-// original file is restored if the retry fails. Existing directories are
-// rejected and never removed.
+// writeJSONOutput keeps the lint-specific error wording at the CLI boundary
+// while delegating temporary-file creation, replacement and cleanup to fs.
 func writeJSONOutput(path string, data []byte) error {
-	dir := outputTempDir(path)
-
-	tmp, err := os.CreateTemp(dir, "vaar-lint-*.json")
+	file, err := fs.NewAtomicFile(path)
 	if err != nil {
+		if errors.Is(err, fs.ErrIsDirectory) {
+			return outputDirectoryError(path)
+		}
 		return NewToolError("creating JSON output file failed", err)
 	}
-	tmpName := tmp.Name()
-	// Clean up the temporary file on any early return. This is a no-op once the
-	// rename below consumes it.
-	defer os.Remove(tmpName)
+	defer func() { _ = file.Cleanup() }()
 
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
+	if _, err := file.Write(data); err != nil {
 		return NewToolError(fmt.Sprintf("writing JSON output to %s failed", path), err)
 	}
-	if err := tmp.Close(); err != nil {
+	if err := file.Finalize(); err != nil {
+		if errors.Is(err, fs.ErrIsDirectory) {
+			return outputDirectoryError(path)
+		}
 		return outputWriteError(path, err)
 	}
-
-	return finalizeJSONOutput(tmpName, path)
-}
-
-// hasTrailingSeparator reports whether path ends with a path separator, which
-// signals a directory target rather than a file destination.
-func hasTrailingSeparator(path string) bool {
-	if path == "" {
-		return false
-	}
-	last := path[len(path)-1]
-	return last == '/' || last == os.PathSeparator
+	return nil
 }
 
 // outputTempDir keeps temporary JSON output alongside the final destination so
 // the eventual rename stays on the same volume.
 func outputTempDir(path string) string {
-	return filepath.Dir(path)
-}
-
-func finalizeJSONOutput(tmpName, path string) error {
-	renameErr := os.Rename(tmpName, path)
-	if renameErr == nil {
-		return nil
-	}
-
-	info, statErr := os.Stat(path)
-	if statErr == nil && info.IsDir() {
-		return outputDirectoryError(path)
-	}
-	if runtime.GOOS == "windows" && statErr == nil {
-		if err := replaceJSONOutputWindows(tmpName, path); err != nil {
-			return outputWriteError(path, err)
-		}
-		return nil
-	}
-
-	return outputWriteError(path, renameErr)
-}
-
-func replaceJSONOutputWindows(tmpName, path string) error {
-	backup, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".vaar-backup-*")
-	if err != nil {
-		return err
-	}
-	backupName := backup.Name()
-	if err := backup.Close(); err != nil {
-		_ = os.Remove(backupName)
-		return err
-	}
-
-	cleanBackup := true
-	defer func() {
-		if cleanBackup {
-			_ = os.Remove(backupName)
-		}
-	}()
-
-	if err := os.Rename(path, backupName); err != nil {
-		if chmodErr := os.Chmod(path, 0o600); chmodErr == nil {
-			if retryErr := os.Rename(path, backupName); retryErr == nil {
-				err = nil
-			} else {
-				err = retryErr
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-
-	if err := os.Rename(tmpName, path); err != nil {
-		if restoreErr := os.Rename(backupName, path); restoreErr != nil {
-			cleanBackup = false
-			return fmt.Errorf("%w; restore original failed: %v", err, restoreErr)
-		}
-		return err
-	}
-
-	return nil
+	return fs.TempDirForPath(path)
 }
 
 func outputDirectoryError(path string) error {

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -1,0 +1,224 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// ErrAtomicFileClosed indicates that an AtomicFile has already been
+// finalized or cleaned up.
+var ErrAtomicFileClosed = errors.New("atomic file is closed")
+
+// AtomicFile owns a same-directory temporary file until it is finalized or
+// cleaned up. The destination is replaced only after all writes succeed.
+type AtomicFile struct {
+	destination string
+	temporary   string
+	file        *os.File
+	finalized   bool
+}
+
+// TempDirForPath returns the directory in which a temporary file for path
+// must be created so a subsequent rename remains on the same volume.
+func TempDirForPath(path string) string {
+	return filepath.Dir(path)
+}
+
+// ValidateFileDestination rejects paths that name directories and allows paths
+// that do not exist yet. Errors other than a missing path are returned to the
+// caller unchanged.
+func ValidateFileDestination(path string) error {
+	if hasTrailingSeparator(path) {
+		return directoryDestinationError(path)
+	}
+
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		if info.IsDir() {
+			return directoryDestinationError(path)
+		}
+		return nil
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return err
+	}
+}
+
+// NewAtomicFile creates a transaction for replacing destination. The
+// temporary file is created in destination's directory and uses a generic
+// name so the helper remains independent of its caller's output format.
+func NewAtomicFile(destination string) (*AtomicFile, error) {
+	if err := ValidateFileDestination(destination); err != nil {
+		return nil, err
+	}
+
+	temporary, err := os.CreateTemp(TempDirForPath(destination), "vaar-atomic-*")
+	if err != nil {
+		return nil, err
+	}
+
+	return &AtomicFile{
+		destination: destination,
+		temporary:   temporary.Name(),
+		file:        temporary,
+	}, nil
+}
+
+// Write writes data to the transaction's temporary file. The destination is
+// not changed until Finalize succeeds.
+func (f *AtomicFile) Write(data []byte) (int, error) {
+	if f == nil || f.file == nil {
+		return 0, ErrAtomicFileClosed
+	}
+
+	written, err := f.file.Write(data)
+	if err != nil {
+		_ = f.Cleanup()
+		return written, err
+	}
+	if written != len(data) {
+		_ = f.Cleanup()
+		return written, io.ErrShortWrite
+	}
+	return written, nil
+}
+
+// Finalize closes the temporary file and atomically replaces the destination.
+// It cleans up the temporary file if closing or replacement fails.
+func (f *AtomicFile) Finalize() error {
+	if f == nil {
+		return ErrAtomicFileClosed
+	}
+	if f.finalized {
+		return nil
+	}
+	if f.temporary == "" {
+		return ErrAtomicFileClosed
+	}
+
+	if f.file != nil {
+		err := f.file.Close()
+		f.file = nil
+		if err != nil {
+			_ = f.Cleanup()
+			return err
+		}
+	}
+
+	if err := replaceFile(f.temporary, f.destination); err != nil {
+		_ = f.Cleanup()
+		return err
+	}
+
+	f.temporary = ""
+	f.finalized = true
+	return nil
+}
+
+// Cleanup closes any open temporary file and removes an uncommitted temporary
+// path. It is safe to call repeatedly and after successful finalization.
+func (f *AtomicFile) Cleanup() error {
+	if f == nil {
+		return nil
+	}
+
+	var closeErr error
+	if f.file != nil {
+		closeErr = f.file.Close()
+		f.file = nil
+	}
+
+	if f.temporary == "" {
+		return closeErr
+	}
+
+	removeErr := os.Remove(f.temporary)
+	if removeErr == nil || os.IsNotExist(removeErr) {
+		f.temporary = ""
+	}
+	return errors.Join(closeErr, removeErr)
+}
+
+func replaceFile(temporary, destination string) error {
+	renameErr := os.Rename(temporary, destination)
+	if renameErr == nil {
+		return nil
+	}
+
+	info, statErr := os.Stat(destination)
+	if statErr == nil {
+		if info.IsDir() {
+			return directoryDestinationError(destination)
+		}
+		if runtime.GOOS == "windows" {
+			return replaceFileWindows(temporary, destination)
+		}
+	}
+
+	return renameErr
+}
+
+func replaceFileWindows(temporary, destination string) error {
+	backup, err := os.CreateTemp(TempDirForPath(destination), filepath.Base(destination)+".vaar-backup-*")
+	if err != nil {
+		return err
+	}
+	backupName := backup.Name()
+	if err := backup.Close(); err != nil {
+		_ = os.Remove(backupName)
+		return err
+	}
+
+	cleanBackup := true
+	defer func() {
+		if cleanBackup {
+			_ = os.Remove(backupName)
+		}
+	}()
+
+	if err := os.Rename(destination, backupName); err != nil {
+		if chmodErr := os.Chmod(destination, 0o600); chmodErr == nil {
+			if retryErr := os.Rename(destination, backupName); retryErr == nil {
+				err = nil
+			} else {
+				err = retryErr
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := os.Rename(temporary, destination); err != nil {
+		if restoreErr := os.Rename(backupName, destination); restoreErr != nil {
+			cleanBackup = false
+			return fmt.Errorf("%w; restore original failed: %v", err, restoreErr)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func hasTrailingSeparator(path string) bool {
+	if path == "" {
+		return false
+	}
+	last := path[len(path)-1]
+	return last == '/' || last == os.PathSeparator
+}
+
+func directoryDestinationError(path string) error {
+	return fmt.Errorf("%w: %s", ErrIsDirectory, path)
+}

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -151,6 +151,12 @@ func (f *AtomicFile) Cleanup() error {
 }
 
 func replaceFile(temporary, destination string) error {
+	// Revalidate immediately before replacement so a directory or a symlink to
+	// a directory created after NewAtomicFile cannot be replaced as a file.
+	if err := ValidateFileDestination(destination); err != nil {
+		return err
+	}
+
 	renameErr := os.Rename(temporary, destination)
 	if renameErr == nil {
 		return nil
@@ -169,7 +175,14 @@ func replaceFile(temporary, destination string) error {
 	return renameErr
 }
 
+// replaceFileWindows preserves the original destination while replacing a
+// regular file on Windows, where a direct rename over an existing file may
+// fail because the destination is still open.
 func replaceFileWindows(temporary, destination string) error {
+	if err := ValidateFileDestination(destination); err != nil {
+		return err
+	}
+
 	backup, err := os.CreateTemp(TempDirForPath(destination), filepath.Base(destination)+".vaar-backup-*")
 	if err != nil {
 		return err
@@ -211,6 +224,8 @@ func replaceFileWindows(temporary, destination string) error {
 	return nil
 }
 
+// hasTrailingSeparator reports whether path denotes a directory-like target
+// through a trailing platform-independent or native path separator.
 func hasTrailingSeparator(path string) bool {
 	if path == "" {
 		return false
@@ -219,6 +234,8 @@ func hasTrailingSeparator(path string) bool {
 	return last == '/' || last == os.PathSeparator
 }
 
+// directoryDestinationError preserves the directory identity for callers that
+// need to translate it into a user-facing error.
 func directoryDestinationError(path string) error {
 	return fmt.Errorf("%w: %s", ErrIsDirectory, path)
 }

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -127,6 +128,60 @@ func TestAtomicFilePreservesDirectoryCreatedAfterOpen(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Fatal("destination is no longer a directory")
+	}
+	assertFileBytes(t, kept, []byte("keep"))
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFilePreservesDirectorySymlinkCreatedAfterOpen(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "destination")
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("create target directory failed: %v", err)
+	}
+	kept := filepath.Join(target, "keep.txt")
+	if err := os.WriteFile(kept, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write directory sentinel failed: %v", err)
+	}
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+	if _, err := file.Write([]byte("replacement")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if err := os.Symlink(target, destination); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink creation is unavailable: %v", err)
+		}
+		t.Fatalf("create directory symlink failed: %v", err)
+	}
+
+	err = file.Finalize()
+	if err == nil {
+		t.Fatal("expected finalize to reject a directory symlink created after open")
+	}
+	if !errors.Is(err, fs.ErrIsDirectory) {
+		t.Fatalf("expected ErrIsDirectory, got %v", err)
+	}
+
+	info, err := os.Lstat(destination)
+	if err != nil {
+		t.Fatalf("lstat destination failed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("destination symlink was replaced")
+	}
+	linkedTarget, err := os.Readlink(destination)
+	if err != nil {
+		t.Fatalf("read destination symlink failed: %v", err)
+	}
+	if linkedTarget != target {
+		t.Fatalf("destination symlink target changed: got %q want %q", linkedTarget, target)
 	}
 	assertFileBytes(t, kept, []byte("keep"))
 	assertNoAtomicTemporaryFiles(t, root)

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+func TestAtomicFileReplacesMissingDestination(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "lint.json")
+	payload := []byte("replacement")
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+
+	if _, err := file.Write(payload); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := file.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	assertFileBytes(t, destination, payload)
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFileReplacesExistingFile(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "lint.json")
+	if err := os.WriteFile(destination, []byte("stale"), 0o644); err != nil {
+		t.Fatalf("write stale file failed: %v", err)
+	}
+	payload := []byte("replacement")
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+
+	if _, err := file.Write(payload); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if err := file.Finalize(); err != nil {
+		t.Fatalf("finalize failed: %v", err)
+	}
+
+	assertFileBytes(t, destination, payload)
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFileDoesNotReplaceDirectory(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "destination")
+	if err := os.Mkdir(destination, 0o755); err != nil {
+		t.Fatalf("create destination directory failed: %v", err)
+	}
+	kept := filepath.Join(destination, "keep.txt")
+	if err := os.WriteFile(kept, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write directory sentinel failed: %v", err)
+	}
+
+	_, err := fs.NewAtomicFile(destination)
+	if err == nil {
+		t.Fatal("expected directory destination to be rejected")
+	}
+	if !errors.Is(err, fs.ErrIsDirectory) {
+		t.Fatalf("expected ErrIsDirectory, got %v", err)
+	}
+
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatalf("stat destination failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("destination is no longer a directory")
+	}
+	assertFileBytes(t, kept, []byte("keep"))
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFilePreservesDirectoryCreatedAfterOpen(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "destination")
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+	if _, err := file.Write([]byte("replacement")); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	if err := os.Mkdir(destination, 0o755); err != nil {
+		t.Fatalf("create replacement directory failed: %v", err)
+	}
+	kept := filepath.Join(destination, "keep.txt")
+	if err := os.WriteFile(kept, []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write directory sentinel failed: %v", err)
+	}
+
+	err = file.Finalize()
+	if err == nil {
+		t.Fatal("expected finalize to reject a directory created after open")
+	}
+	if !errors.Is(err, fs.ErrIsDirectory) {
+		t.Fatalf("expected ErrIsDirectory, got %v", err)
+	}
+
+	info, err := os.Stat(destination)
+	if err != nil {
+		t.Fatalf("stat destination failed: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("destination is no longer a directory")
+	}
+	assertFileBytes(t, kept, []byte("keep"))
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFileCleanupRemovesTemporaryFile(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "lint.json")
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read temporary directory failed: %v", err)
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0].Name(), "vaar-atomic-") {
+		t.Fatalf("expected one atomic temporary file, got %v", entries)
+	}
+
+	if err := file.Cleanup(); err != nil {
+		t.Fatalf("first cleanup failed: %v", err)
+	}
+	if err := file.Cleanup(); err != nil {
+		t.Fatalf("second cleanup should be harmless: %v", err)
+	}
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFileRejectsWritesAfterCleanup(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "lint.json")
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	if err := file.Cleanup(); err != nil {
+		t.Fatalf("cleanup failed: %v", err)
+	}
+
+	if _, err := file.Write([]byte("replacement")); !errors.Is(err, fs.ErrAtomicFileClosed) {
+		t.Fatalf("expected ErrAtomicFileClosed, got %v", err)
+	}
+}
+
+func TestValidateFileDestinationRejectsTrailingSeparator(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "destination") + string(os.PathSeparator)
+
+	if err := fs.ValidateFileDestination(path); !errors.Is(err, fs.ErrIsDirectory) {
+		t.Fatalf("expected ErrIsDirectory, got %v", err)
+	}
+}
+
+func TestTempDirForPathUsesDestinationDirectory(t *testing.T) {
+	path := filepath.Join("root", "reports", "lint.json")
+	if got, want := fs.TempDirForPath(path), filepath.Dir(path); got != want {
+		t.Fatalf("unexpected temporary directory: got %q want %q", got, want)
+	}
+}
+
+func assertFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q failed: %v", path, err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("unexpected bytes in %q: got %q want %q", path, got, want)
+	}
+}
+
+func assertNoAtomicTemporaryFiles(t *testing.T, root string) {
+	t.Helper()
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read directory failed: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "vaar-atomic-") {
+			t.Fatalf("temporary atomic file was not cleaned up: %q", entry.Name())
+		}
+	}
+}

--- a/internal/fs/walk.go
+++ b/internal/fs/walk.go
@@ -3,8 +3,9 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package fs provides reusable filesystem mechanics and deterministic dotenv
-// discovery that skips generated, vendored and fixture directories.
+// Package fs provides reusable filesystem mechanics, atomic file replacement
+// and deterministic dotenv discovery that skips generated, vendored and
+// fixture directories.
 package fs
 
 import (


### PR DESCRIPTION
<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Extract reusable atomic file replacement mechanics from `internal/cli/output.go` into `internal/fs`.

## Why

GitHub issue [#76](https://github.com/envaar/vaar/issues/76) requires filesystem replacement mechanics to be reusable for future mutation work while preserving current lint JSON behavior.

Related architecture discussion: [Discussion #58](https://github.com/envaar/vaar/discussions/58).

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added transactional atomic file replacement utilities to `internal/fs`.
- Preserved same-directory temporary files, Unix rename behavior, Windows backup/restore fallback, and cleanup guarantees.
- Added protection against replacing existing directories, including directory changes after transaction creation.
- Updated lint JSON output to use the reusable filesystem transaction.
- Preserved existing CLI-specific error wording and output behavior.
- Added focused filesystem lifecycle and safety tests.

## User-visible changes

**None.**

Lint JSON output behavior, report contents, CLI messages, and exit codes remain unchanged.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
go test -count=1 ./...
go vet ./...
go test -race ./internal/fs ./internal/cli
GOOS=windows GOARCH=amd64 go test -c ./internal/fs
GOOS=windows GOARCH=amd64 go test -c ./internal/cli
make build

Also verified:
- git diff --check
- internal/fs dependency boundary
- forbidden CLI/output/JSON dependencies
- temporary-file cleanup and directory preservation
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Updated the `internal/fs` package comment to describe atomic replacement support.

## Release notes

Extract reusable atomic file replacement mechanics into the filesystem package without changing CLI behavior.

## Reviewer notes

Please pay special attention to:

- Atomic replacement and same-directory temporary-file creation.
- Cleanup behavior after write, finalize, and replacement failures.
- Protection against replacing or removing directories.
- Windows backup, retry, restoration, and backup-retention behavior.
- Preservation of existing lint JSON output and CLI error wording.
- Scope control: no mutation planning, permission preservation, stale-write detection, or output-format changes are included.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI JSON output reliability through atomic file replacement.
  * Prevented accidental replacement of destination directories.
  * Improved cleanup of temporary output files, including Windows-specific handling.

* **Documentation**
  * Updated filesystem package documentation to describe atomic file replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->