### PR TITLE
refactor(lint): add read-only lint orchestration

### DIFF
--- a/internal/application/lint/application.go
+++ b/internal/application/lint/application.go
@@ -1,0 +1,151 @@
+// Copyright © 2026 envaar
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lint coordinates one read-only lint use case. It composes scope
+// resolution, dotenv loading, analysis conversion and the analysis-backed lint
+// engine, but does not render output, map exit codes or mutate files.
+package lint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
+	lintengine "github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/scope"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+// Options selects the repository inputs and rules for one read-only lint run.
+// Output, exit-code and mutation options deliberately do not belong here.
+type Options struct {
+	Root      string
+	Target    string
+	TargetDir string
+	OnlyRules []string
+	SkipRules []string
+}
+
+// Dependencies provides narrow seams for the application boundary. Production
+// callers should use New, which supplies the repository scope resolver and
+// dotenv loader. The seams let tests prove that orchestration resolves and
+// loads exactly once without introducing source interfaces into analysis.
+type Dependencies struct {
+	ResolveScope func(scope.Options) (scope.Selection, error)
+	LoadDotenv   func(paths, displayPaths []string) ([]sourcedotenv.Document, error)
+}
+
+// Service is the read-only lint application service.
+type Service struct {
+	engine       *lintengine.Engine
+	resolveScope func(scope.Options) (scope.Selection, error)
+	loadDotenv   func(paths, displayPaths []string) ([]sourcedotenv.Document, error)
+}
+
+// Result contains the findings and the loaded state needed by the later
+// mutation-planning flow. Reporters should consume Findings only;
+// LoadedDocuments retain source-owned values for internal fix planning and are
+// not output data.
+type Result struct {
+	Findings        []lintengine.Finding
+	Selection       scope.Selection
+	LoadedDocuments []sourcedotenv.Document
+	Snapshot        analysis.Snapshot
+	SelectedRules   []lintengine.Rule
+}
+
+// New constructs a read-only lint application service with the standard scope
+// resolver and dotenv source loader.
+func New(rules ...lintengine.Rule) *Service {
+	return NewWithDependencies(Dependencies{}, rules...)
+}
+
+// NewWithDependencies constructs a service with explicit boundary functions.
+// Nil dependencies use the production implementations.
+func NewWithDependencies(dependencies Dependencies, rules ...lintengine.Rule) *Service {
+	if dependencies.ResolveScope == nil {
+		dependencies.ResolveScope = scope.Resolve
+	}
+	if dependencies.LoadDotenv == nil {
+		dependencies.LoadDotenv = sourcedotenv.LoadMany
+	}
+
+	return &Service{
+		engine:       lintengine.NewEngine(rules...),
+		resolveScope: dependencies.ResolveScope,
+		loadDotenv:   dependencies.LoadDotenv,
+	}
+}
+
+// Run resolves the requested scope once, loads each selected dotenv source
+// once, converts the loaded documents into one analysis snapshot, and runs the
+// selected lint rules. It performs no writes, rendering or exit-code mapping.
+func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
+	selected, err := s.engine.SelectRules(lintengine.EngineOptions{
+		OnlyRules: opts.OnlyRules,
+		SkipRules: opts.SkipRules,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	selection, err := s.resolveScope(scope.Options{
+		Root:      opts.Root,
+		Target:    opts.Target,
+		TargetDir: opts.TargetDir,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve lint scope: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	displayPaths := make([]string, len(selection.Paths))
+	for i, path := range selection.Paths {
+		displayPaths[i] = selection.DisplayPath(path)
+	}
+
+	documents, err := s.loadDotenv(selection.Paths, displayPaths)
+	if err != nil {
+		return Result{}, fmt.Errorf("load lint sources: %w", err)
+	}
+	if len(documents) != len(selection.Paths) {
+		return Result{}, fmt.Errorf(
+			"load lint sources: got %d documents for %d selected paths",
+			len(documents), len(selection.Paths),
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return Result{}, err
+	}
+
+	inputs := make([]analysisdotenv.DocumentInput, len(documents))
+	for i, document := range documents {
+		inputs[i] = analysisdotenv.DocumentInput{
+			ID:     analysis.DocumentID(selection.Paths[i]),
+			Source: document,
+		}
+	}
+
+	snapshot := analysis.NewSnapshot(analysisdotenv.FromDocuments(inputs))
+	findings, err := s.engine.Run(ctx, snapshot, lintengine.EngineOptions{
+		OnlyRules: opts.OnlyRules,
+		SkipRules: opts.SkipRules,
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("run lint engine: %w", err)
+	}
+
+	return Result{
+		Findings:        findings,
+		Selection:       selection,
+		LoadedDocuments: documents,
+		Snapshot:        snapshot,
+		SelectedRules:   selected,
+	}, nil
+}

--- a/internal/application/lint/application.go
+++ b/internal/application/lint/application.go
@@ -82,13 +82,14 @@ func NewWithDependencies(dependencies Dependencies, rules ...lintengine.Rule) *S
 // once, converts the loaded documents into one analysis snapshot, and runs the
 // selected lint rules. It performs no writes, rendering or exit-code mapping.
 func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
-	selected, err := s.engine.SelectRules(lintengine.EngineOptions{
+	plan, err := s.engine.SelectRulePlan(lintengine.EngineOptions{
 		OnlyRules: opts.OnlyRules,
 		SkipRules: opts.SkipRules,
 	})
 	if err != nil {
 		return Result{}, err
 	}
+	selected := plan.Rules()
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}
@@ -147,10 +148,7 @@ func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
 	}
 
 	snapshot := analysis.NewSnapshot(analysisdotenv.FromDocuments(inputs))
-	findings, err := s.engine.Run(ctx, snapshot, lintengine.EngineOptions{
-		OnlyRules: opts.OnlyRules,
-		SkipRules: opts.SkipRules,
-	})
+	findings, err := s.engine.RunPlan(ctx, snapshot, plan)
 	if err != nil {
 		return Result{}, fmt.Errorf("run lint engine: %w", err)
 	}

--- a/internal/application/lint/application.go
+++ b/internal/application/lint/application.go
@@ -120,6 +120,20 @@ func (s *Service) Run(ctx context.Context, opts Options) (Result, error) {
 			len(documents), len(selection.Paths),
 		)
 	}
+	for i, document := range documents {
+		if document.SourcePath != selection.Paths[i] {
+			return Result{}, fmt.Errorf(
+				"load lint sources: document %d has source path %q, want %q",
+				i, document.SourcePath, selection.Paths[i],
+			)
+		}
+		if document.Path != displayPaths[i] {
+			return Result{}, fmt.Errorf(
+				"load lint sources: document %d has display path %q, want %q",
+				i, document.Path, displayPaths[i],
+			)
+		}
+	}
 	if err := ctx.Err(); err != nil {
 		return Result{}, err
 	}

--- a/internal/application/lint/application_test.go
+++ b/internal/application/lint/application_test.go
@@ -21,12 +21,18 @@ import (
 
 type applicationRule struct {
 	id       string
+	idCalls  *int
 	calls    *int
 	findings []lintmodel.Finding
 	err      error
 }
 
-func (r applicationRule) ID() string          { return r.id }
+func (r applicationRule) ID() string {
+	if r.idCalls != nil {
+		(*r.idCalls)++
+	}
+	return r.id
+}
 func (r applicationRule) Description() string { return "application test rule" }
 
 func (r applicationRule) Run(lintmodel.Context) ([]lintmodel.Finding, error) {
@@ -108,6 +114,35 @@ func TestServicePreservesOnlyAndSkipRuleSelection(t *testing.T) {
 	}
 	if firstCalls != 1 || secondCalls != 0 {
 		t.Fatalf("rule calls = (%d, %d), want (1, 0)", firstCalls, secondCalls)
+	}
+}
+
+func TestServiceDoesNotReselectRulesDuringExecution(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=value\n")
+
+	idCalls := 0
+	callsAtLoad := -1
+	service := applicationlint.NewWithDependencies(applicationlint.Dependencies{
+		LoadDotenv: func(paths, displayPaths []string) ([]sourcedotenv.Document, error) {
+			callsAtLoad = idCalls
+			return sourcedotenv.LoadMany(paths, displayPaths)
+		},
+	}, applicationRule{id: "rule", idCalls: &idCalls})
+
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if callsAtLoad < 0 {
+		t.Fatal("loader did not observe rule selection")
+	}
+	if idCalls != callsAtLoad {
+		t.Fatalf("rule ID calls after loading = %d, want %d", idCalls, callsAtLoad)
+	}
+	if len(result.SelectedRules) != 1 {
+		t.Fatalf("selected rules = %#v, want one rule", result.SelectedRules)
 	}
 }
 

--- a/internal/application/lint/application_test.go
+++ b/internal/application/lint/application_test.go
@@ -222,6 +222,75 @@ func TestServiceResolvesScopeAndLoadsSelectedFilesOnce(t *testing.T) {
 	}
 }
 
+func TestServiceRejectsLoadedDocumentsWithMismatchedProvenance(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, ".env.first")
+	secondPath := filepath.Join(root, ".env.second")
+	mustWrite(t, firstPath, "FIRST=value\n")
+	mustWrite(t, secondPath, "SECOND=value\n")
+
+	cases := []struct {
+		name   string
+		mutate func([]sourcedotenv.Document)
+		want   string
+	}{
+		{
+			name: "swapped documents",
+			mutate: func(documents []sourcedotenv.Document) {
+				documents[0], documents[1] = documents[1], documents[0]
+			},
+			want: "source path",
+		},
+		{
+			name: "mismatched source path",
+			mutate: func(documents []sourcedotenv.Document) {
+				documents[0].SourcePath = filepath.Join(root, "unexpected.env")
+			},
+			want: "source path",
+		},
+		{
+			name: "mismatched display path",
+			mutate: func(documents []sourcedotenv.Document) {
+				documents[0].Path = "unexpected.env"
+			},
+			want: "display path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ruleCalls := 0
+			service := applicationlint.NewWithDependencies(applicationlint.Dependencies{
+				ResolveScope: func(scope.Options) (scope.Selection, error) {
+					return scope.Selection{
+						Root:  root,
+						Paths: []string{firstPath, secondPath},
+					}, nil
+				},
+				LoadDotenv: func(paths, displayPaths []string) ([]sourcedotenv.Document, error) {
+					documents, err := sourcedotenv.LoadMany(paths, displayPaths)
+					if err != nil {
+						return nil, err
+					}
+					tc.mutate(documents)
+					return documents, nil
+				},
+			}, applicationRule{id: "rule", calls: &ruleCalls})
+
+			_, err := service.Run(context.Background(), applicationlint.Options{})
+			if err == nil {
+				t.Fatal("expected provenance validation error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+			if ruleCalls != 0 {
+				t.Fatalf("rule calls = %d, want 0", ruleCalls)
+			}
+		})
+	}
+}
+
 func TestServiceReturnsLoadingFailureWithoutRunningRules(t *testing.T) {
 	root := t.TempDir()
 	loadErr := errors.New("source load failed")

--- a/internal/application/lint/application_test.go
+++ b/internal/application/lint/application_test.go
@@ -1,0 +1,336 @@
+// Copyright © 2026 envaar
+// SPDX-License-Identifier: Apache-2.0
+
+package lint_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	applicationlint "github.com/envaar/vaar/internal/application/lint"
+	lintmodel "github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+	"github.com/envaar/vaar/internal/scope"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+type applicationRule struct {
+	id       string
+	calls    *int
+	findings []lintmodel.Finding
+	err      error
+}
+
+func (r applicationRule) ID() string          { return r.id }
+func (r applicationRule) Description() string { return "application test rule" }
+
+func (r applicationRule) Run(lintmodel.Context) ([]lintmodel.Finding, error) {
+	if r.calls != nil {
+		(*r.calls)++
+	}
+	return r.findings, r.err
+}
+
+func TestServiceCleanRunReturnsLoadedAnalysisState(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=value\n")
+
+	service := applicationlint.New(rules.NewDuplicateKey())
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if result.Findings == nil {
+		t.Fatal("findings must be non-nil for a clean run")
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("findings = %#v, want none", result.Findings)
+	}
+	if got, want := len(result.LoadedDocuments), 1; got != want {
+		t.Fatalf("loaded document count = %d, want %d", got, want)
+	}
+	if got, want := len(result.Snapshot.Documents()), 1; got != want {
+		t.Fatalf("analysis document count = %d, want %d", got, want)
+	}
+	if got, want := result.LoadedDocuments[0].Path, ".env"; got != want {
+		t.Fatalf("display path = %q, want %q", got, want)
+	}
+	if got, want := len(result.SelectedRules), 1; got != want {
+		t.Fatalf("selected rule count = %d, want %d", got, want)
+	}
+}
+
+func TestServiceReturnsFindingsFromAnalysisEngine(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=first\nKEY=second\n")
+
+	service := applicationlint.New(rules.NewDuplicateKey())
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if got, want := len(result.Findings), 1; got != want {
+		t.Fatalf("finding count = %d, want %d", got, want)
+	}
+	finding := result.Findings[0]
+	if finding.Rule != "duplicate-key" || finding.File != ".env" || finding.Line != 2 {
+		t.Fatalf("unexpected finding: %#v", finding)
+	}
+}
+
+func TestServicePreservesOnlyAndSkipRuleSelection(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=value\n")
+
+	firstCalls, secondCalls := 0, 0
+	service := applicationlint.New(
+		applicationRule{id: "first", calls: &firstCalls},
+		applicationRule{id: "second", calls: &secondCalls},
+	)
+
+	_, err := service.Run(context.Background(), applicationlint.Options{
+		Root:      root,
+		OnlyRules: []string{"first", "second"},
+		SkipRules: []string{"second"},
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if firstCalls != 1 || secondCalls != 0 {
+		t.Fatalf("rule calls = (%d, %d), want (1, 0)", firstCalls, secondCalls)
+	}
+}
+
+func TestServicePreservesDefaultTargetAndTargetDirectoryScopes(t *testing.T) {
+	root := t.TempDir()
+	rootFile := filepath.Join(root, ".env")
+	nestedFile := filepath.Join(root, "service", ".env.local")
+	mustWrite(t, rootFile, "ROOT=value\n")
+	mustWrite(t, nestedFile, "NESTED=value\n")
+
+	service := applicationlint.New()
+	cases := []struct {
+		name        string
+		options     applicationlint.Options
+		wantPaths   []string
+		wantDisplay []string
+	}{
+		{
+			name:        "default",
+			options:     applicationlint.Options{Root: root},
+			wantPaths:   []string{rootFile, nestedFile},
+			wantDisplay: []string{".env", filepath.Join("service", ".env.local")},
+		},
+		{
+			name:        "target file",
+			options:     applicationlint.Options{Root: root, Target: ".env"},
+			wantPaths:   []string{rootFile},
+			wantDisplay: []string{".env"},
+		},
+		{
+			name:        "target directory",
+			options:     applicationlint.Options{Root: root, TargetDir: "service"},
+			wantPaths:   []string{nestedFile},
+			wantDisplay: []string{filepath.Join("service", ".env.local")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := service.Run(context.Background(), tc.options)
+			if err != nil {
+				t.Fatalf("run failed: %v", err)
+			}
+			if got := result.Selection.Paths; !reflect.DeepEqual(got, tc.wantPaths) {
+				t.Fatalf("selected paths = %#v, want %#v", got, tc.wantPaths)
+			}
+			gotDisplay := make([]string, len(result.LoadedDocuments))
+			for i, document := range result.LoadedDocuments {
+				gotDisplay[i] = document.Path
+			}
+			if !reflect.DeepEqual(gotDisplay, tc.wantDisplay) {
+				t.Fatalf("display paths = %#v, want %#v", gotDisplay, tc.wantDisplay)
+			}
+		})
+	}
+}
+
+func TestServiceSupportsEmptyDiscovery(t *testing.T) {
+	service := applicationlint.New()
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: t.TempDir()})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if result.LoadedDocuments == nil {
+		t.Fatal("loaded documents must be non-nil for empty discovery")
+	}
+	if result.Findings == nil {
+		t.Fatal("findings must be non-nil for empty discovery")
+	}
+	if len(result.LoadedDocuments) != 0 || len(result.Findings) != 0 {
+		t.Fatalf("empty discovery result = %#v, want no documents or findings", result)
+	}
+}
+
+func TestServiceResolvesScopeAndLoadsSelectedFilesOnce(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, ".env.first")
+	secondPath := filepath.Join(root, ".env.second")
+	mustWrite(t, firstPath, "FIRST=value\n")
+	mustWrite(t, secondPath, "SECOND=value\n")
+
+	resolveCalls := 0
+	loadCalls := 0
+	loadedPathCount := 0
+	service := applicationlint.NewWithDependencies(applicationlint.Dependencies{
+		ResolveScope: func(options scope.Options) (scope.Selection, error) {
+			resolveCalls++
+			return scope.Resolve(options)
+		},
+		LoadDotenv: func(paths, displayPaths []string) ([]sourcedotenv.Document, error) {
+			loadCalls++
+			loadedPathCount += len(paths)
+			return sourcedotenv.LoadMany(paths, displayPaths)
+		},
+	}, rules.NewDuplicateKey())
+
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if resolveCalls != 1 {
+		t.Fatalf("scope resolve calls = %d, want 1", resolveCalls)
+	}
+	if loadCalls != 1 {
+		t.Fatalf("source load calls = %d, want 1", loadCalls)
+	}
+	if loadedPathCount != 2 {
+		t.Fatalf("loaded path count = %d, want 2", loadedPathCount)
+	}
+	if got, want := len(result.LoadedDocuments), 2; got != want {
+		t.Fatalf("loaded document count = %d, want %d", got, want)
+	}
+}
+
+func TestServiceReturnsLoadingFailureWithoutRunningRules(t *testing.T) {
+	root := t.TempDir()
+	loadErr := errors.New("source load failed")
+	ruleCalls := 0
+	service := applicationlint.NewWithDependencies(applicationlint.Dependencies{
+		ResolveScope: func(scope.Options) (scope.Selection, error) {
+			return scope.Selection{Root: root}, nil
+		},
+		LoadDotenv: func([]string, []string) ([]sourcedotenv.Document, error) {
+			return nil, loadErr
+		},
+	}, applicationRule{id: "rule", calls: &ruleCalls})
+
+	_, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("error = %v, want source load error", err)
+	}
+	if ruleCalls != 0 {
+		t.Fatalf("rule calls = %d, want 0", ruleCalls)
+	}
+}
+
+func TestServiceReturnsRuleExecutionFailure(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=value\n")
+	ruleErr := errors.New("rule failed")
+	service := applicationlint.New(applicationRule{id: "broken-rule", err: ruleErr})
+
+	_, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if !errors.Is(err, ruleErr) {
+		t.Fatalf("error = %v, want rule error", err)
+	}
+	if !strings.Contains(err.Error(), "broken-rule") {
+		t.Fatalf("error = %v, want rule ID", err)
+	}
+}
+
+func TestServiceStopsBeforeScopeResolutionWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	resolveCalls := 0
+	loadCalls := 0
+	service := applicationlint.NewWithDependencies(applicationlint.Dependencies{
+		ResolveScope: func(scope.Options) (scope.Selection, error) {
+			resolveCalls++
+			return scope.Selection{}, nil
+		},
+		LoadDotenv: func([]string, []string) ([]sourcedotenv.Document, error) {
+			loadCalls++
+			return nil, nil
+		},
+	}, applicationRule{id: "rule"})
+
+	_, err := service.Run(ctx, applicationlint.Options{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context cancellation", err)
+	}
+	if resolveCalls != 0 || loadCalls != 0 {
+		t.Fatalf("dependency calls = (%d, %d), want (0, 0)", resolveCalls, loadCalls)
+	}
+}
+
+func TestServiceValidatesRuleSelectionBeforeCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	service := applicationlint.New(applicationRule{id: "known-rule"})
+
+	_, err := service.Run(ctx, applicationlint.Options{
+		OnlyRules: []string{"unknown-rule"},
+	})
+	if err == nil {
+		t.Fatal("expected rule-selection error")
+	}
+	if !strings.Contains(err.Error(), `unknown lint rule "unknown-rule"`) {
+		t.Fatalf("error = %v, want unknown-rule selection error", err)
+	}
+}
+
+func TestServiceConvertsDocumentsThroughAnalysisAdapter(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, "KEY=value with spaces\n")
+
+	service := applicationlint.New()
+	result, err := service.Run(context.Background(), applicationlint.Options{Root: root})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	documents := result.Snapshot.Documents()
+	if len(documents) != 1 || len(documents[0].Lines) != 1 {
+		t.Fatalf("unexpected snapshot: %#v", documents)
+	}
+	line := documents[0].Lines[0]
+	if !line.ValueContainsWhitespace || line.Key != "KEY" || !line.HasAssignment {
+		t.Fatalf("analysis line facts = %#v", line)
+	}
+	if line.Number != 1 || documents[0].DisplayPath != ".env" {
+		t.Fatalf("analysis provenance = %#v", documents[0])
+	}
+}
+
+func mustWrite(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create parent directory failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s failed: %v", path, err)
+	}
+}

