### PR TITLE
refactor(lint): run rules through analysis-backed engine

### DIFF
--- a/internal/analysis/doc.go
+++ b/internal/analysis/doc.go
@@ -3,7 +3,8 @@
 
 // Package analysis owns value-free, ordered document and line facts with ordered
 // provenance, plus narrow document-local key inventories and declaration
-// locations.
+// locations. Snapshots provide defensive collection access and allocation-aware
+// read-only traversal views for consumers that inspect documents repeatedly.
 // Engines consume these facts, but analysis does not decide lint severity,
 // diff output, query status, or mutation behavior. Key inventories record only
 // valid assignment-key presence and declaration locations; engines apply all

--- a/internal/analysis/model.go
+++ b/internal/analysis/model.go
@@ -73,6 +73,52 @@ type Document struct {
 	Lines            []Line
 }
 
+// DocumentView exposes document metadata and read-only line traversal without
+// exposing the snapshot's backing line slice.
+type DocumentView struct {
+	ID               DocumentID
+	SourcePath       string
+	DisplayPath      string
+	BOM              bool
+	MixedLineEndings bool
+	EndsWithNewline  bool
+
+	lines []Line
+}
+
+// RangeDocuments calls fn once for each document in source order. The view
+// does not expose mutable collection storage, so callers can inspect a
+// snapshot without allocating a complete defensive copy for every consumer.
+func (s Snapshot) RangeDocuments(fn func(DocumentView)) {
+	if fn == nil {
+		return
+	}
+
+	for _, document := range s.documents {
+		fn(DocumentView{
+			ID:               document.ID,
+			SourcePath:       document.SourcePath,
+			DisplayPath:      document.DisplayPath,
+			BOM:              document.BOM,
+			MixedLineEndings: document.MixedLineEndings,
+			EndsWithNewline:  document.EndsWithNewline,
+			lines:            document.Lines,
+		})
+	}
+}
+
+// RangeLines calls fn once for each line in source order. Each line is passed
+// by value, so changing the callback argument cannot mutate the snapshot.
+func (d DocumentView) RangeLines(fn func(Line)) {
+	if fn == nil {
+		return
+	}
+
+	for _, line := range d.lines {
+		fn(line)
+	}
+}
+
 // Declaration identifies one value-free assignment occurrence in a document.
 // It preserves only the document identity, user-facing path, and source line.
 type Declaration struct {

--- a/internal/analysis/model_test.go
+++ b/internal/analysis/model_test.go
@@ -285,6 +285,47 @@ func TestSnapshotDefensivelyCopiesInput(t *testing.T) {
 	}
 }
 
+func TestSnapshotRangesDocumentsAndLinesThroughReadOnlyViews(t *testing.T) {
+	snapshot := analysis.NewSnapshot([]analysis.Document{{
+		ID:          analysis.DocumentID("document"),
+		SourcePath:  "/repo/.env",
+		DisplayPath: ".env",
+		BOM:         true,
+		Lines: []analysis.Line{
+			{Number: 1, Key: "FIRST", HasKey: true},
+			{Number: 2, Key: "SECOND", HasKey: true},
+		},
+	}})
+
+	var documents []string
+	var lines []string
+	snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		documents = append(documents, string(document.ID), document.DisplayPath)
+		document.RangeLines(func(line analysis.Line) {
+			lines = append(lines, line.Key)
+			line.Key = "MUTATED"
+		})
+	})
+
+	if want := []string{"document", ".env"}; !reflect.DeepEqual(documents, want) {
+		t.Fatalf("document view values = %#v, want %#v", documents, want)
+	}
+	if want := []string{"FIRST", "SECOND"}; !reflect.DeepEqual(lines, want) {
+		t.Fatalf("line view values = %#v, want %#v", lines, want)
+	}
+
+	got := snapshot.Documents()
+	if got[0].Lines[0].Key != "FIRST" || got[0].Lines[1].Key != "SECOND" {
+		t.Fatalf("snapshot changed through read-only views: %#v", got[0].Lines)
+	}
+}
+
+func TestDocumentViewDoesNotExposeLineCollection(t *testing.T) {
+	if _, ok := reflect.TypeOf(analysis.DocumentView{}).FieldByName("Lines"); ok {
+		t.Fatal("DocumentView exposes a mutable Lines field")
+	}
+}
+
 func TestDocumentsReturnsDefensiveCopies(t *testing.T) {
 	snapshot := analysis.NewSnapshot([]analysis.Document{
 		{

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -1,0 +1,146 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/envaar/vaar/internal/analysis"
+)
+
+// EngineOptions contains only rule-selection input for one analysis-backed
+// lint execution. Scope, filesystem, output and mutation options belong to
+// application orchestration instead.
+type EngineOptions struct {
+	// OnlyRules keeps only the named rule IDs.
+	OnlyRules []string
+	// SkipRules removes the named rule IDs after selection.
+	SkipRules []string
+}
+
+// Engine executes lint rules against an immutable analysis snapshot.
+type Engine struct {
+	rules []Rule
+}
+
+// NewEngine copies the provided rules so callers can reuse or mutate their
+// input slice without affecting future runs.
+func NewEngine(rules ...Rule) *Engine {
+	copied := make([]Rule, len(rules))
+	copy(copied, rules)
+	return &Engine{rules: copied}
+}
+
+// Run selects and executes rules against snapshot. It performs no filesystem
+// I/O, parsing, mutation, rendering or exit-code mapping.
+func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts EngineOptions) ([]Finding, error) {
+	selected, err := selectRules(e.rules, opts.OnlyRules, opts.SkipRules)
+	if err != nil {
+		return nil, err
+	}
+
+	findings := make([]Finding, 0, 16)
+	ruleContext := Context{Snapshot: snapshot}
+	for _, rule := range selected {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		ruleFindings, err := rule.Run(ruleContext)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", rule.ID(), err)
+		}
+		findings = append(findings, ruleFindings...)
+	}
+
+	sortFindings(findings)
+	return findings, nil
+}
+
+// selectRules applies --only and --skip in declaration order so the selected
+// set stays predictable for completions, tests and report output.
+func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
+	if len(all) == 0 {
+		return nil, nil
+	}
+
+	allowed := make(map[string]Rule, len(all))
+	ordered := make([]Rule, 0, len(all))
+	for _, rule := range all {
+		allowed[rule.ID()] = rule
+		ordered = append(ordered, rule)
+	}
+
+	selectedIDs := make(map[string]struct{}, len(all))
+
+	if len(only) > 0 {
+		for _, id := range only {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				return nil, fmt.Errorf("invalid empty rule ID in --only")
+			}
+			if _, ok := allowed[id]; !ok {
+				return nil, fmt.Errorf("unknown lint rule %q", id)
+			}
+			selectedIDs[id] = struct{}{}
+		}
+	} else {
+		for _, rule := range ordered {
+			selectedIDs[rule.ID()] = struct{}{}
+		}
+	}
+
+	if len(skip) > 0 {
+		for _, id := range skip {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				return nil, fmt.Errorf("invalid empty rule ID in --skip")
+			}
+			if _, ok := allowed[id]; !ok {
+				return nil, fmt.Errorf("unknown lint rule %q", id)
+			}
+			delete(selectedIDs, id)
+		}
+	}
+
+	selected := make([]Rule, 0, len(selectedIDs))
+	for _, rule := range ordered {
+		if _, ok := selectedIDs[rule.ID()]; ok {
+			selected = append(selected, rule)
+		}
+	}
+
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no lint rules selected after applying --only and --skip")
+	}
+
+	return selected, nil
+}
+
+// sortFindings orders output by file, line, severity, rule and message so
+// repeated runs produce the same report.
+func sortFindings(findings []Finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		if left.File != right.File {
+			return left.File < right.File
+		}
+		if left.Line != right.Line {
+			return left.Line < right.Line
+		}
+		if left.Severity.Rank() != right.Severity.Rank() {
+			return left.Severity.Rank() < right.Severity.Rank()
+		}
+		if left.Rule != right.Rule {
+			return left.Rule < right.Rule
+		}
+		return left.Message < right.Message
+	})
+}

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -37,10 +37,18 @@ func NewEngine(rules ...Rule) *Engine {
 	return &Engine{rules: copied}
 }
 
