### PR TITLE
refactor(fs): centralize permission-preserving file writes

### DIFF
--- a/internal/envfile/writer.go
+++ b/internal/envfile/writer.go
@@ -5,15 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package envfile
 
-import "os"
+import "github.com/envaar/vaar/internal/fs"
 
 // Write writes data back to path and preserves the file's existing permissions
 // when the file already exists.
 func Write(path string, data []byte) error {
-	perm := os.FileMode(0o644)
-	if info, err := os.Stat(path); err == nil {
-		perm = info.Mode().Perm()
-	}
-
-	return os.WriteFile(path, data, perm)
+	return fs.WriteFile(path, data)
 }

--- a/internal/envfile/writer_test.go
+++ b/internal/envfile/writer_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package envfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/envaar/vaar/internal/envfile"
+)
+
+func TestWritePreservesExistingPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("OLD=value\n"), 0o640); err != nil {
+		t.Fatalf("write initial file failed: %v", err)
+	}
+	initialInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat initial file failed: %v", err)
+	}
+	initialPerm := initialInfo.Mode().Perm()
+
+	if err := envfile.Write(path, []byte("NEW=value\n")); err != nil {
+		t.Fatalf("write envfile failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), initialPerm; got != want {
+		t.Fatalf("rewritten envfile permissions changed: got %o want %o", got, want)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten envfile failed: %v", err)
+	}
+	if got, want := string(contents), "NEW=value\n"; got != want {
+		t.Fatalf("rewritten envfile contents changed unexpectedly: got %q want %q", got, want)
+	}
+}

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import "os"
+
+const defaultFileMode os.FileMode = 0o644
+
+// WriteFile writes data to path, preserving the existing permission bits when
+// path already identifies a file. New files use the standard 0644 mode,
+// subject to the process umask.
+func WriteFile(path string, data []byte) error {
+	perm := defaultFileMode
+	if info, err := os.Stat(path); err == nil {
+		perm = info.Mode().Perm()
+	}
+
+	return os.WriteFile(path, data, perm)
+}

--- a/internal/fs/write_test.go
+++ b/internal/fs/write_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+func TestWriteFilePreservesExistingPermissions(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "config.env")
+
+	if err := os.WriteFile(path, []byte("old"), 0o601); err != nil {
+		t.Fatalf("write initial file failed: %v", err)
+	}
+	initialInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat initial file failed: %v", err)
+	}
+	initialPerm := initialInfo.Mode().Perm()
+
+	if err := fs.WriteFile(path, []byte("new")); err != nil {
+		t.Fatalf("write existing file failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat rewritten file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), initialPerm; got != want {
+		t.Fatalf("rewritten file permissions changed: got %o want %o", got, want)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten file failed: %v", err)
+	}
+	if got, want := string(contents), "new"; got != want {
+		t.Fatalf("rewritten file contents changed unexpectedly: got %q want %q", got, want)
+	}
+}
+
+func TestWriteFileUsesDefaultModeForNewFiles(t *testing.T) {
+	root := t.TempDir()
+	reference := filepath.Join(root, "reference")
+	path := filepath.Join(root, "created")
+
+	if err := os.WriteFile(reference, []byte("reference"), 0o644); err != nil {
+		t.Fatalf("write reference file failed: %v", err)
+	}
+	if err := fs.WriteFile(path, []byte("created")); err != nil {
+		t.Fatalf("write new file failed: %v", err)
+	}
+
+	referenceInfo, err := os.Stat(reference)
+	if err != nil {
+		t.Fatalf("stat reference file failed: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat created file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), referenceInfo.Mode().Perm(); got != want {
+		t.Fatalf("new file permissions differ from default: got %o want %o", got, want)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read created file failed: %v", err)
+	}
+	if got, want := string(contents), "created"; got != want {
+		t.Fatalf("created file contents differ: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #77

<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Centralize permission-preserving file writes in `internal/fs`.

## Why

`internal/envfile` previously contained generic filesystem mode logic. Moving that behavior into `internal/fs` gives filesystem operations a single owner while preserving existing behavior.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/fs.WriteFile`, preserving existing permission bits and using the default `0644` mode for new files.
- Updated `internal/envfile.Write` to delegate to `internal/fs.WriteFile`.
- Added regression tests for permissions, file creation, content replacement, umask behavior, and envfile integration.

## User-visible changes

**None.**

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [x] `go run ./cmd/vaar lint ...` (covered by `make lint`)

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go vet ./...
GOCACHE=/tmp/vaar-go-cache make build
umask 077 with focused filesystem and envfile tests
GOOS=windows GOARCH=amd64 go test -c for internal/fs and internal/envfile
```

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [ ] Updated documentation
- [x] Not applicable

## Release notes

Centralize permission-preserving file writes under `internal/fs` without changing existing behavior.

## Reviewer notes

Please verify:

- Existing file permissions remain unchanged after rewrites.
- New files retain the existing default mode behavior.
- `internal/envfile` no longer owns generic filesystem mode logic.
- The change does not introduce atomic replacement, parser changes, lint changes, discovery changes, or CLI behavior changes.
- Tests remain portable across different umasks and supported platforms.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated file writing to preserve existing file permissions when contents are replaced.
  - New files are created with standard default permissions.

- **Tests**
  - Added coverage confirming permission preservation for existing files.
  - Added coverage verifying default permissions and content for newly created files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->