--- a/internal/lint/engine.go
+++ b/internal/lint/engine.go
@@ -24,6 +24,14 @@ type EngineOptions struct {
 	SkipRules []string
 }
 
+// RulePlan is an engine-owned, immutable selection of rules for one run.
+// Plans can only be created by an Engine and can only be executed by the
+// Engine that created them.
+type RulePlan struct {
+	engine *Engine
+	rules  []Rule
+}
+
 // Engine executes lint rules against an immutable analysis snapshot.
 type Engine struct {
 	rules []Rule
@@ -37,25 +45,59 @@ func NewEngine(rules ...Rule) *Engine {
 	return &Engine{rules: copied}
 }
 
+// SelectRulePlan validates and resolves rule-selection input against the
+// engine's registered rules. The returned plan is owned by this engine and can
+// be executed without repeating selection.
+func (e *Engine) SelectRulePlan(opts EngineOptions) (RulePlan, error) {
+	selected, err := selectRules(e.rules, opts.OnlyRules, opts.SkipRules)
+	if err != nil {
+		return RulePlan{}, err
+	}
+
+	return RulePlan{engine: e, rules: selected}, nil
+}
+
+// Rules returns a copy of the plan's selected rules. The returned slice can be
+// changed by the caller without changing the plan.
+func (p RulePlan) Rules() []Rule {
+	selected := make([]Rule, len(p.rules))
+	copy(selected, p.rules)
+	return selected
+}
+
 // SelectRules validates and resolves rule-selection input against the engine's
 // registered rules. The returned slice is independent of the engine's rule
 // collection and is useful to compatibility adapters that need the selected
 // rules for fix planning or other orchestration concerns.
 func (e *Engine) SelectRules(opts EngineOptions) ([]Rule, error) {
-	return selectRules(e.rules, opts.OnlyRules, opts.SkipRules)
+	plan, err := e.SelectRulePlan(opts)
+	if err != nil {
+		return nil, err
+	}
+	return plan.Rules(), nil
 }
 
 // Run selects and executes rules against snapshot. It performs no filesystem
 // I/O, parsing, mutation, rendering or exit-code mapping.
 func (e *Engine) Run(ctx context.Context, snapshot analysis.Snapshot, opts EngineOptions) ([]Finding, error) {
-	selected, err := e.SelectRules(opts)
+	plan, err := e.SelectRulePlan(opts)
 	if err != nil {
 		return nil, err
 	}
 
+	return e.RunPlan(ctx, snapshot, plan)
+}
+
+// RunPlan executes the rules selected by this engine against snapshot. It
+// checks cancellation before every rule and never performs rule selection.
+func (e *Engine) RunPlan(ctx context.Context, snapshot analysis.Snapshot, plan RulePlan) ([]Finding, error) {
+	if plan.engine != e {
+		return nil, fmt.Errorf("lint rule plan does not belong to engine")
+	}
+
 	findings := make([]Finding, 0, 16)
 	ruleContext := Context{Snapshot: snapshot}
-	for _, rule := range selected {
+	for _, rule := range plan.rules {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}

--- a/internal/lint/engine_test.go
+++ b/internal/lint/engine_test.go
@@ -19,6 +19,7 @@ import (
 
 type engineTestRule struct {
 	id       string
+	idCalls  *int
 	calls    *int
 	observed *[]string
 	onRun    func()
@@ -26,7 +27,12 @@ type engineTestRule struct {
 	err      error
 }
 
-func (r engineTestRule) ID() string          { return r.id }
+func (r engineTestRule) ID() string {
+	if r.idCalls != nil {
+		(*r.idCalls)++
+	}
+	return r.id
+}
 func (r engineTestRule) Description() string { return "engine test rule" }
 
 func (r engineTestRule) Run(ctx lint.Context) ([]lint.Finding, error) {
@@ -268,6 +274,67 @@ func TestEngineExposesSelectedRulesForCompatibilityAdapters(t *testing.T) {
 	}
 	if selected[0].ID() != "second" {
 		t.Fatalf("selected rule = %q, want second", selected[0].ID())
+	}
+}
+
+func TestEngineRunsRulePlanWithoutReselectingRules(t *testing.T) {
+	idCalls := 0
+	rule := engineTestRule{id: "planned", idCalls: &idCalls}
+	engine := lint.NewEngine(rule)
+
+	plan, err := engine.SelectRulePlan(lint.EngineOptions{})
+	if err != nil {
+		t.Fatalf("select rule plan failed: %v", err)
+	}
+	selectedCalls := idCalls
+
+	findings, err := engine.RunPlan(context.Background(), emptyAnalysisSnapshot(), plan)
+	if err != nil {
+		t.Fatalf("run rule plan failed: %v", err)
+	}
+	if findings == nil {
+		t.Fatal("clean rule-plan run returned nil findings")
+	}
+	if idCalls != selectedCalls {
+		t.Fatalf("rule ID calls during execution = %d, want %d", idCalls, selectedCalls)
+	}
+
+	selected := plan.Rules()
+	if len(selected) != 1 || selected[0].ID() != "planned" {
+		t.Fatalf("rule plan contents = %#v, want planned rule", selected)
+	}
+}
+
+func TestEngineRunPlanStopsBeforeFirstRuleWhenCanceled(t *testing.T) {
+	ruleCalls := 0
+	engine := lint.NewEngine(engineTestRule{id: "planned", calls: &ruleCalls})
+	plan, err := engine.SelectRulePlan(lint.EngineOptions{})
+	if err != nil {
+		t.Fatalf("select rule plan failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = engine.RunPlan(ctx, emptyAnalysisSnapshot(), plan)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if ruleCalls != 0 {
+		t.Fatalf("rule calls = %d, want 0", ruleCalls)
+	}
+}
+
+func TestEngineRejectsRulePlanFromAnotherEngine(t *testing.T) {
+	first := lint.NewEngine(engineTestRule{id: "first"})
+	second := lint.NewEngine(engineTestRule{id: "second"})
+	plan, err := first.SelectRulePlan(lint.EngineOptions{})
+	if err != nil {
+		t.Fatalf("select rule plan failed: %v", err)
+	}
+
+	_, err = second.RunPlan(context.Background(), emptyAnalysisSnapshot(), plan)
+	if err == nil || !strings.Contains(err.Error(), "does not belong to engine") {
+		t.Fatalf("error = %v, want plan ownership error", err)
 	}
 }
 


### PR DESCRIPTION
Closes #93

<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add a read-only lint application service that coordinates scope resolution, dotenv loading, analysis conversion, and analysis-backed rule execution.

## Why

This establishes the application boundary described in Discussion #58 while keeping CLI, output, exit-code, and mutation concerns separate.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/application/lint` read-only orchestration service.
- Coordinates scope resolution, shared dotenv loading, analysis snapshot construction, and lint engine execution.
- Preserves loaded source state for the future mutation-planning flow.
- Added coverage for scopes, rule selection, empty discovery, failures, cancellation, ordering, and single-load behavior.
- Kept the existing CLI and compatibility runner unchanged.

## User-visible changes

**None.**

The CLI is intentionally not migrated in this ticket. That belongs to the later lint migration ticket.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go vet ./...
GOCACHE=/tmp/vaar-go-cache make build
GOCACHE=/tmp/vaar-go-cache go test ./internal/application/lint
```

The CLI smoke command was not required because this ticket does not change CLI wiring or behavior.

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [ ] Updated documentation
- [x] Not applicable

Package-level documentation was added alongside the new service.

## Release notes

Added the read-only lint application orchestration boundary for the layered refactor.

## Reviewer notes

Please pay special attention to:

- Scope resolution occurring exactly once per run.
- Each selected dotenv file being loaded exactly once.
- Analysis conversion remaining separate from source loading.
- Rules receiving the analysis snapshot rather than parser-owned files.
- Loaded source documents being retained only for future mutation planning.
- No filesystem writes, output rendering, exit-code mapping, or Cobra dependencies in the new service.
- Existing CLI and compatibility-runner behavior remaining unchanged.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a unified linting workflow that selects applicable rules, determines the analysis scope, loads environment configuration, and returns lint findings.
  - Supports linting specific files, directories, or default project scopes.
  - Added options to include only selected rules or skip specified rules.
  - Reports analysis results and errors clearly while respecting cancellation requests.
  - Ensures selected rules remain consistent throughout each linting run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->