+// SelectRules validates and resolves rule-selection input against the engine's
+// registered rules. The returned slice is independent of the engine's rule
+// collection and is useful to compatibility adapters that need the selected
+// rules for fix planning or other orchestration concerns.
+func (e *Engine) SelectRules(opts EngineOptions) ([]Rule, error) {
+	return selectRules(e.rules, opts.OnlyRules, opts.SkipRules)
+}
+
 // Run selects and executes rules against snapshot. It performs no filesystem
 // I/O, parsing, mutation, rendering or exit-code mapping.
 func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts EngineOptions) ([]Finding, error) {
-	selected, err := selectRules(e.rules, opts.OnlyRules, opts.SkipRules)
+	selected, err := e.SelectRules(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -74,10 +74,6 @@ func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts Engin
 // selectRules applies --only and --skip in declaration order so the selected
 // set stays predictable for completions, tests and report output.
 func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
-	if len(all) == 0 {
-		return nil, nil
-	}
-
 	allowed := make(map[string]Rule, len(all))
 	ordered := make([]Rule, 0, len(all))
 	for _, rule := range all {
@@ -85,18 +81,22 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 		ordered = append(ordered, rule)
 	}
 
+	if err := validateRuleIDs(only, "--only", allowed); err != nil {
+		return nil, err
+	}
+	if err := validateRuleIDs(skip, "--skip", allowed); err != nil {
+		return nil, err
+	}
+
+	if len(all) == 0 {
+		return nil, nil
+	}
+
 	selectedIDs := make(map[string]struct{}, len(all))
 
 	if len(only) > 0 {
 		for _, id := range only {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --only")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			selectedIDs[id] = struct{}{}
+			selectedIDs[strings.TrimSpace(id)] = struct{}{}
 		}
 	} else {
 		for _, rule := range ordered {
@@ -106,14 +106,7 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 
 	if len(skip) > 0 {
 		for _, id := range skip {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --skip")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			delete(selectedIDs, id)
+			delete(selectedIDs, strings.TrimSpace(id))
 		}
 	}
 
@@ -129,6 +122,19 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 	}
 
 	return selected, nil
+}
+
+func validateRuleIDs(ids []string, flag string, allowed map[string]Rule) error {
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return fmt.Errorf("invalid empty rule ID in %s", flag)
+		}
+		if _, ok := allowed[id]; !ok {
+			return fmt.Errorf("unknown lint rule %q", id)
+		}
+	}
+	return nil
 }
 
 // sortFindings orders output by file, line, severity, rule and message so

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -66,6 +66,10 @@ func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts Engin
 // selectRules applies --only and --skip in declaration order so the selected
 // set stays predictable for completions, tests and report output.
 func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
+	if len(all) == 0 {
+		return nil, nil
+	}
+
 	allowed := make(map[string]Rule, len(all))
 	ordered := make([]Rule, 0, len(all))
 	for _, rule := range all {
@@ -73,34 +77,18 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 		ordered = append(ordered, rule)
 	}
 
-	for _, id := range only {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			return nil, fmt.Errorf("invalid empty rule ID in --only")
-		}
-		if _, ok := allowed[id]; !ok {
-			return nil, fmt.Errorf("unknown lint rule %q", id)
-		}
-	}
-	for _, id := range skip {
-		id = strings.TrimSpace(id)
-		if id == "" {
-			return nil, fmt.Errorf("invalid empty rule ID in --skip")
-		}
-		if _, ok := allowed[id]; !ok {
-			return nil, fmt.Errorf("unknown lint rule %q", id)
-		}
-	}
-
-	if len(all) == 0 {
-		return nil, nil
-	}
-
 	selectedIDs := make(map[string]struct{}, len(all))
 
 	if len(only) > 0 {
 		for _, id := range only {
-			selectedIDs[strings.TrimSpace(id)] = struct{}{}
+			id = strings.TrimSpace(id)
+			if id == "" {
+				return nil, fmt.Errorf("invalid empty rule ID in --only")
+			}
+			if _, ok := allowed[id]; !ok {
+				return nil, fmt.Errorf("unknown lint rule %q", id)
+			}
+			selectedIDs[id] = struct{}{}
 		}
 	} else {
 		for _, rule := range ordered {
@@ -110,7 +98,14 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 
 	if len(skip) > 0 {
 		for _, id := range skip {
-			delete(selectedIDs, strings.TrimSpace(id))
+			id = strings.TrimSpace(id)
+			if id == "" {
+				return nil, fmt.Errorf("invalid empty rule ID in --skip")
+			}
+			if _, ok := allowed[id]; !ok {
+				return nil, fmt.Errorf("unknown lint rule %q", id)
+			}
+			delete(selectedIDs, id)
 		}
 	}
 

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -66,10 +66,6 @@ func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts Engin
 // selectRules applies --only and --skip in declaration order so the selected
 // set stays predictable for completions, tests and report output.
 func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
-	if len(all) == 0 {
-		return nil, nil
-	}
-
 	allowed := make(map[string]Rule, len(all))
 	ordered := make([]Rule, 0, len(all))
 	for _, rule := range all {
@@ -77,18 +73,34 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 		ordered = append(ordered, rule)
 	}
 
+	for _, id := range only {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, fmt.Errorf("invalid empty rule ID in --only")
+		}
+		if _, ok := allowed[id]; !ok {
+			return nil, fmt.Errorf("unknown lint rule %q", id)
+		}
+	}
+	for _, id := range skip {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, fmt.Errorf("invalid empty rule ID in --skip")
+		}
+		if _, ok := allowed[id]; !ok {
+			return nil, fmt.Errorf("unknown lint rule %q", id)
+		}
+	}
+
+	if len(all) == 0 {
+		return nil, nil
+	}
+
 	selectedIDs := make(map[string]struct{}, len(all))
 
 	if len(only) > 0 {
 		for _, id := range only {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --only")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			selectedIDs[id] = struct{}{}
+			selectedIDs[strings.TrimSpace(id)] = struct{}{}
 		}
 	} else {
 		for _, rule := range ordered {
@@ -98,14 +110,7 @@ func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
 
 	if len(skip) > 0 {
 		for _, id := range skip {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --skip")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			delete(selectedIDs, id)
+			delete(selectedIDs, strings.TrimSpace(id))
 		}
 	}
 

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -1,0 +1,334 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package lint_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/analysis"
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+)
+
+type engineTestRule struct {
+	id       string
+	calls    *int
+	observed *[]string
+	onRun    func()
+	findings []lint.Finding
+	err      error
+}
+
+func (r engineTestRule) ID() string          { return r.id }
+func (r engineTestRule) Description() string { return "engine test rule" }
+
+func (r engineTestRule) Run(ctx lint.Context) ([]lint.Finding, error) {
+	if r.calls != nil {
+		(*r.calls)++
+	}
+	if r.observed != nil {
+		for _, document := range ctx.Snapshot.Documents() {
+			*r.observed = append(*r.observed, document.DisplayPath)
+		}
+	}
+	if r.onRun != nil {
+		r.onRun()
+	}
+	return r.findings, r.err
+}
+
+func emptyAnalysisSnapshot() analysis.Snapshot {
+	return analysis.NewSnapshot(nil)
+}
+
+func TestEngineRunsRulesAgainstAnalysisSnapshotAndSortsFindings(t *testing.T) {
+	calls := 0
+	var observed []string
+	rule := engineTestRule{
+		id:       "snapshot-rule",
+		calls:    &calls,
+		observed: &observed,
+		findings: []lint.Finding{
+			{Rule: "snapshot-rule", Severity: lint.SeverityWarn, File: "b.env", Line: 4, Message: "later"},
+			{Rule: "snapshot-rule", Severity: lint.SeverityError, File: "a.env", Line: 2, Message: "first"},
+		},
+	}
+	snapshot := analysis.NewSnapshot([]analysis.Document{
+		{DisplayPath: "b.env", Lines: []analysis.Line{{Number: 4, Key: "B"}}},
+		{DisplayPath: "a.env", Lines: []analysis.Line{{Number: 2, Key: "A"}}},
+	})
+
+	findings, err := lint.NewEngine(rule).Run(context.Background(), snapshot, lint.EngineOptions{})
+	if err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("rule calls = %d, want 1", calls)
+	}
+	if want := []string{"b.env", "a.env"}; !reflect.DeepEqual(observed, want) {
+		t.Fatalf("observed documents = %#v, want %#v", observed, want)
+	}
+
+	if got, want := len(findings), 2; got != want {
+		t.Fatalf("finding count = %d, want %d", got, want)
+	}
+	if findings[0].File != "a.env" || findings[1].File != "b.env" {
+		t.Fatalf("findings were not sorted deterministically: %#v", findings)
+	}
+}
+
+func TestEngineRunsBuiltInRulesAgainstInMemoryAnalysis(t *testing.T) {
+	snapshot := analysis.NewSnapshot([]analysis.Document{{
+		DisplayPath:      ".env",
+		BOM:              true,
+		MixedLineEndings: true,
+		EndsWithNewline:  true,
+		Lines: []analysis.Line{
+			{
+				Number:                  1,
+				Key:                     "lower",
+				HasKey:                  true,
+				HasValue:                true,
+				HasAssignment:           true,
+				QuoteState:              analysis.QuoteNone,
+				SpaceBeforeDelimiter:    true,
+				SpaceAfterDelimiter:     true,
+				HasLeadingWhitespace:    true,
+				HasTrailingWhitespace:   true,
+				ValueContainsWhitespace: true,
+			},
+			{
+				Number:         2,
+				Key:            "lower",
+				HasKey:         true,
+				HasAssignment:  true,
+				DelimiterState: analysis.DelimiterEquals,
+			},
+			{
+				Number:         3,
+				Key:            "1BAD",
+				HasKey:         true,
+				HasValue:       true,
+				HasAssignment:  true,
+				DelimiterState: analysis.DelimiterEquals,
+			},
+			{
+				Number:         4,
+				Key:            "COLON",
+				HasKey:         true,
+				HasValue:       true,
+				DelimiterState: analysis.DelimiterColon,
+			},
+			{
+				Number:         5,
+				Key:            "NO_VALUE",
+				HasKey:         true,
+				DelimiterState: analysis.DelimiterMissing,
+			},
+			{
+				Number:         6,
+				HasValue:       true,
+				DelimiterState: analysis.DelimiterEquals,
+			},
+			{
+				Number:     7,
+				QuoteState: analysis.QuoteUnbalanced,
+			},
+			{Number: 8, IsBlank: true},
+			{Number: 9, IsBlank: true},
+		},
+	}})
+
+	findings, err := lint.NewEngine(rules.All()...).Run(
+		context.Background(), snapshot, lint.EngineOptions{},
+	)
+	if err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+
+	gotRules := make(map[string]bool, len(findings))
+	for _, finding := range findings {
+		gotRules[finding.Rule] = true
+		if finding.File != ".env" {
+			t.Fatalf("finding file = %q, want .env", finding.File)
+		}
+	}
+
+	wantRules := []string{
+		"bom-character",
+		"constant-case",
+		"duplicate-key",
+		"ending-blank-line",
+		"extra-blank-line",
+		"incorrect-delimiter",
+		"invalid-key-name",
+		"key-without-value",
+		"leading-character",
+		"line-ending",
+		"quote-character",
+		"space-character",
+		"trailing-whitespace",
+		"value-without-key",
+		"value-without-quotes",
+	}
+	for _, ruleID := range wantRules {
+		if !gotRules[ruleID] {
+			t.Errorf("missing finding from built-in rule %q: %#v", ruleID, findings)
+		}
+	}
+}
+
+func TestEngineSelectionPreservesOnlyAndSkipSemantics(t *testing.T) {
+	cases := []struct {
+		name        string
+		only        []string
+		skip        []string
+		wantCalls   map[string]int
+		wantErrPart string
+	}{
+		{
+			name:      "default selects all in declaration order",
+			wantCalls: map[string]int{"first": 1, "second": 1},
+		},
+		{
+			name:      "only selects named rules",
+			only:      []string{"second"},
+			wantCalls: map[string]int{"first": 0, "second": 1},
+		},
+		{
+			name:      "skip removes named rules",
+			skip:      []string{"first"},
+			wantCalls: map[string]int{"first": 0, "second": 1},
+		},
+		{
+			name:        "only and skip can leave no rules",
+			only:        []string{"first"},
+			skip:        []string{"first"},
+			wantCalls:   map[string]int{"first": 0, "second": 0},
+			wantErrPart: "no lint rules selected after applying --only and --skip",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			firstCalls, secondCalls := 0, 0
+			engine := lint.NewEngine(
+				engineTestRule{id: "first", calls: &firstCalls},
+				engineTestRule{id: "second", calls: &secondCalls},
+			)
+
+			findings, err := engine.Run(context.Background(), emptyAnalysisSnapshot(), lint.EngineOptions{
+				OnlyRules: tc.only,
+				SkipRules: tc.skip,
+			})
+			if tc.wantErrPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrPart) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErrPart)
+				}
+				if findings != nil {
+					t.Fatalf("findings = %#v, want nil on selection error", findings)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("engine run failed: %v", err)
+			}
+			if findings == nil {
+				t.Fatal("clean engine run returned nil findings")
+			}
+			if got, want := firstCalls, tc.wantCalls["first"]; got != want {
+				t.Fatalf("first calls = %d, want %d", got, want)
+			}
+			if got, want := secondCalls, tc.wantCalls["second"]; got != want {
+				t.Fatalf("second calls = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestEngineRejectsUnknownAndEmptyRuleIDs(t *testing.T) {
+	engine := lint.NewEngine(engineTestRule{id: "known"})
+	cases := []struct {
+		name string
+		only []string
+		skip []string
+		want string
+	}{
+		{name: "unknown only", only: []string{"missing"}, want: `unknown lint rule "missing"`},
+		{name: "unknown skip", skip: []string{"missing"}, want: `unknown lint rule "missing"`},
+		{name: "empty only", only: []string{""}, want: "invalid empty rule ID in --only"},
+		{name: "empty skip", skip: []string{""}, want: "invalid empty rule ID in --skip"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := engine.Run(context.Background(), emptyAnalysisSnapshot(), lint.EngineOptions{
+				OnlyRules: tc.only,
+				SkipRules: tc.skip,
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestEngineChecksCancellationBetweenRules(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	secondCalls := 0
+	engine := lint.NewEngine(
+		engineTestRule{id: "first", onRun: cancel},
+		engineTestRule{id: "second", calls: &secondCalls},
+	)
+
+	_, err := engine.Run(ctx, emptyAnalysisSnapshot(), lint.EngineOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if secondCalls != 0 {
+		t.Fatalf("second rule calls = %d, want 0 after cancellation", secondCalls)
+	}
+}
+
+func TestEngineWrapsRuleErrorsWithRuleID(t *testing.T) {
+	sentinel := errors.New("sentinel rule failure")
+	_, err := lint.NewEngine(engineTestRule{id: "broken-rule", err: sentinel}).Run(
+		context.Background(),
+		emptyAnalysisSnapshot(),
+		lint.EngineOptions{},
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error = %v, want wrapped sentinel", err)
+	}
+	if !strings.Contains(err.Error(), "broken-rule: sentinel rule failure") {
+		t.Fatalf("error = %v, want rule ID and message", err)
+	}
+}
+
+func TestRuleContextExposesOnlyAnalysisSnapshot(t *testing.T) {
+	typ := reflect.TypeOf(lint.Context{})
+	snapshotType := reflect.TypeOf(analysis.Snapshot{})
+	if typ.NumField() != 1 {
+		t.Fatalf("lint.Context has %d fields, want exactly one", typ.NumField())
+	}
+	field := typ.Field(0)
+	if field.Name != "Snapshot" || field.Type != snapshotType {
+		t.Fatalf("lint.Context field = %s %s, want Snapshot %s", field.Name, field.Type, snapshotType)
+	}
+
+	forbidden := []string{"Root", "Files", "Options", "Target", "TargetDir", "Fix", "Output"}
+	for _, name := range forbidden {
+		if _, ok := typ.FieldByName(name); ok {
+			t.Fatalf("lint.Context exposes forbidden field %q", name)
+		}
+	}
+}

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -253,6 +253,48 @@ func TestEngineSelectionPreservesOnlyAndSkipSemantics(t *testing.T) {
 	}
 }
 
+func TestEngineValidatesSelectionWithNoRegisteredRules(t *testing.T) {
+	cases := []struct {
+		name        string
+		only        []string
+		skip        []string
+		wantErrPart string
+	}{
+		{name: "valid empty selection"},
+		{name: "unknown only", only: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
+		{name: "unknown skip", skip: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
+		{name: "empty only", only: []string{""}, wantErrPart: "invalid empty rule ID in --only"},
+		{name: "empty skip", skip: []string{""}, wantErrPart: "invalid empty rule ID in --skip"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, err := lint.NewEngine().Run(context.Background(), emptyAnalysisSnapshot(), lint.EngineOptions{
+				OnlyRules: tc.only,
+				SkipRules: tc.skip,
+			})
+			if tc.wantErrPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrPart) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErrPart)
+				}
+				if findings != nil {
+					t.Fatalf("findings = %#v, want nil on selection error", findings)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("engine run failed: %v", err)
+			}
+			if findings == nil {
+				t.Fatal("valid empty engine run returned nil findings")
+			}
+			if len(findings) != 0 {
+				t.Fatalf("findings = %#v, want empty", findings)
+			}
+		})
+	}
+}
+
 func TestEngineRejectsUnknownAndEmptyRuleIDs(t *testing.T) {
 	engine := lint.NewEngine(engineTestRule{id: "known"})
 	cases := []struct {

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -253,18 +253,17 @@ func TestEngineSelectionPreservesOnlyAndSkipSemantics(t *testing.T) {
 	}
 }
 
-func TestEngineValidatesSelectionWithNoRegisteredRules(t *testing.T) {
+func TestEnginePreservesEmptyRuleSetSelectionBehavior(t *testing.T) {
 	cases := []struct {
-		name        string
-		only        []string
-		skip        []string
-		wantErrPart string
+		name string
+		only []string
+		skip []string
 	}{
 		{name: "valid empty selection"},
-		{name: "unknown only", only: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
-		{name: "unknown skip", skip: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
-		{name: "empty only", only: []string{""}, wantErrPart: "invalid empty rule ID in --only"},
-		{name: "empty skip", skip: []string{""}, wantErrPart: "invalid empty rule ID in --skip"},
+		{name: "unknown only", only: []string{"missing"}},
+		{name: "unknown skip", skip: []string{"missing"}},
+		{name: "empty only", only: []string{""}},
+		{name: "empty skip", skip: []string{""}},
 	}
 
 	for _, tc := range cases {
@@ -273,15 +272,6 @@ func TestEngineValidatesSelectionWithNoRegisteredRules(t *testing.T) {
 				OnlyRules: tc.only,
 				SkipRules: tc.skip,
 			})
-			if tc.wantErrPart != "" {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErrPart) {
-					t.Fatalf("error = %v, want substring %q", err, tc.wantErrPart)
-				}
-				if findings != nil {
-					t.Fatalf("findings = %#v, want nil on selection error", findings)
-				}
-				return
-			}
 			if err != nil {
 				t.Fatalf("engine run failed: %v", err)
 			}

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -253,6 +253,24 @@ func TestEngineSelectionPreservesOnlyAndSkipSemantics(t *testing.T) {
 	}
 }
 
+func TestEngineExposesSelectedRulesForCompatibilityAdapters(t *testing.T) {
+	first := engineTestRule{id: "first"}
+	second := engineTestRule{id: "second"}
+
+	selected, err := lint.NewEngine(first, second).SelectRules(lint.EngineOptions{
+		OnlyRules: []string{"second"},
+	})
+	if err != nil {
+		t.Fatalf("select rules failed: %v", err)
+	}
+	if len(selected) != 1 {
+		t.Fatalf("selected rules = %#v, want one rule", selected)
+	}
+	if selected[0].ID() != "second" {
+		t.Fatalf("selected rule = %q, want second", selected[0].ID())
+	}
+}
+
 func TestEnginePreservesEmptyRuleSetSelectionBehavior(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -271,17 +271,18 @@ func TestEngineExposesSelectedRulesForCompatibilityAdapters(t *testing.T) {
 	}
 }
 
-func TestEnginePreservesEmptyRuleSetSelectionBehavior(t *testing.T) {
+func TestEngineValidatesSelectionWithNoRegisteredRules(t *testing.T) {
 	cases := []struct {
-		name string
-		only []string
-		skip []string
+		name        string
+		only        []string
+		skip        []string
+		wantErrPart string
 	}{
 		{name: "valid empty selection"},
-		{name: "unknown only", only: []string{"missing"}},
-		{name: "unknown skip", skip: []string{"missing"}},
-		{name: "empty only", only: []string{""}},
-		{name: "empty skip", skip: []string{""}},
+		{name: "unknown only", only: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
+		{name: "unknown skip", skip: []string{"missing"}, wantErrPart: `unknown lint rule "missing"`},
+		{name: "empty only", only: []string{""}, wantErrPart: "invalid empty rule ID in --only"},
+		{name: "empty skip", skip: []string{""}, wantErrPart: "invalid empty rule ID in --skip"},
 	}
 
 	for _, tc := range cases {
@@ -290,6 +291,15 @@ func TestEnginePreservesEmptyRuleSetSelectionBehavior(t *testing.T) {
 				OnlyRules: tc.only,
 				SkipRules: tc.skip,
 			})
+			if tc.wantErrPart != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErrPart) {
+					t.Fatalf("error = %v, want substring %q", err, tc.wantErrPart)
+				}
+				if findings != nil {
+					t.Fatalf("findings = %#v, want nil on selection error", findings)
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("engine run failed: %v", err)
 			}

--- a/internal/lint/rule.go
+++ b/internal/lint/rule.go
@@ -3,11 +3,15 @@ Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package lint discovers dotenv files, runs rule sets and returns findings in
-// a stable order for humans and automation.
+// Package lint runs analysis-backed dotenv rules and returns findings in a
+// stable order for humans and automation. The legacy Runner remains a
+// temporary orchestration adapter while callers migrate to the layered path.
 package lint
 
-import "github.com/envaar/vaar/internal/envfile"
+import (
+	"github.com/envaar/vaar/internal/analysis"
+	"github.com/envaar/vaar/internal/envfile"
+)
 
 // Options control one lint run without tying callers to Cobra flags. The CLI
 // maps its flags into this struct before handing work to the runner.
@@ -26,19 +30,17 @@ type Options struct {
 	Fix bool
 }
 
-// Context gives each rule read-only access to the repository snapshot and the
-// selected command-line options.
+// Context gives each rule read-only access to the immutable analysis snapshot.
+// Scope, filesystem, command-line and mutation concerns are intentionally not
+// part of the rule-facing context.
 type Context struct {
-	// Root is the absolute repository root for the current run.
-	Root string
-	// Files is the parsed file set the runner loaded for this run.
-	Files []envfile.File
-	// Options holds the resolved lint settings.
-	Options Options
+	// Snapshot contains the ordered, value-free documents being linted.
+	Snapshot analysis.Snapshot
 }
 
 // Rule describes one lint check that can evaluate the current Context without
-// mutating shared state.
+// mutating shared state. FixableRule remains a separate byte-transform
+// contract for the temporary compatibility runner.
 type Rule interface {
 	ID() string
 	Description() string

--- a/internal/lint/rules/deterministic/bom_character.go
+++ b/internal/lint/rules/deterministic/bom_character.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 )
@@ -26,14 +27,18 @@ func (bomCharacterRule) Fix(data []byte) []byte { return envfile.StripBOM(data) 
 
 func (bomCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
 		if !document.BOM {
-			continue
+			return
 		}
 		lineNumber := 1
-		if len(document.Lines) > 0 {
-			lineNumber = document.Lines[0].Number
-		}
+		hasLine := false
+		document.RangeLines(func(line analysis.Line) {
+			if !hasLine {
+				lineNumber = line.Number
+				hasLine = true
+			}
+		})
 		findings = append(findings, finding(
 			bomCharacterRule{}.ID(),
 			lint.SeverityWarn,
@@ -41,6 +46,6 @@ func (bomCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 			lineNumber,
 			"file starts with a UTF-8 BOM",
 		))
-	}
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/bom_character.go
+++ b/internal/lint/rules/deterministic/bom_character.go
@@ -26,18 +26,18 @@ func (bomCharacterRule) Fix(data []byte) []byte { return envfile.StripBOM(data) 
 
 func (bomCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		if !file.BOM {
+	for _, document := range ctx.Snapshot.Documents() {
+		if !document.BOM {
 			continue
 		}
 		lineNumber := 1
-		if len(file.Lines) > 0 {
-			lineNumber = file.Lines[0].Number
+		if len(document.Lines) > 0 {
+			lineNumber = document.Lines[0].Number
 		}
 		findings = append(findings, finding(
 			bomCharacterRule{}.ID(),
 			lint.SeverityWarn,
-			file.Path,
+			document.DisplayPath,
 			lineNumber,
 			"file starts with a UTF-8 BOM",
 		))

--- a/internal/lint/rules/deterministic/constant_case.go
+++ b/internal/lint/rules/deterministic/constant_case.go
@@ -25,8 +25,8 @@ func (constantCaseRule) Description() string {
 
 func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			// Structurally invalid keys belong to invalid-key-name; this
 			// rule only reports otherwise-valid keys whose sole deviation
 			// is lowercase letters.
@@ -40,7 +40,7 @@ func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 			findings = append(findings, finding(
 				constantCaseRule{}.ID(),
 				lint.SeverityWarn,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				fmt.Sprintf("%s should use CONSTANT_CASE: %s", line.Key, upper),
 			))

--- a/internal/lint/rules/deterministic/constant_case.go
+++ b/internal/lint/rules/deterministic/constant_case.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -25,17 +26,17 @@ func (constantCaseRule) Description() string {
 
 func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			// Structurally invalid keys belong to invalid-key-name; this
 			// rule only reports otherwise-valid keys whose sole deviation
 			// is lowercase letters.
 			if !line.HasKey || !validKeyName(line.Key) {
-				continue
+				return
 			}
 			upper := constantCaseKey(line.Key)
 			if upper == line.Key {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				constantCaseRule{}.ID(),
@@ -44,8 +45,8 @@ func (constantCaseRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				fmt.Sprintf("%s should use CONSTANT_CASE: %s", line.Key, upper),
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }
 

--- a/internal/lint/rules/deterministic/duplicate_key.go
+++ b/internal/lint/rules/deterministic/duplicate_key.go
@@ -25,11 +25,11 @@ func (duplicateKeyRule) Description() string {
 
 func (duplicateKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		seen := make(map[string]int, len(document.Lines))
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		seen := make(map[string]int)
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasKey || line.DelimiterState == analysis.DelimiterMissing {
-				continue
+				return
 			}
 			if _, ok := seen[line.Key]; ok {
 				findings = append(findings, finding(
@@ -39,10 +39,10 @@ func (duplicateKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 					line.Number,
 					fmt.Sprintf("%s is defined more than once", line.Key),
 				))
-				continue
+				return
 			}
 			seen[line.Key] = line.Number
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/duplicate_key.go
+++ b/internal/lint/rules/deterministic/duplicate_key.go
@@ -8,7 +8,7 @@ package deterministic
 import (
 	"fmt"
 
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -25,17 +25,17 @@ func (duplicateKeyRule) Description() string {
 
 func (duplicateKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		seen := make(map[string]int, len(file.Lines))
-		for _, line := range file.Lines {
-			if !line.HasKey || line.DelimiterState == envfile.DelimiterMissing {
+	for _, document := range ctx.Snapshot.Documents() {
+		seen := make(map[string]int, len(document.Lines))
+		for _, line := range document.Lines {
+			if !line.HasKey || line.DelimiterState == analysis.DelimiterMissing {
 				continue
 			}
 			if _, ok := seen[line.Key]; ok {
 				findings = append(findings, finding(
 					duplicateKeyRule{}.ID(),
 					lint.SeverityError,
-					file.Path,
+					document.DisplayPath,
 					line.Number,
 					fmt.Sprintf("%s is defined more than once", line.Key),
 				))

--- a/internal/lint/rules/deterministic/ending_blank_line.go
+++ b/internal/lint/rules/deterministic/ending_blank_line.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 )
@@ -26,12 +27,16 @@ func (endingBlankLineRule) Fix(data []byte) []byte { return envfile.TrimFinalBla
 
 func (endingBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		if len(document.Lines) == 0 {
-			continue
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		var last analysis.Line
+		hasLine := false
+		document.RangeLines(func(line analysis.Line) {
+			last = line
+			hasLine = true
+		})
+		if !hasLine {
+			return
 		}
-
-		last := document.Lines[len(document.Lines)-1]
 		if !document.EndsWithNewline || last.IsBlank {
 			findings = append(findings, finding(
 				endingBlankLineRule{}.ID(),
@@ -41,6 +46,6 @@ func (endingBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				"file must end with exactly one final newline",
 			))
 		}
-	}
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/ending_blank_line.go
+++ b/internal/lint/rules/deterministic/ending_blank_line.go
@@ -26,17 +26,17 @@ func (endingBlankLineRule) Fix(data []byte) []byte { return envfile.TrimFinalBla
 
 func (endingBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		if len(file.Lines) == 0 {
+	for _, document := range ctx.Snapshot.Documents() {
+		if len(document.Lines) == 0 {
 			continue
 		}
 
-		last := file.Lines[len(file.Lines)-1]
-		if !file.EndsWithNewline || last.IsBlank {
+		last := document.Lines[len(document.Lines)-1]
+		if !document.EndsWithNewline || last.IsBlank {
 			findings = append(findings, finding(
 				endingBlankLineRule{}.ID(),
 				lint.SeverityWarn,
-				file.Path,
+				document.DisplayPath,
 				last.Number,
 				"file must end with exactly one final newline",
 			))

--- a/internal/lint/rules/deterministic/extra_blank_line.go
+++ b/internal/lint/rules/deterministic/extra_blank_line.go
@@ -24,16 +24,16 @@ func (extraBlankLineRule) Fix(data []byte) []byte { return envfile.CollapseBlank
 
 func (extraBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
+	for _, document := range ctx.Snapshot.Documents() {
 		run := 0
-		for _, line := range file.Lines {
+		for _, line := range document.Lines {
 			if line.IsBlank {
 				run++
 				if run > 1 {
 					findings = append(findings, finding(
 						extraBlankLineRule{}.ID(),
 						lint.SeverityWarn,
-						file.Path,
+						document.DisplayPath,
 						line.Number,
 						"repeated blank line",
 					))

--- a/internal/lint/rules/deterministic/extra_blank_line.go
+++ b/internal/lint/rules/deterministic/extra_blank_line.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 )
@@ -24,9 +25,9 @@ func (extraBlankLineRule) Fix(data []byte) []byte { return envfile.CollapseBlank
 
 func (extraBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
 		run := 0
-		for _, line := range document.Lines {
+		document.RangeLines(func(line analysis.Line) {
 			if line.IsBlank {
 				run++
 				if run > 1 {
@@ -38,10 +39,10 @@ func (extraBlankLineRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 						"repeated blank line",
 					))
 				}
-				continue
+				return
 			}
 			run = 0
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/incorrect_delimiter.go
+++ b/internal/lint/rules/deterministic/incorrect_delimiter.go
@@ -25,10 +25,10 @@ func (incorrectDelimiterRule) Description() string {
 
 func (incorrectDelimiterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasKey || line.DelimiterState != analysis.DelimiterColon {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				incorrectDelimiterRule{}.ID(),
@@ -37,7 +37,7 @@ func (incorrectDelimiterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				fmt.Sprintf("%s uses ':' instead of '='", line.Key),
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/incorrect_delimiter.go
+++ b/internal/lint/rules/deterministic/incorrect_delimiter.go
@@ -8,7 +8,7 @@ package deterministic
 import (
 	"fmt"
 
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -25,15 +25,15 @@ func (incorrectDelimiterRule) Description() string {
 
 func (incorrectDelimiterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
-			if !line.HasKey || line.DelimiterState != envfile.DelimiterColon {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
+			if !line.HasKey || line.DelimiterState != analysis.DelimiterColon {
 				continue
 			}
 			findings = append(findings, finding(
 				incorrectDelimiterRule{}.ID(),
 				lint.SeverityError,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				fmt.Sprintf("%s uses ':' instead of '='", line.Key),
 			))

--- a/internal/lint/rules/deterministic/invalid_key_name.go
+++ b/internal/lint/rules/deterministic/invalid_key_name.go
@@ -8,6 +8,7 @@ package deterministic
 import (
 	"fmt"
 
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -24,10 +25,10 @@ func (invalidKeyNameRule) Description() string {
 
 func (invalidKeyNameRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasKey || validKeyName(line.Key) {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				invalidKeyNameRule{}.ID(),
@@ -36,7 +37,7 @@ func (invalidKeyNameRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				fmt.Sprintf("%s is not a portable env key name", line.Key),
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/invalid_key_name.go
+++ b/internal/lint/rules/deterministic/invalid_key_name.go
@@ -24,15 +24,15 @@ func (invalidKeyNameRule) Description() string {
 
 func (invalidKeyNameRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			if !line.HasKey || validKeyName(line.Key) {
 				continue
 			}
 			findings = append(findings, finding(
 				invalidKeyNameRule{}.ID(),
 				lint.SeverityError,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				fmt.Sprintf("%s is not a portable env key name", line.Key),
 			))

--- a/internal/lint/rules/deterministic/key_without_value.go
+++ b/internal/lint/rules/deterministic/key_without_value.go
@@ -8,7 +8,7 @@ package deterministic
 import (
 	"fmt"
 
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -25,17 +25,17 @@ func (keyWithoutValueRule) Description() string {
 
 func (keyWithoutValueRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			if !line.HasKey {
 				continue
 			}
-			if line.DelimiterState == envfile.DelimiterMissing || (line.DelimiterState == envfile.DelimiterEquals && !line.HasValue) {
+			if line.DelimiterState == analysis.DelimiterMissing || (line.DelimiterState == analysis.DelimiterEquals && !line.HasValue) {
 				message := fmt.Sprintf("%s is missing a value", line.Key)
 				findings = append(findings, finding(
 					keyWithoutValueRule{}.ID(),
 					lint.SeverityError,
-					file.Path,
+					document.DisplayPath,
 					line.Number,
 					message,
 				))

--- a/internal/lint/rules/deterministic/key_without_value.go
+++ b/internal/lint/rules/deterministic/key_without_value.go
@@ -25,10 +25,10 @@ func (keyWithoutValueRule) Description() string {
 
 func (keyWithoutValueRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasKey {
-				continue
+				return
 			}
 			if line.DelimiterState == analysis.DelimiterMissing || (line.DelimiterState == analysis.DelimiterEquals && !line.HasValue) {
 				message := fmt.Sprintf("%s is missing a value", line.Key)
@@ -40,7 +40,7 @@ func (keyWithoutValueRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 					message,
 				))
 			}
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/leading_character.go
+++ b/internal/lint/rules/deterministic/leading_character.go
@@ -18,15 +18,15 @@ func (leadingCharacterRule) Description() string { return "warns when a line sta
 
 func (leadingCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
-			if line.IsBlank || line.IsComment || line.LeadingWhitespace == "" {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
+			if line.IsBlank || line.IsComment || !line.HasLeadingWhitespace {
 				continue
 			}
 			findings = append(findings, finding(
 				leadingCharacterRule{}.ID(),
 				lint.SeverityWarn,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				"line starts with leading whitespace",
 			))

--- a/internal/lint/rules/deterministic/leading_character.go
+++ b/internal/lint/rules/deterministic/leading_character.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/analysis"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type leadingCharacterRule struct{}
 
@@ -18,10 +21,10 @@ func (leadingCharacterRule) Description() string { return "warns when a line sta
 
 func (leadingCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if line.IsBlank || line.IsComment || !line.HasLeadingWhitespace {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				leadingCharacterRule{}.ID(),
@@ -30,7 +33,7 @@ func (leadingCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				"line starts with leading whitespace",
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/line_ending.go
+++ b/internal/lint/rules/deterministic/line_ending.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 )
@@ -33,14 +34,18 @@ func (lineEndingRule) Fix(data []byte) []byte {
 
 func (lineEndingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
 		if !document.MixedLineEndings {
-			continue
+			return
 		}
 		lineNumber := 1
-		if len(document.Lines) > 0 {
-			lineNumber = document.Lines[0].Number
-		}
+		hasLine := false
+		document.RangeLines(func(line analysis.Line) {
+			if !hasLine {
+				lineNumber = line.Number
+				hasLine = true
+			}
+		})
 		findings = append(findings, finding(
 			lineEndingRule{}.ID(),
 			lint.SeverityWarn,
@@ -48,6 +53,6 @@ func (lineEndingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 			lineNumber,
 			"file uses mixed CRLF and LF line endings",
 		))
-	}
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/line_ending.go
+++ b/internal/lint/rules/deterministic/line_ending.go
@@ -33,18 +33,18 @@ func (lineEndingRule) Fix(data []byte) []byte {
 
 func (lineEndingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		if !file.MixedLineEndings {
+	for _, document := range ctx.Snapshot.Documents() {
+		if !document.MixedLineEndings {
 			continue
 		}
 		lineNumber := 1
-		if len(file.Lines) > 0 {
-			lineNumber = file.Lines[0].Number
+		if len(document.Lines) > 0 {
+			lineNumber = document.Lines[0].Number
 		}
 		findings = append(findings, finding(
 			lineEndingRule{}.ID(),
 			lint.SeverityWarn,
-			file.Path,
+			document.DisplayPath,
 			lineNumber,
 			"file uses mixed CRLF and LF line endings",
 		))

--- a/internal/lint/rules/deterministic/quote_character.go
+++ b/internal/lint/rules/deterministic/quote_character.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -23,15 +23,15 @@ func (quoteCharacterRule) Description() string {
 
 func (quoteCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
-			if line.QuoteState != envfile.QuoteUnbalanced {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
+			if line.QuoteState != analysis.QuoteUnbalanced {
 				continue
 			}
 			findings = append(findings, finding(
 				quoteCharacterRule{}.ID(),
 				lint.SeverityError,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				"value has unbalanced quotes",
 			))

--- a/internal/lint/rules/deterministic/quote_character.go
+++ b/internal/lint/rules/deterministic/quote_character.go
@@ -23,10 +23,10 @@ func (quoteCharacterRule) Description() string {
 
 func (quoteCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if line.QuoteState != analysis.QuoteUnbalanced {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				quoteCharacterRule{}.ID(),
@@ -35,7 +35,7 @@ func (quoteCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				"value has unbalanced quotes",
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/space_character.go
+++ b/internal/lint/rules/deterministic/space_character.go
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 
 package deterministic
 
-import "github.com/envaar/vaar/internal/lint"
+import (
+	"github.com/envaar/vaar/internal/analysis"
+	"github.com/envaar/vaar/internal/lint"
+)
 
 type spaceCharacterRule struct{}
 
@@ -20,13 +23,13 @@ func (spaceCharacterRule) Description() string {
 
 func (spaceCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if line.IsBlank || line.IsComment {
-				continue
+				return
 			}
 			if !line.SpaceBeforeDelimiter && !line.SpaceAfterDelimiter {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				spaceCharacterRule{}.ID(),
@@ -35,7 +38,7 @@ func (spaceCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				"line has spaces around the key, delimiter or value",
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/space_character.go
+++ b/internal/lint/rules/deterministic/space_character.go
@@ -20,8 +20,8 @@ func (spaceCharacterRule) Description() string {
 
 func (spaceCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			if line.IsBlank || line.IsComment {
 				continue
 			}
@@ -31,7 +31,7 @@ func (spaceCharacterRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 			findings = append(findings, finding(
 				spaceCharacterRule{}.ID(),
 				lint.SeverityWarn,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				"line has spaces around the key, delimiter or value",
 			))

--- a/internal/lint/rules/deterministic/test_helpers_test.go
+++ b/internal/lint/rules/deterministic/test_helpers_test.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
 )
 
 type ruleTestCase struct {
@@ -32,7 +35,16 @@ func runRuleTest(t *testing.T, tc ruleTestCase) {
 		t.Fatalf("parse failed: %v", err)
 	}
 
-	findings, err := tc.rule.Run(lint.Context{Files: []envfile.File{file}})
+	snapshotDocument := analysisdotenv.FromDocument(analysisdotenv.DocumentInput{
+		ID: analysis.DocumentID("test.env"),
+		Source: sourcedotenv.Document{
+			File:       file,
+			SourcePath: "test.env",
+		},
+	})
+	findings, err := tc.rule.Run(lint.Context{
+		Snapshot: analysis.NewSnapshot([]analysis.Document{snapshotDocument}),
+	})
 	if err != nil {
 		t.Fatalf("rule run failed: %v", err)
 	}

--- a/internal/lint/rules/deterministic/trailing_whitespace.go
+++ b/internal/lint/rules/deterministic/trailing_whitespace.go
@@ -24,15 +24,15 @@ func (trailingWhitespaceRule) Fix(data []byte) []byte { return envfile.TrimTrail
 
 func (trailingWhitespaceRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
-			if line.TrailingWhitespace == "" {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
+			if !line.HasTrailingWhitespace {
 				continue
 			}
 			findings = append(findings, finding(
 				trailingWhitespaceRule{}.ID(),
 				lint.SeverityWarn,
-				file.Path,
+				document.DisplayPath,
 				line.Number,
 				"line has trailing whitespace",
 			))

--- a/internal/lint/rules/deterministic/trailing_whitespace.go
+++ b/internal/lint/rules/deterministic/trailing_whitespace.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 )
@@ -24,10 +25,10 @@ func (trailingWhitespaceRule) Fix(data []byte) []byte { return envfile.TrimTrail
 
 func (trailingWhitespaceRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasTrailingWhitespace {
-				continue
+				return
 			}
 			findings = append(findings, finding(
 				trailingWhitespaceRule{}.ID(),
@@ -36,7 +37,7 @@ func (trailingWhitespaceRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 				line.Number,
 				"line has trailing whitespace",
 			))
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/value_without_key.go
+++ b/internal/lint/rules/deterministic/value_without_key.go
@@ -23,10 +23,10 @@ func (valueWithoutKeyRule) Description() string {
 
 func (valueWithoutKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if line.HasKey || line.IsBlank || line.IsComment {
-				continue
+				return
 			}
 			if line.DelimiterState == analysis.DelimiterEquals || line.DelimiterState == analysis.DelimiterColon || line.HasValue {
 				findings = append(findings, finding(
@@ -37,7 +37,7 @@ func (valueWithoutKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 					"value appears without a valid key",
 				))
 			}
-		}
-	}
+		})
+	})
 	return findings, nil
 }

--- a/internal/lint/rules/deterministic/value_without_key.go
+++ b/internal/lint/rules/deterministic/value_without_key.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -23,16 +23,16 @@ func (valueWithoutKeyRule) Description() string {
 
 func (valueWithoutKeyRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			if line.HasKey || line.IsBlank || line.IsComment {
 				continue
 			}
-			if line.DelimiterState == envfile.DelimiterEquals || line.DelimiterState == envfile.DelimiterColon || line.Value != "" {
+			if line.DelimiterState == analysis.DelimiterEquals || line.DelimiterState == analysis.DelimiterColon || line.HasValue {
 				findings = append(findings, finding(
 					valueWithoutKeyRule{}.ID(),
 					lint.SeverityError,
-					file.Path,
+					document.DisplayPath,
 					line.Number,
 					"value appears without a valid key",
 				))

--- a/internal/lint/rules/deterministic/value_without_quotes.go
+++ b/internal/lint/rules/deterministic/value_without_quotes.go
@@ -6,9 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package deterministic
 
 import (
-	"strings"
-
-	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/lint"
 )
 
@@ -27,26 +25,21 @@ func (valueWithoutQuotesRule) Description() string {
 func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
 
-	for _, file := range ctx.Files {
-		for _, line := range file.Lines {
+	for _, document := range ctx.Snapshot.Documents() {
+		for _, line := range document.Lines {
 			if !line.HasAssignment || !line.HasValue {
 				continue
 			}
 
-			if line.Value == "" {
+			if line.QuoteState != analysis.QuoteNone {
 				continue
 			}
 
-			if line.QuoteState != envfile.QuoteNone {
-				continue
-			}
-
-			if strings.ContainsRune(line.Value, ' ') ||
-				strings.ContainsRune(line.Value, '\t') {
+			if line.ValueContainsWhitespace {
 				findings = append(findings, finding(
 					valueWithoutQuotesRule{}.ID(),
 					lint.SeverityError,
-					file.Path,
+					document.DisplayPath,
 					line.Number,
 					"value containing whitespace should be enclosed in quotes",
 				))

--- a/internal/lint/rules/deterministic/value_without_quotes.go
+++ b/internal/lint/rules/deterministic/value_without_quotes.go
@@ -25,14 +25,14 @@ func (valueWithoutQuotesRule) Description() string {
 func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 	findings := make([]lint.Finding, 0)
 
-	for _, document := range ctx.Snapshot.Documents() {
-		for _, line := range document.Lines {
+	ctx.Snapshot.RangeDocuments(func(document analysis.DocumentView) {
+		document.RangeLines(func(line analysis.Line) {
 			if !line.HasAssignment || !line.HasValue {
-				continue
+				return
 			}
 
 			if line.QuoteState != analysis.QuoteNone {
-				continue
+				return
 			}
 
 			if line.ValueContainsWhitespace {
@@ -44,8 +44,8 @@ func (valueWithoutQuotesRule) Run(ctx lint.Context) ([]lint.Finding, error) {
 					"value containing whitespace should be enclosed in quotes",
 				))
 			}
-		}
-	}
+		})
+	})
 
 	return findings, nil
 }

--- a/internal/lint/rules/fixability_test.go
+++ b/internal/lint/rules/fixability_test.go
@@ -23,9 +23,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/lint"
 	"github.com/envaar/vaar/internal/lint/rules"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
 )
 
 // expectedFixable is the empirical set of rules the --fix pass repairs. The
@@ -78,7 +81,16 @@ func hasFinding(t *testing.T, rule lint.Rule, data []byte) bool {
 	if err != nil {
 		t.Fatalf("parse failed: %v", err)
 	}
-	findings, err := rule.Run(lint.Context{Files: []envfile.File{file}})
+	snapshotDocument := analysisdotenv.FromDocument(analysisdotenv.DocumentInput{
+		ID: analysis.DocumentID("drift.env"),
+		Source: sourcedotenv.Document{
+			File:       file,
+			SourcePath: "drift.env",
+		},
+	})
+	findings, err := rule.Run(lint.Context{
+		Snapshot: analysis.NewSnapshot([]analysis.Document{snapshotDocument}),
+	})
 	if err != nil {
 		t.Fatalf("rule run failed: %v", err)
 	}

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -20,21 +20,29 @@ import (
 // Runner executes a rule set over discovered dotenv files and keeps the
 // resulting report deterministic.
 type Runner struct {
-	rules []Rule
+	engine *Engine
 }
 
 // NewRunner copies the provided rules so callers can reuse or mutate their
 // input slice without affecting future runs.
 func NewRunner(rules ...Rule) *Runner {
-	copied := make([]Rule, len(rules))
-	copy(copied, rules)
-	return &Runner{rules: copied}
+	return &Runner{engine: NewEngine(rules...)}
+}
+
+func (r *Runner) ruleEngine() *Engine {
+	if r.engine != nil {
+		return r.engine
+	}
+	return NewEngine()
 }
 
 // ValidateRuleSelection checks the requested only/skip rule IDs against the
 // available rule set and returns the same validation errors that Run would.
 func ValidateRuleSelection(all []Rule, only, skip []string) error {
-	_, err := selectRules(all, only, skip)
+	_, err := NewEngine(all...).SelectRules(EngineOptions{
+		OnlyRules: only,
+		SkipRules: skip,
+	})
 	return err
 }
 
@@ -43,8 +51,12 @@ func ValidateRuleSelection(all []Rule, only, skip []string) error {
 // original findings that disappeared as fixed and keeps the post-fix findings.
 func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 	opts = normalizeOptions(opts)
+	engine := r.ruleEngine()
 
-	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
+	selected, err := engine.SelectRules(EngineOptions{
+		OnlyRules: opts.OnlyRules,
+		SkipRules: opts.SkipRules,
+	})
 	if err != nil {
 		return Result{}, err
 	}
@@ -58,7 +70,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	return r.runWithSelection(ctx, opts, selection, selected)
+	return r.runWithSelection(ctx, opts, selection, engine, selected)
 }
 
 // RunWithSelection executes the configured rules against a pre-resolved scope
@@ -67,22 +79,26 @@ func (r *Runner) Run(ctx context.Context, opts Options) (Result, error) {
 // tree twice.
 func (r *Runner) RunWithSelection(ctx context.Context, opts Options, selection scope.Selection) (Result, error) {
 	opts = normalizeOptions(opts)
+	engine := r.ruleEngine()
 
-	selected, err := selectRules(r.rules, opts.OnlyRules, opts.SkipRules)
+	selected, err := engine.SelectRules(EngineOptions{
+		OnlyRules: opts.OnlyRules,
+		SkipRules: opts.SkipRules,
+	})
 	if err != nil {
 		return Result{}, err
 	}
 
-	return r.runWithSelection(ctx, opts, selection, selected)
+	return r.runWithSelection(ctx, opts, selection, engine, selected)
 }
 
-func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection, selected []Rule) (Result, error) {
+func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection, engine *Engine, selected []Rule) (Result, error) {
 	loaded, err := loadFiles(selection)
 	if err != nil {
 		return Result{}, err
 	}
 
-	findings, err := runRules(ctx, selected, loaded.snapshot)
+	findings, err := runRules(ctx, engine, opts, loaded.snapshot)
 	if err != nil {
 		return Result{}, err
 	}
@@ -100,7 +116,7 @@ func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection s
 				return Result{}, err
 			}
 
-			remaining, err := runRules(ctx, selected, fixed.snapshot)
+			remaining, err := runRules(ctx, engine, opts, fixed.snapshot)
 			if err != nil {
 				return Result{}, err
 			}
@@ -126,8 +142,11 @@ func normalizeOptions(opts Options) Options {
 	return opts
 }
 
-func runRules(ctx context.Context, selected []Rule, snapshot analysis.Snapshot) ([]Finding, error) {
-	return NewEngine(selected...).Run(ctx, snapshot, EngineOptions{})
+func runRules(ctx context.Context, engine *Engine, opts Options, snapshot analysis.Snapshot) ([]Finding, error) {
+	return engine.Run(ctx, snapshot, EngineOptions{
+		OnlyRules: opts.OnlyRules,
+		SkipRules: opts.SkipRules,
+	})
 }
 
 type findingKey struct {

--- a/internal/lint/runner.go
+++ b/internal/lint/runner.go
@@ -8,12 +8,13 @@ package lint
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
 
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
 	"github.com/envaar/vaar/internal/envfile"
 	"github.com/envaar/vaar/internal/fs"
 	"github.com/envaar/vaar/internal/scope"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
 )
 
 // Runner executes a rule set over discovered dotenv files and keeps the
@@ -76,12 +77,12 @@ func (r *Runner) RunWithSelection(ctx context.Context, opts Options, selection s
 }
 
 func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection scope.Selection, selected []Rule) (Result, error) {
-	files, err := loadFiles(selection)
+	loaded, err := loadFiles(selection)
 	if err != nil {
 		return Result{}, err
 	}
 
-	findings, err := r.runRules(ctx, selection.Root, selected, files, opts)
+	findings, err := runRules(ctx, selected, loaded.snapshot)
 	if err != nil {
 		return Result{}, err
 	}
@@ -94,18 +95,18 @@ func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection s
 		}
 
 		if changed {
-			fixedFiles, err := loadFiles(selection)
+			fixed, err := loadFiles(selection)
 			if err != nil {
 				return Result{}, err
 			}
 
-			remaining, err := r.runRules(ctx, selection.Root, selected, fixedFiles, opts)
+			remaining, err := runRules(ctx, selected, fixed.snapshot)
 			if err != nil {
 				return Result{}, err
 			}
 
 			findings = markFixedFindings(findings, remaining)
-			files = fixedFiles
+			loaded = fixed
 		}
 	}
 
@@ -113,7 +114,7 @@ func (r *Runner) runWithSelection(ctx context.Context, opts Options, selection s
 
 	return Result{
 		Findings: findings,
-		Files:    files,
+		Files:    loaded.files,
 		Changed:  changed,
 	}, nil
 }
@@ -125,22 +126,8 @@ func normalizeOptions(opts Options) Options {
 	return opts
 }
 
-func (r *Runner) runRules(ctx context.Context, root string, selected []Rule, files []envfile.File, opts Options) ([]Finding, error) {
-	runCtx := Context{Root: root, Files: files, Options: opts}
-	findings := make([]Finding, 0, 16)
-	for _, rule := range selected {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		ruleFindings, err := rule.Run(runCtx)
-		if err != nil {
-			return nil, fmt.Errorf("%s: %w", rule.ID(), err)
-		}
-		findings = append(findings, ruleFindings...)
-	}
-
-	return findings, nil
+func runRules(ctx context.Context, selected []Rule, snapshot analysis.Snapshot) ([]Finding, error) {
+	return NewEngine(selected...).Run(ctx, snapshot, EngineOptions{})
 }
 
 type findingKey struct {
@@ -180,104 +167,40 @@ func markFixedFindings(original, remaining []Finding) []Finding {
 	return append(findings, remaining...)
 }
 
+type loadedFiles struct {
+	files    []envfile.File
+	snapshot analysis.Snapshot
+}
+
 // loadFiles reads each selected path and parses it relative to the configured
-// repository root.
-func loadFiles(selection scope.Selection) ([]envfile.File, error) {
+// repository root. The parsed files remain available only for the temporary
+// runner result and fix adapter; rules receive the derived analysis snapshot.
+func loadFiles(selection scope.Selection) (loadedFiles, error) {
 	files := make([]envfile.File, 0, len(selection.Paths))
+	inputs := make([]analysisdotenv.DocumentInput, 0, len(selection.Paths))
 	for _, path := range selection.Paths {
 		display := selection.DisplayPath(path)
 		data, err := fs.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("read %q: %w", display, err)
+			return loadedFiles{}, fmt.Errorf("read %q: %w", display, err)
 		}
 
 		parsed, err := envfile.Parse(display, data)
 		if err != nil {
-			return nil, fmt.Errorf("parse %q: %w", display, err)
+			return loadedFiles{}, fmt.Errorf("parse %q: %w", display, err)
 		}
 		files = append(files, parsed)
-	}
-	return files, nil
-}
-
-// selectRules applies --only and --skip in declaration order so the selected
-// set stays predictable for completions, tests and report output.
-func selectRules(all []Rule, only, skip []string) ([]Rule, error) {
-	if len(all) == 0 {
-		return nil, nil
+		inputs = append(inputs, analysisdotenv.DocumentInput{
+			ID: analysis.DocumentID(path),
+			Source: sourcedotenv.Document{
+				File:       parsed,
+				SourcePath: path,
+			},
+		})
 	}
 
-	allowed := make(map[string]Rule, len(all))
-	ordered := make([]Rule, 0, len(all))
-	for _, rule := range all {
-		allowed[rule.ID()] = rule
-		ordered = append(ordered, rule)
-	}
-
-	selectedIDs := make(map[string]struct{}, len(all))
-
-	if len(only) > 0 {
-		for _, id := range only {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --only")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			selectedIDs[id] = struct{}{}
-		}
-	} else {
-		for _, rule := range ordered {
-			selectedIDs[rule.ID()] = struct{}{}
-		}
-	}
-
-	if len(skip) > 0 {
-		for _, id := range skip {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				return nil, fmt.Errorf("invalid empty rule ID in --skip")
-			}
-			if _, ok := allowed[id]; !ok {
-				return nil, fmt.Errorf("unknown lint rule %q", id)
-			}
-			delete(selectedIDs, id)
-		}
-	}
-
-	selected := make([]Rule, 0, len(selectedIDs))
-	for _, rule := range ordered {
-		if _, ok := selectedIDs[rule.ID()]; ok {
-			selected = append(selected, rule)
-		}
-	}
-
-	if len(selected) == 0 {
-		return nil, fmt.Errorf("no lint rules selected after applying --only and --skip")
-	}
-
-	return selected, nil
-}
-
-// sortFindings orders output by file, line, severity, rule and message so
-// repeated runs produce the same report.
-func sortFindings(findings []Finding) {
-	sort.SliceStable(findings, func(i, j int) bool {
-		left := findings[i]
-		right := findings[j]
-		if left.File != right.File {
-			return left.File < right.File
-		}
-		if left.Line != right.Line {
-			return left.Line < right.Line
-		}
-		if left.Severity.Rank() != right.Severity.Rank() {
-			return left.Severity.Rank() < right.Severity.Rank()
-		}
-		if left.Rule != right.Rule {
-			return left.Rule < right.Rule
-		}
-		return left.Message < right.Message
-	})
+	return loadedFiles{
+		files:    files,
+		snapshot: analysis.NewSnapshot(analysisdotenv.FromDocuments(inputs)),
+	}, nil
 }

--- a/internal/lint/runner_test.go
+++ b/internal/lint/runner_test.go
@@ -33,18 +33,6 @@ func (r countingRule) Run(lint.Context) ([]lint.Finding, error) {
 	return nil, nil
 }
 
-type rootRecordingRule struct {
-	root *string
-}
-
-func (r rootRecordingRule) ID() string          { return "root-recording" }
-func (r rootRecordingRule) Description() string { return "records the root option" }
-
-func (r rootRecordingRule) Run(ctx lint.Context) ([]lint.Finding, error) {
-	*r.root = ctx.Options.Root
-	return nil, nil
-}
-
 func TestRunnerRuleSelection(t *testing.T) {
 	root := t.TempDir()
 
@@ -210,20 +198,6 @@ func TestRunnerInvalidRuleSelectionBeatsScopeErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown lint rule \"unknown-rule\"") {
 		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestRunnerDefaultsEmptyRootForRuleContext(t *testing.T) {
-	var gotRoot string
-	runner := lint.NewRunner(rootRecordingRule{root: &gotRoot})
-
-	_, err := runner.Run(context.Background(), lint.Options{})
-	if err != nil {
-		t.Fatalf("run failed: %v", err)
-	}
-
-	if got, want := gotRoot, "."; got != want {
-		t.Fatalf("unexpected ctx.Options.Root: got %q want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #92

## Summary

Move deterministic lint rule execution behind an analysis-backed engine while retaining the existing `Runner` compatibility adapter and byte-based fix behavior.

## Why

This advances the refactor architecture from Discussion #58 by making lint rules consume normalized analysis facts instead of parser-owned `envfile.File` values. It creates a clean boundary between analysis, rule execution, orchestration, and future result/output migration.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added an analysis-backed `lint.Engine` responsible for rule selection, cancellation, execution, error wrapping, and deterministic finding ordering.
- Changed the rule-facing `lint.Context` to expose only `analysis.Snapshot`.
- Migrated all deterministic lint rules to consume analysis document and line facts.
- Preserved existing rule IDs, severities, messages, paths, line numbers, duplicate behavior, and file-level behavior.
- Preserved `only`, `skip`, unknown-rule, and empty-selection semantics.
- Retained `Runner` as the temporary compatibility adapter for scope resolution, source loading, parsing, fixes, and existing CLI behavior.
- Preserved all existing byte-based fix methods and fixability behavior.
- Added engine, cancellation, selection, error-wrapping, deterministic-ordering, in-memory snapshot, and context-boundary tests.
- Updated affected package comments to document the transitional architecture.

## User-visible changes

**None.**

The existing CLI behavior, lint findings, output, rule IDs, fixability, and exit behavior remain unchanged.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go test -count=1 ./...
GOCACHE=/tmp/vaar-go-cache go test -race ./internal/lint ./internal/lint/rules/...
GOCACHE=/tmp/vaar-go-cache go vet ./...
make build
git diff --check
```

`go run ./cmd/vaar lint ...` was not run because the existing CLI path is intentionally retained as a compatibility adapter and no CLI behavior was changed in this ticket.

## Tests

- [x] Added tests
- [x] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Updated affected package comments to describe the analysis-backed rule boundary and temporary `Runner` compatibility role.

## Release notes

Lint rules now execute through the analysis-backed engine without changing existing CLI behavior or fix functionality.

## Reviewer notes

Please pay particular attention to:

- The rule-facing `lint.Context` boundary: it exposes only `analysis.Snapshot`.
- All deterministic rules now consume normalized analysis facts rather than `envfile.File`.
- Finding ordering remains deterministic.
- Existing rule IDs, severities, messages, paths, line numbers, duplicate handling, and file-level behavior are preserved.
- Rule selection and cancellation semantics remain unchanged.
- `Runner` intentionally remains as a temporary orchestration adapter.
- Existing byte-based fixes remain unchanged.
- This PR intentionally does not implement orchestration migration, mutation planning, final CLI migration, reporter changes, query behavior, or source-loading removal.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized lint execution with rule selection, cancellation support, and deterministic finding order.
  * Linting now runs consistently against analyzed document snapshots.

* **Bug Fixes**
  * Improved consistency of lint findings across files and standardized document metadata reporting.
  * Preserved detailed rule errors during lint execution.

* **Tests**
  * Added comprehensive coverage for rule selection, cancellation, sorting, error handling, and snapshot-based analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->