### PR TITLE
refactor(mutations): add safe lint fix planning

### DIFF
--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -94,6 +94,21 @@ func (f *AtomicFile) Write(data []byte) (int, error) {
 	return written, nil
 }
 
+// Chmod applies permission bits to the temporary replacement file. The
+// destination is unchanged until Finalize succeeds, so callers can preserve
+// an existing destination mode as part of an atomic replacement.
+func (f *AtomicFile) Chmod(mode os.FileMode) error {
+	if f == nil || f.file == nil {
+		return ErrAtomicFileClosed
+	}
+
+	if err := f.file.Chmod(mode.Perm()); err != nil {
+		_ = f.Cleanup()
+		return err
+	}
+	return nil
+}
+
 // Finalize closes the temporary file and atomically replaces the destination.
 // It cleans up the temporary file if closing or replacement fails.
 func (f *AtomicFile) Finalize() error {

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -84,12 +84,10 @@ func (f *AtomicFile) Write(data []byte) (int, error) {
 
 	written, err := f.file.Write(data)
 	if err != nil {
-		_ = f.Cleanup()
-		return written, err
+		return written, errors.Join(err, f.Cleanup())
 	}
 	if written != len(data) {
-		_ = f.Cleanup()
-		return written, io.ErrShortWrite
+		return written, errors.Join(io.ErrShortWrite, f.Cleanup())
 	}
 	return written, nil
 }
@@ -103,8 +101,7 @@ func (f *AtomicFile) Chmod(mode os.FileMode) error {
 	}
 
 	if err := f.file.Chmod(mode.Perm()); err != nil {
-		_ = f.Cleanup()
-		return err
+		return errors.Join(err, f.Cleanup())
 	}
 	return nil
 }
@@ -126,14 +123,12 @@ func (f *AtomicFile) Finalize() error {
 		err := f.file.Close()
 		f.file = nil
 		if err != nil {
-			_ = f.Cleanup()
-			return err
+			return errors.Join(err, f.Cleanup())
 		}
 	}
 
 	if err := replaceFile(f.temporary, f.destination); err != nil {
-		_ = f.Cleanup()
-		return err
+		return errors.Join(err, f.Cleanup())
 	}
 
 	f.temporary = ""

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -20,7 +20,9 @@ var ErrAtomicFileClosed = errors.New("atomic file is closed")
 
 // AtomicFile owns a same-directory temporary file and destination writer lock
 // until it is finalized or cleaned up. The destination is replaced only after
-// all writes succeed.
+// all writes succeed. The lock coordinates Vaar writers that use AtomicFile or
+// WriteFile; an external process that ignores the advisory lock contract is
+// outside the stale-state guarantee.
 type AtomicFile struct {
 	destination string
 	temporary   string

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -18,12 +18,14 @@ import (
 // finalized or cleaned up.
 var ErrAtomicFileClosed = errors.New("atomic file is closed")
 
-// AtomicFile owns a same-directory temporary file until it is finalized or
-// cleaned up. The destination is replaced only after all writes succeed.
+// AtomicFile owns a same-directory temporary file and destination writer lock
+// until it is finalized or cleaned up. The destination is replaced only after
+// all writes succeed.
 type AtomicFile struct {
 	destination string
 	temporary   string
 	file        *os.File
+	lock        *pathLock
 	finalized   bool
 }
 
@@ -63,15 +65,24 @@ func NewAtomicFile(destination string) (*AtomicFile, error) {
 		return nil, err
 	}
 
-	temporary, err := os.CreateTemp(TempDirForPath(destination), "vaar-atomic-*")
+	lock, err := acquirePathLock(destination)
 	if err != nil {
 		return nil, err
+	}
+	if err := ValidateFileDestination(destination); err != nil {
+		return nil, errors.Join(err, lock.release())
+	}
+
+	temporary, err := os.CreateTemp(TempDirForPath(destination), "vaar-atomic-*")
+	if err != nil {
+		return nil, errors.Join(err, lock.release())
 	}
 
 	return &AtomicFile{
 		destination: destination,
 		temporary:   temporary.Name(),
 		file:        temporary,
+		lock:        lock,
 	}, nil
 }
 
@@ -133,7 +144,7 @@ func (f *AtomicFile) Finalize() error {
 
 	f.temporary = ""
 	f.finalized = true
-	return nil
+	return f.Cleanup()
 }
 
 // Cleanup closes any open temporary file and removes an uncommitted temporary
@@ -149,15 +160,20 @@ func (f *AtomicFile) Cleanup() error {
 		f.file = nil
 	}
 
-	if f.temporary == "" {
-		return closeErr
+	var removeErr error
+	if f.temporary != "" {
+		removeErr = os.Remove(f.temporary)
+		if removeErr == nil || os.IsNotExist(removeErr) {
+			f.temporary = ""
+		}
 	}
 
-	removeErr := os.Remove(f.temporary)
-	if removeErr == nil || os.IsNotExist(removeErr) {
-		f.temporary = ""
+	var unlockErr error
+	if f.lock != nil {
+		unlockErr = f.lock.release()
+		f.lock = nil
 	}
-	return errors.Join(closeErr, removeErr)
+	return errors.Join(closeErr, removeErr, unlockErr)
 }
 
 func replaceFile(temporary, destination string) error {

--- a/internal/fs/atomic.go
+++ b/internal/fs/atomic.go
@@ -117,6 +117,25 @@ func (f *AtomicFile) Chmod(mode os.FileMode) error {
 	return nil
 }
 
+// ReadDestination reads the currently locked destination. When the platform
+// uses a destination byte-range lock, the read is performed through the same
+// handle that owns that lock so Windows does not reject a second handle's
+// access to the locked range. If the destination has no target handle yet,
+// such as a missing file or an identity-lock fallback, it reads by pathname.
+func (f *AtomicFile) ReadDestination() ([]byte, error) {
+	if f == nil || f.lock == nil || f.temporary == "" {
+		return nil, ErrAtomicFileClosed
+	}
+
+	if f.lock.targetFile == nil {
+		return ReadFile(f.destination)
+	}
+	if _, err := f.lock.targetFile.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return io.ReadAll(f.lock.targetFile)
+}
+
 // Finalize closes the temporary file and atomically replaces the destination.
 // It cleans up the temporary file if closing or replacement fails.
 func (f *AtomicFile) Finalize() error {

--- a/internal/fs/atomic_internal_test.go
+++ b/internal/fs/atomic_internal_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAtomicFileWriteReportsCleanupFailure(t *testing.T) {
+	root := t.TempDir()
+	temporary := filepath.Join(root, "temporary")
+	if err := os.Mkdir(temporary, 0o755); err != nil {
+		t.Fatalf("create temporary directory failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(temporary, "keep"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write directory sentinel failed: %v", err)
+	}
+
+	file, err := os.CreateTemp(root, "closed-")
+	if err != nil {
+		t.Fatalf("create closed file failed: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close file failed: %v", err)
+	}
+
+	atomic := &AtomicFile{
+		temporary: temporary,
+		file:      file,
+	}
+	_, err = atomic.Write([]byte("replacement"))
+	if err == nil {
+		t.Fatal("expected write failure")
+	}
+	if !strings.Contains(err.Error(), temporary) {
+		t.Fatalf("write error = %v, want cleanup path", err)
+	}
+	if atomic.temporary != temporary {
+		t.Fatalf("temporary path = %q, want retained path after cleanup failure", atomic.temporary)
+	}
+}

--- a/internal/fs/atomic_test.go
+++ b/internal/fs/atomic_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package fs_test
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -61,6 +62,29 @@ func TestAtomicFileReplacesExistingFile(t *testing.T) {
 
 	assertFileBytes(t, destination, payload)
 	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestAtomicFileReadsExistingDestinationThroughLock(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "lint.json")
+	payload := []byte("current")
+	if err := os.WriteFile(destination, payload, 0o644); err != nil {
+		t.Fatalf("write destination failed: %v", err)
+	}
+
+	file, err := fs.NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+
+	got, err := file.ReadDestination()
+	if err != nil {
+		t.Fatalf("read locked destination failed: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("locked destination = %q, want %q", got, payload)
+	}
 }
 
 func TestAtomicFileDoesNotReplaceDirectory(t *testing.T) {

--- a/internal/fs/identity.go
+++ b/internal/fs/identity.go
@@ -1,0 +1,54 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"errors"
+	"os"
+)
+
+// FileIdentity is an opaque identity captured from an opened filesystem
+// entry. It intentionally exposes no operating-system-specific metadata while
+// still allowing callers to detect replacement, symlink retargeting, and
+// hard-link aliases through os.SameFile.
+type FileIdentity struct {
+	info os.FileInfo
+}
+
+// NewFileIdentity captures the identity represented by info. A nil info
+// produces an invalid identity.
+func NewFileIdentity(info os.FileInfo) FileIdentity {
+	return FileIdentity{info: info}
+}
+
+// Valid reports whether the identity contains a captured filesystem entry.
+func (id FileIdentity) Valid() bool {
+	return id.info != nil
+}
+
+// Same reports whether two captured identities refer to the same filesystem
+// entry. It recognizes hard-link aliases on platforms supported by os.SameFile.
+func (id FileIdentity) Same(other FileIdentity) bool {
+	if !id.Valid() || !other.Valid() {
+		return false
+	}
+	return os.SameFile(id.info, other.info)
+}
+
+// MatchesPath reports whether path still identifies the captured filesystem
+// entry. The path is statted through the operating system, so symlink target
+// changes and file replacement are detected.
+func (id FileIdentity) MatchesPath(path string) (bool, error) {
+	if !id.Valid() {
+		return false, errors.New("file identity is invalid")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return false, err
+	}
+	return os.SameFile(id.info, info), nil
+}

--- a/internal/fs/lock.go
+++ b/internal/fs/lock.go
@@ -25,6 +25,7 @@ const pathLockDirectoryPrefix = "vaar-locks-"
 type pathLock struct {
 	pathFile   *os.File
 	targetFile *os.File
+	targetLock *os.File
 }
 
 func acquirePathLock(path string) (*pathLock, error) {
@@ -35,6 +36,7 @@ func acquirePathLock(path string) (*pathLock, error) {
 			return nil, fmt.Errorf("resolve lock path %q: %w", path, err)
 		}
 	}
+	key = normalizeLockPath(key)
 
 	lockDirectory, err := pathLockDirectory()
 	if err != nil {
@@ -55,11 +57,11 @@ func acquirePathLock(path string) (*pathLock, error) {
 		return nil, errors.Join(fmt.Errorf("lock path %q: %w", path, err), pathFile.Close())
 	}
 
-	targetFile, err := openTargetLock(path)
+	targetFile, targetLock, err := openTargetLock(path)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("open target lock %q: %w", path, err), unlockAndClose(pathFile))
 	}
-	return &pathLock{pathFile: pathFile, targetFile: targetFile}, nil
+	return &pathLock{pathFile: pathFile, targetFile: targetFile, targetLock: targetLock}, nil
 }
 
 func pathLockDirectory() (string, error) {
@@ -90,6 +92,13 @@ func ensurePrivateLockDir(path string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("lock path is not a directory")
 	}
+	owned, err := lockDirectoryOwnedByCurrentUser(path, info)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return fmt.Errorf("lock directory is not owned by the current user")
+	}
 
 	// Windows does not expose POSIX permission bits through os.FileMode. On
 	// Unix-like systems, remove group/world access even when a directory from a
@@ -107,6 +116,13 @@ func ensurePrivateLockDir(path string) error {
 		}
 		if info.Mode().Perm()&0o077 != 0 {
 			return fmt.Errorf("lock directory is not private")
+		}
+		owned, err := lockDirectoryOwnedByCurrentUser(path, info)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			return fmt.Errorf("lock directory ownership changed while securing it")
 		}
 	}
 	return nil
@@ -160,10 +176,11 @@ func (l *pathLock) release() error {
 	}
 
 	var targetErr error
-	if l.targetFile != nil {
-		targetErr = unlockAndClose(l.targetFile)
-		l.targetFile = nil
+	if l.targetLock != nil {
+		targetErr = unlockAndClose(l.targetLock)
+		l.targetLock = nil
 	}
+	l.targetFile = nil
 
 	var pathErr error
 	if l.pathFile != nil {
@@ -173,25 +190,31 @@ func (l *pathLock) release() error {
 	return errors.Join(targetErr, pathErr)
 }
 
-func openTargetLock(path string) (*os.File, error) {
+func openTargetLock(path string) (targetFile, targetLock *os.File, err error) {
 	var lastErr error
 	for _, flags := range []int{os.O_RDWR, os.O_WRONLY, os.O_RDONLY} {
-		target, err := os.OpenFile(path, flags, 0)
+		target, err := openTargetFile(path, flags)
 		if err == nil {
 			if err := lockFile(target); err != nil {
-				return nil, errors.Join(err, target.Close())
+				lastErr = errors.Join(err, target.Close())
+				continue
 			}
 			if err := verifyTargetLock(path, target); err != nil {
-				return nil, errors.Join(err, unlockAndClose(target))
+				return nil, nil, errors.Join(err, unlockAndClose(target))
 			}
-			return target, nil
+			return target, target, nil
 		}
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, nil, nil
 		}
 		lastErr = err
 	}
-	return nil, lastErr
+
+	identityLock, identityErr := openIdentityTargetLock(path)
+	if identityErr == nil {
+		return nil, identityLock, nil
+	}
+	return nil, nil, errors.Join(lastErr, identityErr)
 }
 
 func verifyTargetLock(path string, target *os.File) error {

--- a/internal/fs/lock.go
+++ b/internal/fs/lock.go
@@ -14,12 +14,14 @@ import (
 	"path/filepath"
 )
 
-// pathLock coordinates Vaar writers for one canonical destination. The lock
-// file lives in the operating system's temporary directory and is deliberately
-// retained after release: removing it while another process is waiting could
-// let a new process create a different inode and bypass the existing lock.
+// pathLock coordinates Vaar writers for one destination. The retained path
+// lock serializes replacement of the same pathname, while the target lock
+// serializes aliases that currently resolve to the same filesystem entry.
+// This two-level lock is needed because atomic replacement changes the target
+// inode behind a pathname.
 type pathLock struct {
-	file *os.File
+	pathFile   *os.File
+	targetFile *os.File
 }
 
 func acquirePathLock(path string) (*pathLock, error) {
@@ -33,24 +35,64 @@ func acquirePathLock(path string) (*pathLock, error) {
 
 	digest := sha256.Sum256([]byte(key))
 	lockPath := filepath.Join(os.TempDir(), "vaar-path-"+hex.EncodeToString(digest[:])+".lock")
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	pathFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o666)
 	if err != nil {
 		return nil, fmt.Errorf("open path lock %q: %w", path, err)
 	}
-
-	if err := lockFile(file); err != nil {
-		return nil, errors.Join(fmt.Errorf("lock path %q: %w", path, err), file.Close())
+	// The lock file contains no data and is retained so waiting processes never
+	// observe an inode split. Explicitly make it reopenable by another
+	// legitimate user of a shared checkout, independent of the creator's umask.
+	if err := pathFile.Chmod(0o666); err != nil {
+		return nil, errors.Join(fmt.Errorf("set path lock permissions %q: %w", path, err), pathFile.Close())
 	}
-	return &pathLock{file: file}, nil
+
+	if err := lockFile(pathFile); err != nil {
+		return nil, errors.Join(fmt.Errorf("lock path %q: %w", path, err), pathFile.Close())
+	}
+
+	targetFile, err := openTargetLock(path)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("open target lock %q: %w", path, err), unlockAndClose(pathFile))
+	}
+	return &pathLock{pathFile: pathFile, targetFile: targetFile}, nil
 }
 
 func (l *pathLock) release() error {
-	if l == nil || l.file == nil {
+	if l == nil {
 		return nil
 	}
 
-	unlockErr := unlockFile(l.file)
-	closeErr := l.file.Close()
-	l.file = nil
-	return errors.Join(unlockErr, closeErr)
+	var targetErr error
+	if l.targetFile != nil {
+		targetErr = unlockAndClose(l.targetFile)
+		l.targetFile = nil
+	}
+
+	var pathErr error
+	if l.pathFile != nil {
+		pathErr = unlockAndClose(l.pathFile)
+		l.pathFile = nil
+	}
+	return errors.Join(targetErr, pathErr)
+}
+
+func openTargetLock(path string) (*os.File, error) {
+	target, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if err := lockFile(target); err != nil {
+		return nil, errors.Join(err, target.Close())
+	}
+	return target, nil
+}
+
+func unlockAndClose(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	return errors.Join(unlockFile(file), file.Close())
 }

--- a/internal/fs/lock.go
+++ b/internal/fs/lock.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// pathLock coordinates Vaar writers for one canonical destination. The lock
+// file lives in the operating system's temporary directory and is deliberately
+// retained after release: removing it while another process is waiting could
+// let a new process create a different inode and bypass the existing lock.
+type pathLock struct {
+	file *os.File
+}
+
+func acquirePathLock(path string) (*pathLock, error) {
+	key, err := CanonicalPath(path)
+	if err != nil {
+		key, err = filepath.Abs(path)
+		if err != nil {
+			return nil, fmt.Errorf("resolve lock path %q: %w", path, err)
+		}
+	}
+
+	digest := sha256.Sum256([]byte(key))
+	lockPath := filepath.Join(os.TempDir(), "vaar-path-"+hex.EncodeToString(digest[:])+".lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open path lock %q: %w", path, err)
+	}
+
+	if err := lockFile(file); err != nil {
+		return nil, errors.Join(fmt.Errorf("lock path %q: %w", path, err), file.Close())
+	}
+	return &pathLock{file: file}, nil
+}
+
+func (l *pathLock) release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+
+	unlockErr := unlockFile(l.file)
+	closeErr := l.file.Close()
+	l.file = nil
+	return errors.Join(unlockErr, closeErr)
+}

--- a/internal/fs/lock.go
+++ b/internal/fs/lock.go
@@ -65,15 +65,18 @@ func acquirePathLock(path string) (*pathLock, error) {
 }
 
 func pathLockDirectory() (string, error) {
-	ownerPath, err := os.UserCacheDir()
+	ownerKey, err := os.UserCacheDir()
 	if err != nil {
-		ownerPath, err = os.UserHomeDir()
+		ownerKey, err = os.UserHomeDir()
 		if err != nil {
-			return "", fmt.Errorf("resolve per-user lock namespace: %w", err)
+			ownerKey, err = fallbackLockNamespace()
+			if err != nil {
+				return "", fmt.Errorf("resolve per-user lock namespace: %w", err)
+			}
 		}
 	}
 
-	digest := sha256.Sum256([]byte(filepath.Clean(ownerPath)))
+	digest := sha256.Sum256([]byte(filepath.Clean(ownerKey)))
 	return filepath.Join(os.TempDir(), pathLockDirectoryPrefix+hex.EncodeToString(digest[:])), nil
 }
 
@@ -103,7 +106,7 @@ func ensurePrivateLockDir(path string) error {
 	// Windows does not expose POSIX permission bits through os.FileMode. On
 	// Unix-like systems, remove group/world access even when a directory from a
 	// previous process already exists.
-	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
 		if err := os.Chmod(path, 0o700); err != nil {
 			return err
 		}
@@ -114,7 +117,7 @@ func ensurePrivateLockDir(path string) error {
 		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 			return fmt.Errorf("lock directory changed while securing it")
 		}
-		if info.Mode().Perm()&0o077 != 0 {
+		if info.Mode().Perm() != 0o700 {
 			return fmt.Errorf("lock directory is not private")
 		}
 		owned, err := lockDirectoryOwnedByCurrentUser(path, info)

--- a/internal/fs/lock.go
+++ b/internal/fs/lock.go
@@ -12,13 +12,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
+const pathLockDirectoryPrefix = "vaar-locks-"
+
 // pathLock coordinates Vaar writers for one destination. The retained path
-// lock serializes replacement of the same pathname, while the target lock
-// serializes aliases that currently resolve to the same filesystem entry.
-// This two-level lock is needed because atomic replacement changes the target
-// inode behind a pathname.
+// lock serializes replacement of the same pathname within the current user's
+// lock namespace, while the target lock serializes aliases that currently
+// resolve to the same filesystem entry. This two-level lock is needed because
+// atomic replacement changes the target inode behind a pathname.
 type pathLock struct {
 	pathFile   *os.File
 	targetFile *os.File
@@ -33,17 +36,19 @@ func acquirePathLock(path string) (*pathLock, error) {
 		}
 	}
 
+	lockDirectory, err := pathLockDirectory()
+	if err != nil {
+		return nil, fmt.Errorf("resolve path lock directory: %w", err)
+	}
+	if err := ensurePrivateLockDir(lockDirectory); err != nil {
+		return nil, fmt.Errorf("prepare path lock directory %q: %w", lockDirectory, err)
+	}
+
 	digest := sha256.Sum256([]byte(key))
-	lockPath := filepath.Join(os.TempDir(), "vaar-path-"+hex.EncodeToString(digest[:])+".lock")
-	pathFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o666)
+	lockPath := filepath.Join(lockDirectory, "vaar-path-"+hex.EncodeToString(digest[:])+".lock")
+	pathFile, err := openPathLock(lockPath)
 	if err != nil {
 		return nil, fmt.Errorf("open path lock %q: %w", path, err)
-	}
-	// The lock file contains no data and is retained so waiting processes never
-	// observe an inode split. Explicitly make it reopenable by another
-	// legitimate user of a shared checkout, independent of the creator's umask.
-	if err := pathFile.Chmod(0o666); err != nil {
-		return nil, errors.Join(fmt.Errorf("set path lock permissions %q: %w", path, err), pathFile.Close())
 	}
 
 	if err := lockFile(pathFile); err != nil {
@@ -55,6 +60,98 @@ func acquirePathLock(path string) (*pathLock, error) {
 		return nil, errors.Join(fmt.Errorf("open target lock %q: %w", path, err), unlockAndClose(pathFile))
 	}
 	return &pathLock{pathFile: pathFile, targetFile: targetFile}, nil
+}
+
+func pathLockDirectory() (string, error) {
+	ownerPath, err := os.UserCacheDir()
+	if err != nil {
+		ownerPath, err = os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve per-user lock namespace: %w", err)
+		}
+	}
+
+	digest := sha256.Sum256([]byte(filepath.Clean(ownerPath)))
+	return filepath.Join(os.TempDir(), pathLockDirectoryPrefix+hex.EncodeToString(digest[:])), nil
+}
+
+func ensurePrivateLockDir(path string) error {
+	if err := os.Mkdir(path, 0o700); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("lock directory is a symlink")
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("lock path is not a directory")
+	}
+
+	// Windows does not expose POSIX permission bits through os.FileMode. On
+	// Unix-like systems, remove group/world access even when a directory from a
+	// previous process already exists.
+	if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		if err := os.Chmod(path, 0o700); err != nil {
+			return err
+		}
+		info, err = os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("lock directory changed while securing it")
+		}
+		if info.Mode().Perm()&0o077 != 0 {
+			return fmt.Errorf("lock directory is not private")
+		}
+	}
+	return nil
+}
+
+func openPathLock(path string) (*os.File, error) {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("lock path is a symlink")
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("lock path is not a regular file")
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	// O_EXCL handles the first-creation race. If another process already
+	// created the retained lock file, validate it with Lstat before reopening.
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		if !os.IsExist(err) {
+			return nil, err
+		}
+
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return nil, statErr
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("lock path is a symlink")
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("lock path is not a regular file")
+		}
+
+		file, err = os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if err := file.Chmod(0o600); err != nil {
+		return nil, errors.Join(err, file.Close())
+	}
+	return file, nil
 }
 
 func (l *pathLock) release() error {
@@ -77,17 +174,39 @@ func (l *pathLock) release() error {
 }
 
 func openTargetLock(path string) (*os.File, error) {
-	target, err := os.Open(path)
-	if err != nil {
+	var lastErr error
+	for _, flags := range []int{os.O_RDWR, os.O_WRONLY, os.O_RDONLY} {
+		target, err := os.OpenFile(path, flags, 0)
+		if err == nil {
+			if err := lockFile(target); err != nil {
+				return nil, errors.Join(err, target.Close())
+			}
+			if err := verifyTargetLock(path, target); err != nil {
+				return nil, errors.Join(err, unlockAndClose(target))
+			}
+			return target, nil
+		}
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, err
+		lastErr = err
 	}
-	if err := lockFile(target); err != nil {
-		return nil, errors.Join(err, target.Close())
+	return nil, lastErr
+}
+
+func verifyTargetLock(path string, target *os.File) error {
+	current, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat target after locking: %w", err)
 	}
-	return target, nil
+	targetInfo, err := target.Stat()
+	if err != nil {
+		return fmt.Errorf("stat locked target: %w", err)
+	}
+	if !os.SameFile(current, targetInfo) {
+		return fmt.Errorf("target changed while acquiring lock")
+	}
+	return nil
 }
 
 func unlockAndClose(file *os.File) error {

--- a/internal/fs/lock_case_insensitive_test.go
+++ b/internal/fs/lock_case_insensitive_test.go
@@ -1,0 +1,50 @@
+//go:build darwin || windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAcquirePathLockSerializesCaseVariantsForMissingDestination(t *testing.T) {
+	root := t.TempDir()
+	first, err := acquirePathLock(filepath.Join(root, ".env"))
+	if err != nil {
+		t.Fatalf("acquire first path lock failed: %v", err)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		second, err := acquirePathLock(filepath.Join(root, ".ENV"))
+		if err == nil {
+			err = second.release()
+		}
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("case-variant path lock acquired early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := first.release(); err != nil {
+		t.Fatalf("release first path lock failed: %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("case-variant path lock failed after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("case-variant path lock did not acquire after release")
+	}
+}

--- a/internal/fs/lock_fcntl.go
+++ b/internal/fs/lock_fcntl.go
@@ -1,0 +1,25 @@
+//go:build aix || (solaris && !illumos)
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLKW, &syscall.Flock_t{
+		Type: syscall.F_WRLCK,
+	})
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, &syscall.Flock_t{
+		Type: syscall.F_UNLCK,
+	})
+}

--- a/internal/fs/lock_fcntl.go
+++ b/internal/fs/lock_fcntl.go
@@ -8,18 +8,109 @@ SPDX-License-Identifier: Apache-2.0
 package fs
 
 import (
+	"fmt"
 	"os"
+	"sync"
 	"syscall"
 )
 
+type fcntlProcessLock struct {
+	key   string
+	state *fcntlProcessLockState
+}
+
+type fcntlProcessLockState struct {
+	mu   sync.Mutex
+	refs int
+}
+
+var fcntlProcessLocks = struct {
+	sync.Mutex
+	locks map[string]*fcntlProcessLockState
+	owned map[*os.File]*fcntlProcessLock
+}{
+	locks: make(map[string]*fcntlProcessLockState),
+	owned: make(map[*os.File]*fcntlProcessLock),
+}
+
+func fcntlInfoKey(info os.FileInfo) (string, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("file has unsupported identity metadata")
+	}
+	return fmt.Sprintf("%T:%d:%d", stat, stat.Dev, stat.Ino), nil
+}
+
+func acquireFcntlProcessLock(file *os.File) (*fcntlProcessLock, error) {
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	key, err := fcntlInfoKey(info)
+	if err != nil {
+		return nil, err
+	}
+
+	fcntlProcessLocks.Lock()
+	state := fcntlProcessLocks.locks[key]
+	if state == nil {
+		state = &fcntlProcessLockState{}
+		fcntlProcessLocks.locks[key] = state
+	}
+	state.refs++
+	fcntlProcessLocks.Unlock()
+
+	state.mu.Lock()
+	return &fcntlProcessLock{key: key, state: state}, nil
+}
+
+func releaseFcntlProcessLock(file *os.File, held *fcntlProcessLock) {
+	held.state.mu.Unlock()
+
+	fcntlProcessLocks.Lock()
+	delete(fcntlProcessLocks.owned, file)
+	held.state.refs--
+	if held.state.refs == 0 {
+		delete(fcntlProcessLocks.locks, held.key)
+	}
+	fcntlProcessLocks.Unlock()
+}
+
 func lockFile(file *os.File) error {
-	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLKW, &syscall.Flock_t{
+	held, err := acquireFcntlProcessLock(file)
+	if err != nil {
+		return err
+	}
+
+	if err := syscall.FcntlFlock(file.Fd(), syscall.F_SETLKW, &syscall.Flock_t{
 		Type: syscall.F_WRLCK,
-	})
+	}); err != nil {
+		held.state.mu.Unlock()
+		fcntlProcessLocks.Lock()
+		held.state.refs--
+		if held.state.refs == 0 {
+			delete(fcntlProcessLocks.locks, held.key)
+		}
+		fcntlProcessLocks.Unlock()
+		return err
+	}
+
+	fcntlProcessLocks.Lock()
+	fcntlProcessLocks.owned[file] = held
+	fcntlProcessLocks.Unlock()
+	return nil
 }
 
 func unlockFile(file *os.File) error {
-	return syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, &syscall.Flock_t{
+	err := syscall.FcntlFlock(file.Fd(), syscall.F_SETLK, &syscall.Flock_t{
 		Type: syscall.F_UNLCK,
 	})
+
+	fcntlProcessLocks.Lock()
+	held := fcntlProcessLocks.owned[file]
+	fcntlProcessLocks.Unlock()
+	if held != nil {
+		releaseFcntlProcessLock(file, held)
+	}
+	return err
 }

--- a/internal/fs/lock_fcntl_test.go
+++ b/internal/fs/lock_fcntl_test.go
@@ -1,0 +1,96 @@
+//go:build aix || (solaris && !illumos)
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFcntlLocksSerializeGoroutinesInOneProcess(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "lock-target")
+	if err := os.WriteFile(path, []byte("content"), 0o600); err != nil {
+		t.Fatalf("create lock target failed: %v", err)
+	}
+
+	first, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open first descriptor failed: %v", err)
+	}
+	defer first.Close()
+	second, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open second descriptor failed: %v", err)
+	}
+	defer second.Close()
+
+	if err := lockFile(first); err != nil {
+		t.Fatalf("lock first descriptor failed: %v", err)
+	}
+
+	started := make(chan struct{})
+	acquired := make(chan error, 1)
+	go func() {
+		close(started)
+		if err := lockFile(second); err != nil {
+			acquired <- err
+			return
+		}
+		acquired <- unlockFile(second)
+	}()
+	<-started
+
+	select {
+	case err := <-acquired:
+		t.Fatalf("second descriptor acquired process lock early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := unlockFile(first); err != nil {
+		t.Fatalf("unlock first descriptor failed: %v", err)
+	}
+
+	select {
+	case err := <-acquired:
+		if err != nil {
+			t.Fatalf("second descriptor failed after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second descriptor did not acquire process lock after release")
+	}
+}
+
+func TestOpenTargetLockUsesIdentityLockForReadOnlyDestination(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "read-only-target")
+	if err := os.WriteFile(path, []byte("content"), 0o444); err != nil {
+		t.Fatalf("create read-only target failed: %v", err)
+	}
+
+	probe, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err == nil {
+		_ = probe.Close()
+		t.Skip("test environment can open read-only files for writing")
+	}
+
+	target, targetLock, err := openTargetLock(path)
+	if err != nil {
+		t.Fatalf("open target lock failed: %v", err)
+	}
+	if target != nil {
+		_ = target.Close()
+		t.Fatal("read-only destination returned a writable target descriptor")
+	}
+	if targetLock == nil {
+		t.Fatal("read-only destination did not receive an identity lock")
+	}
+	if err := unlockAndClose(targetLock); err != nil {
+		t.Fatalf("release identity lock failed: %v", err)
+	}
+}

--- a/internal/fs/lock_identity_fcntl.go
+++ b/internal/fs/lock_identity_fcntl.go
@@ -1,0 +1,55 @@
+//go:build aix || (solaris && !illumos)
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func openIdentityTargetLock(path string) (*os.File, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	key, err := fcntlInfoKey(info)
+	if err != nil {
+		return nil, err
+	}
+
+	lockDirectory, err := pathLockDirectory()
+	if err != nil {
+		return nil, fmt.Errorf("resolve target lock directory: %w", err)
+	}
+	if err := ensurePrivateLockDir(lockDirectory); err != nil {
+		return nil, fmt.Errorf("prepare target lock directory %q: %w", lockDirectory, err)
+	}
+
+	digest := sha256.Sum256([]byte(key))
+	lockPath := filepath.Join(lockDirectory, "vaar-target-"+hex.EncodeToString(digest[:])+".lock")
+	lock, err := openPathLock(lockPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockFile(lock); err != nil {
+		return nil, errors.Join(err, lock.Close())
+	}
+
+	current, err := os.Stat(path)
+	if err != nil {
+		return nil, errors.Join(err, unlockAndClose(lock))
+	}
+	if !os.SameFile(info, current) {
+		return nil, errors.Join(fmt.Errorf("target changed while acquiring identity lock"), unlockAndClose(lock))
+	}
+	return lock, nil
+}

--- a/internal/fs/lock_identity_other.go
+++ b/internal/fs/lock_identity_other.go
@@ -1,0 +1,17 @@
+//go:build !aix && (!solaris || illumos)
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"errors"
+	"os"
+)
+
+func openIdentityTargetLock(string) (*os.File, error) {
+	return nil, errors.ErrUnsupported
+}

--- a/internal/fs/lock_key_case_insensitive.go
+++ b/internal/fs/lock_key_case_insensitive.go
@@ -1,0 +1,18 @@
+//go:build darwin || windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import "strings"
+
+// normalizeLockPath applies the path-name equivalence used by the default
+// case-insensitive filesystems on macOS and Windows. Lower-casing a missing
+// destination is necessary because there is no filesystem entry for
+// CanonicalPath to resolve yet.
+func normalizeLockPath(path string) string {
+	return strings.ToLower(path)
+}

--- a/internal/fs/lock_key_case_sensitive.go
+++ b/internal/fs/lock_key_case_sensitive.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+func normalizeLockPath(path string) string {
+	return path
+}

--- a/internal/fs/lock_namespace_other.go
+++ b/internal/fs/lock_namespace_other.go
@@ -7,11 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 
 package fs
 
-import (
-	"errors"
-	"os"
-)
+import "runtime"
 
-func lockFile(*os.File) error { return errors.ErrUnsupported }
-
-func unlockFile(*os.File) error { return errors.ErrUnsupported }
+func fallbackLockNamespace() (string, error) {
+	return "platform:" + runtime.GOOS, nil
+}

--- a/internal/fs/lock_namespace_unix.go
+++ b/internal/fs/lock_namespace_unix.go
@@ -1,0 +1,17 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os"
+)
+
+func fallbackLockNamespace() (string, error) {
+	return fmt.Sprintf("uid:%d", os.Geteuid()), nil
+}

--- a/internal/fs/lock_namespace_windows.go
+++ b/internal/fs/lock_namespace_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+func fallbackLockNamespace() (string, error) {
+	sid, err := currentProcessUserSID()
+	if err != nil {
+		return "", err
+	}
+	value, err := sid.String()
+	if err != nil {
+		return "", err
+	}
+	return "sid:" + value, nil
+}

--- a/internal/fs/lock_open_nonwindows.go
+++ b/internal/fs/lock_open_nonwindows.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import "os"
+
+func openTargetFile(path string, flags int) (*os.File, error) {
+	return os.OpenFile(path, flags, 0)
+}

--- a/internal/fs/lock_other.go
+++ b/internal/fs/lock_other.go
@@ -7,8 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package fs
 
-import "os"
+import (
+	"errors"
+	"os"
+)
 
-func lockFile(*os.File) error { return nil }
+func lockFile(*os.File) error { return errors.ErrUnsupported }
 
-func unlockFile(*os.File) error { return nil }
+func unlockFile(*os.File) error { return errors.ErrUnsupported }

--- a/internal/fs/lock_other.go
+++ b/internal/fs/lock_other.go
@@ -1,0 +1,14 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import "os"
+
+func lockFile(*os.File) error { return nil }
+
+func unlockFile(*os.File) error { return nil }

--- a/internal/fs/lock_other_test.go
+++ b/internal/fs/lock_other_test.go
@@ -1,0 +1,29 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestLockFileReportsUnsupportedPlatform(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "lock-")
+	if err != nil {
+		t.Fatalf("create lock fixture failed: %v", err)
+	}
+	defer file.Close()
+
+	if err := lockFile(file); !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("lockFile error = %v, want errors.ErrUnsupported", err)
+	}
+	if err := unlockFile(file); !errors.Is(err, errors.ErrUnsupported) {
+		t.Fatalf("unlockFile error = %v, want errors.ErrUnsupported", err)
+	}
+}

--- a/internal/fs/lock_owner_other.go
+++ b/internal/fs/lock_owner_other.go
@@ -1,0 +1,17 @@
+//go:build !aix && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import "os"
+
+func lockDirectoryOwnedByCurrentUser(string, os.FileInfo) (bool, error) {
+	// These platforms do not expose a portable ownership representation in
+	// the standard library. The directory remains protected by its private
+	// namespace and the platform's normal filesystem permission checks.
+	return true, nil
+}

--- a/internal/fs/lock_owner_unix.go
+++ b/internal/fs/lock_owner_unix.go
@@ -1,0 +1,22 @@
+//go:build aix || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func lockDirectoryOwnedByCurrentUser(_ string, info os.FileInfo) (bool, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false, fmt.Errorf("lock directory has unsupported ownership metadata")
+	}
+	return stat.Uid == uint32(os.Geteuid()), nil
+}

--- a/internal/fs/lock_owner_windows.go
+++ b/internal/fs/lock_owner_windows.go
@@ -169,7 +169,7 @@ func verifyLockDirectoryDACL(descriptor []byte, userSID *syscall.SID) error {
 		return err
 	}
 	for index := uint32(0); index < size.aceCount; index++ {
-		var ace uintptr
+		var ace *byte
 		r1, _, err = getACEProc.Call(
 			dacl,
 			uintptr(index),
@@ -178,11 +178,11 @@ func verifyLockDirectoryDACL(descriptor []byte, userSID *syscall.SID) error {
 		if r1 == 0 {
 			return err
 		}
-		if ace == 0 {
+		if ace == nil {
 			return fmt.Errorf("lock directory DACL contains a nil ACE")
 		}
 
-		aceType := *(*byte)(unsafe.Pointer(ace))
+		aceType := *ace
 		switch aceType {
 		case accessDeniedACEType, accessDeniedCallbackACEType, accessDeniedObjectACEType, accessDeniedCallbackObjectACEType:
 			continue
@@ -190,11 +190,11 @@ func verifyLockDirectoryDACL(descriptor []byte, userSID *syscall.SID) error {
 		default:
 			return fmt.Errorf("lock directory DACL contains unsupported ACE type %d", aceType)
 		}
-		mask := *(*uint32)(unsafe.Pointer(ace + 4))
+		mask := *(*uint32)(unsafe.Add(unsafe.Pointer(ace), 4))
 		if mask&lockDirectoryWriteMask == 0 {
 			continue
 		}
-		aceSID := (*syscall.SID)(unsafe.Pointer(ace + 8))
+		aceSID := (*syscall.SID)(unsafe.Add(unsafe.Pointer(ace), 8))
 		if !sidMatchesAny(aceSID, allowedSIDs) {
 			return fmt.Errorf("lock directory DACL grants write access to an unauthorized principal")
 		}

--- a/internal/fs/lock_owner_windows.go
+++ b/internal/fs/lock_owner_windows.go
@@ -14,12 +14,40 @@ import (
 	"unsafe"
 )
 
-const ownerSecurityInformation = 0x00000001
+const (
+	ownerSecurityInformation          = 0x00000001
+	daclSecurityInformation           = 0x00000004
+	securityInformation               = ownerSecurityInformation | daclSecurityInformation
+	aclInformationSize                = 2
+	accessAllowedACEType              = 0
+	accessDeniedACEType               = 1
+	accessDeniedCallbackACEType       = 3
+	accessDeniedObjectACEType         = 6
+	accessDeniedCallbackObjectACEType = 7
+	lockDirectoryWriteMask            = 0x00000002 | // FILE_ADD_FILE
+		0x00000004 | // FILE_ADD_SUBDIRECTORY
+		0x00000010 | // FILE_WRITE_EA
+		0x00000040 | // FILE_DELETE_CHILD
+		0x00010000 | // DELETE
+		0x00040000 | // WRITE_DAC
+		0x00080000 | // WRITE_OWNER
+		0x10000000 | // GENERIC_ALL
+		0x40000000 // GENERIC_WRITE
+)
+
+type aclSizeInformation struct {
+	aceCount     uint32
+	aclBytesUsed uint32
+	aclBytesFree uint32
+}
 
 var (
 	advapi32                       = syscall.NewLazyDLL("advapi32.dll")
 	getFileSecurityProc            = advapi32.NewProc("GetFileSecurityW")
 	getSecurityDescriptorOwnerProc = advapi32.NewProc("GetSecurityDescriptorOwner")
+	getSecurityDescriptorDACLProc  = advapi32.NewProc("GetSecurityDescriptorDacl")
+	getACLInformationProc          = advapi32.NewProc("GetAclInformation")
+	getACEProc                     = advapi32.NewProc("GetAce")
 	equalSidProc                   = advapi32.NewProc("EqualSid")
 )
 
@@ -28,6 +56,19 @@ var (
 // Windows owner, so the security descriptor API is used instead.
 func lockDirectoryOwnedByCurrentUser(path string, _ os.FileInfo) (bool, error) {
 	return windowsPathOwnedByCurrentUser(path)
+}
+
+func currentProcessUserSID() (*syscall.SID, error) {
+	token, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return nil, err
+	}
+	defer token.Close()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return nil, err
+	}
+	return user.User.Sid, nil
 }
 
 func windowsPathOwnedByCurrentUser(path string) (bool, error) {
@@ -39,7 +80,7 @@ func windowsPathOwnedByCurrentUser(path string) (bool, error) {
 	var needed uint32
 	r1, _, firstErr := getFileSecurityProc.Call(
 		uintptr(unsafe.Pointer(name)),
-		ownerSecurityInformation,
+		securityInformation,
 		0,
 		0,
 		uintptr(unsafe.Pointer(&needed)),
@@ -54,7 +95,7 @@ func windowsPathOwnedByCurrentUser(path string) (bool, error) {
 	descriptor := make([]byte, needed)
 	r1, _, err = getFileSecurityProc.Call(
 		uintptr(unsafe.Pointer(name)),
-		ownerSecurityInformation,
+		securityInformation,
 		uintptr(unsafe.Pointer(&descriptor[0])),
 		uintptr(len(descriptor)),
 		uintptr(unsafe.Pointer(&needed)),
@@ -77,19 +118,111 @@ func windowsPathOwnedByCurrentUser(path string) (bool, error) {
 		return false, fmt.Errorf("security descriptor has no owner")
 	}
 
-	token, err := syscall.OpenCurrentProcessToken()
-	if err != nil {
-		return false, err
-	}
-	defer token.Close()
-	user, err := token.GetTokenUser()
+	userSID, err := currentProcessUserSID()
 	if err != nil {
 		return false, err
 	}
 
 	equal, _, _ := equalSidProc.Call(
 		uintptr(unsafe.Pointer(owner)),
-		uintptr(unsafe.Pointer(user.User.Sid)),
+		uintptr(unsafe.Pointer(userSID)),
 	)
-	return equal != 0, nil
+	if equal == 0 {
+		return false, nil
+	}
+	if err := verifyLockDirectoryDACL(descriptor, userSID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func verifyLockDirectoryDACL(descriptor []byte, userSID *syscall.SID) error {
+	var present int32
+	var dacl uintptr
+	var daclDefaulted int32
+	r1, _, err := getSecurityDescriptorDACLProc.Call(
+		uintptr(unsafe.Pointer(&descriptor[0])),
+		uintptr(unsafe.Pointer(&present)),
+		uintptr(unsafe.Pointer(&dacl)),
+		uintptr(unsafe.Pointer(&daclDefaulted)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	if present == 0 || dacl == 0 {
+		return fmt.Errorf("lock directory has an unrestricted DACL")
+	}
+
+	var size aclSizeInformation
+	r1, _, err = getACLInformationProc.Call(
+		dacl,
+		uintptr(unsafe.Pointer(&size)),
+		uintptr(unsafe.Sizeof(size)),
+		aclInformationSize,
+	)
+	if r1 == 0 {
+		return err
+	}
+
+	allowedSIDs, err := lockDirectoryAllowedSIDs(userSID)
+	if err != nil {
+		return err
+	}
+	for index := uint32(0); index < size.aceCount; index++ {
+		var ace uintptr
+		r1, _, err = getACEProc.Call(
+			dacl,
+			uintptr(index),
+			uintptr(unsafe.Pointer(&ace)),
+		)
+		if r1 == 0 {
+			return err
+		}
+		if ace == 0 {
+			return fmt.Errorf("lock directory DACL contains a nil ACE")
+		}
+
+		aceType := *(*byte)(unsafe.Pointer(ace))
+		switch aceType {
+		case accessDeniedACEType, accessDeniedCallbackACEType, accessDeniedObjectACEType, accessDeniedCallbackObjectACEType:
+			continue
+		case accessAllowedACEType:
+		default:
+			return fmt.Errorf("lock directory DACL contains unsupported ACE type %d", aceType)
+		}
+		mask := *(*uint32)(unsafe.Pointer(ace + 4))
+		if mask&lockDirectoryWriteMask == 0 {
+			continue
+		}
+		aceSID := (*syscall.SID)(unsafe.Pointer(ace + 8))
+		if !sidMatchesAny(aceSID, allowedSIDs) {
+			return fmt.Errorf("lock directory DACL grants write access to an unauthorized principal")
+		}
+	}
+	return nil
+}
+
+func lockDirectoryAllowedSIDs(userSID *syscall.SID) ([]*syscall.SID, error) {
+	allowed := []*syscall.SID{userSID}
+	for _, value := range []string{"S-1-5-18", "S-1-5-32-544", "S-1-3-0"} {
+		sid, err := syscall.StringToSid(value)
+		if err != nil {
+			return nil, err
+		}
+		allowed = append(allowed, sid)
+	}
+	return allowed, nil
+}
+
+func sidMatchesAny(candidate *syscall.SID, allowed []*syscall.SID) bool {
+	for _, sid := range allowed {
+		equal, _, _ := equalSidProc.Call(
+			uintptr(unsafe.Pointer(candidate)),
+			uintptr(unsafe.Pointer(sid)),
+		)
+		if equal != 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/fs/lock_owner_windows.go
+++ b/internal/fs/lock_owner_windows.go
@@ -1,0 +1,95 @@
+//go:build windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const ownerSecurityInformation = 0x00000001
+
+var (
+	advapi32                       = syscall.NewLazyDLL("advapi32.dll")
+	getFileSecurityProc            = advapi32.NewProc("GetFileSecurityW")
+	getSecurityDescriptorOwnerProc = advapi32.NewProc("GetSecurityDescriptorOwner")
+	equalSidProc                   = advapi32.NewProc("EqualSid")
+)
+
+// lockDirectoryOwnedByCurrentUser verifies the Windows security descriptor
+// owner against the current process token. os.FileInfo does not carry a
+// Windows owner, so the security descriptor API is used instead.
+func lockDirectoryOwnedByCurrentUser(path string, _ os.FileInfo) (bool, error) {
+	return windowsPathOwnedByCurrentUser(path)
+}
+
+func windowsPathOwnedByCurrentUser(path string) (bool, error) {
+	name, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return false, err
+	}
+
+	var needed uint32
+	r1, _, firstErr := getFileSecurityProc.Call(
+		uintptr(unsafe.Pointer(name)),
+		ownerSecurityInformation,
+		0,
+		0,
+		uintptr(unsafe.Pointer(&needed)),
+	)
+	if r1 != 0 {
+		return false, fmt.Errorf("unexpected security descriptor query result")
+	}
+	if needed == 0 {
+		return false, firstErr
+	}
+
+	descriptor := make([]byte, needed)
+	r1, _, err = getFileSecurityProc.Call(
+		uintptr(unsafe.Pointer(name)),
+		ownerSecurityInformation,
+		uintptr(unsafe.Pointer(&descriptor[0])),
+		uintptr(len(descriptor)),
+		uintptr(unsafe.Pointer(&needed)),
+	)
+	if r1 == 0 {
+		return false, err
+	}
+
+	var owner *syscall.SID
+	var ownerDefaulted int32
+	r1, _, err = getSecurityDescriptorOwnerProc.Call(
+		uintptr(unsafe.Pointer(&descriptor[0])),
+		uintptr(unsafe.Pointer(&owner)),
+		uintptr(unsafe.Pointer(&ownerDefaulted)),
+	)
+	if r1 == 0 {
+		return false, err
+	}
+	if owner == nil {
+		return false, fmt.Errorf("security descriptor has no owner")
+	}
+
+	token, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return false, err
+	}
+	defer token.Close()
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return false, err
+	}
+
+	equal, _, _ := equalSidProc.Call(
+		uintptr(unsafe.Pointer(owner)),
+		uintptr(unsafe.Pointer(user.User.Sid)),
+	)
+	return equal != 0, nil
+}

--- a/internal/fs/lock_security_test.go
+++ b/internal/fs/lock_security_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +71,10 @@ func TestOpenPathLockRejectsPreexistingSymlink(t *testing.T) {
 }
 
 func TestVerifyTargetLockRejectsReplacedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not permit replacing an open file")
+	}
+
 	root := t.TempDir()
 	path := filepath.Join(root, "destination")
 	replacement := filepath.Join(root, "replacement")
@@ -91,6 +96,18 @@ func TestVerifyTargetLockRejectsReplacedPath(t *testing.T) {
 
 	if err := verifyTargetLock(path, target); err == nil {
 		t.Fatal("expected replaced path to fail target-lock verification")
+	}
+}
+
+func TestNormalizeLockPathMatchesFilesystemCaseRules(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "CaseSensitive.env")
+	got := normalizeLockPath(path)
+	want := path
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		want = strings.ToLower(path)
+	}
+	if got != want {
+		t.Fatalf("normalized lock path = %q, want %q", got, want)
 	}
 }
 

--- a/internal/fs/lock_security_test.go
+++ b/internal/fs/lock_security_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsurePrivateLockDirCreatesRestrictiveDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vaar-locks")
+
+	if err := ensurePrivateLockDir(path); err != nil {
+		t.Fatalf("ensure private lock directory failed: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("stat lock directory failed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("lock directory is a symlink")
+	}
+	if !info.IsDir() {
+		t.Fatal("lock path is not a directory")
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o700 {
+		got, want := info.Mode().Perm(), os.FileMode(0o700)
+		t.Fatalf("lock directory permissions = %o, want %o", got, want)
+	}
+}
+
+func TestEnsurePrivateLockDirRejectsPreexistingSymlink(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "vaar-locks")
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("create symlink target failed: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	if err := ensurePrivateLockDir(path); err == nil {
+		t.Fatal("expected preexisting lock-directory symlink to be rejected")
+	}
+}
+
+func TestOpenPathLockRejectsPreexistingSymlink(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "lock")
+	target := filepath.Join(root, "target")
+	if err := os.WriteFile(target, nil, 0o600); err != nil {
+		t.Fatalf("create symlink target failed: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	file, err := openPathLock(path)
+	if err == nil {
+		_ = file.Close()
+		t.Fatal("expected preexisting lock-file symlink to be rejected")
+	}
+}
+
+func TestVerifyTargetLockRejectsReplacedPath(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "destination")
+	replacement := filepath.Join(root, "replacement")
+	if err := os.WriteFile(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("create destination failed: %v", err)
+	}
+	if err := os.WriteFile(replacement, []byte("new"), 0o600); err != nil {
+		t.Fatalf("create replacement failed: %v", err)
+	}
+
+	target, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open target failed: %v", err)
+	}
+	defer target.Close()
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatalf("replace destination failed: %v", err)
+	}
+
+	if err := verifyTargetLock(path, target); err == nil {
+		t.Fatal("expected replaced path to fail target-lock verification")
+	}
+}
+
+func TestAcquirePathLockUsesPrivateDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "destination")
+	lock, err := acquirePathLock(path)
+	if err != nil {
+		t.Fatalf("acquire path lock failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lock.release(); err != nil {
+			t.Errorf("release path lock failed: %v", err)
+		}
+	})
+
+	want, err := pathLockDirectory()
+	if err != nil {
+		t.Fatalf("resolve path lock directory failed: %v", err)
+	}
+	if got := filepath.Dir(lock.pathFile.Name()); got != want {
+		t.Fatalf("path lock directory = %q, want %q", got, want)
+	}
+}

--- a/internal/fs/lock_security_test.go
+++ b/internal/fs/lock_security_test.go
@@ -36,6 +36,43 @@ func TestEnsurePrivateLockDirCreatesRestrictiveDirectory(t *testing.T) {
 	}
 }
 
+func TestEnsurePrivateLockDirNormalizesRestrictivePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not portable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "vaar-locks")
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("create lock directory failed: %v", err)
+	}
+	if err := os.Chmod(path, 0); err != nil {
+		t.Fatalf("make lock directory restrictive failed: %v", err)
+	}
+
+	if err := ensurePrivateLockDir(path); err != nil {
+		t.Fatalf("ensure private lock directory failed: %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("stat lock directory failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o700); got != want {
+		t.Fatalf("lock directory permissions = %o, want %o", got, want)
+	}
+}
+
+func TestPathLockDirectoryHasEnvironmentIndependentFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("environment fallback differs on Windows")
+	}
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CACHE_HOME", "")
+
+	if _, err := pathLockDirectory(); err != nil {
+		t.Fatalf("path lock directory failed without home environment: %v", err)
+	}
+}
+
 func TestEnsurePrivateLockDirRejectsPreexistingSymlink(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "vaar-locks")

--- a/internal/fs/lock_test.go
+++ b/internal/fs/lock_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewAtomicFileSerializesPathWriters(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, ".env")
+	if err := os.WriteFile(destination, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write destination failed: %v", err)
+	}
+
+	atomic, err := NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		close(started)
+		result <- WriteFile(destination, []byte("KEY=changed\n"))
+	}()
+	<-started
+
+	select {
+	case err := <-result:
+		t.Fatalf("second writer acquired the path lock early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := atomic.Cleanup(); err != nil {
+		t.Fatalf("cleanup atomic file failed: %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("second writer failed after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second writer did not acquire the path lock after release")
+	}
+
+	data, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("read destination failed: %v", err)
+	}
+	if string(data) != "KEY=changed\n" {
+		t.Fatalf("destination = %q, want changed content", data)
+	}
+}

--- a/internal/fs/lock_test.go
+++ b/internal/fs/lock_test.go
@@ -8,6 +8,7 @@ package fs
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -57,5 +58,53 @@ func TestNewAtomicFileSerializesPathWriters(t *testing.T) {
 	}
 	if string(data) != "KEY=changed\n" {
 		t.Fatalf("destination = %q, want changed content", data)
+	}
+}
+
+func TestNewAtomicFileSerializesHardLinkWriters(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard-link behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	destination := filepath.Join(root, "destination.env")
+	alias := filepath.Join(root, "alias.env")
+	if err := os.WriteFile(destination, []byte("KEY=value\n"), 0o644); err != nil {
+		t.Fatalf("write destination failed: %v", err)
+	}
+	if err := os.Link(destination, alias); err != nil {
+		t.Skipf("hard-link creation is unavailable: %v", err)
+	}
+
+	atomic, err := NewAtomicFile(destination)
+	if err != nil {
+		t.Fatalf("create atomic file failed: %v", err)
+	}
+
+	started := make(chan struct{})
+	result := make(chan error, 1)
+	go func() {
+		close(started)
+		result <- WriteFile(alias, []byte("KEY=changed\n"))
+	}()
+	<-started
+
+	select {
+	case err := <-result:
+		t.Fatalf("hard-link writer acquired the identity lock early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := atomic.Cleanup(); err != nil {
+		t.Fatalf("cleanup atomic file failed: %v", err)
+	}
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("hard-link writer failed after release: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("hard-link writer did not acquire the identity lock after release")
 	}
 }

--- a/internal/fs/lock_unix.go
+++ b/internal/fs/lock_unix.go
@@ -1,0 +1,21 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/internal/fs/lock_unix.go
+++ b/internal/fs/lock_unix.go
@@ -1,4 +1,4 @@
-//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd
 
 /*
 Copyright © 2026 envaar

--- a/internal/fs/lock_windows.go
+++ b/internal/fs/lock_windows.go
@@ -21,6 +21,40 @@ var (
 	unlockFileProc = kernel32.NewProc("UnlockFileEx")
 )
 
+func openTargetFile(path string, flags int) (*os.File, error) {
+	access := uint32(syscall.GENERIC_READ)
+	switch flags & (os.O_WRONLY | os.O_RDWR) {
+	case os.O_WRONLY:
+		access = syscall.GENERIC_WRITE
+	case os.O_RDWR:
+		access = syscall.GENERIC_READ | syscall.GENERIC_WRITE
+	}
+
+	name, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	handle, err := syscall.CreateFile(
+		name,
+		access,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE|syscall.FILE_SHARE_DELETE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	file := os.NewFile(uintptr(handle), path)
+	if file == nil {
+		_ = syscall.CloseHandle(handle)
+		return nil, os.ErrInvalid
+	}
+	return file, nil
+}
+
 func lockFile(file *os.File) error {
 	var overlapped syscall.Overlapped
 	r1, _, err := lockFileExProc.Call(

--- a/internal/fs/lock_windows.go
+++ b/internal/fs/lock_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const lockFileExclusive = 0x00000002
+
+var (
+	kernel32       = syscall.NewLazyDLL("kernel32.dll")
+	lockFileExProc = kernel32.NewProc("LockFileEx")
+	unlockFileProc = kernel32.NewProc("UnlockFileEx")
+)
+
+func lockFile(file *os.File) error {
+	var overlapped syscall.Overlapped
+	r1, _, err := lockFileExProc.Call(
+		file.Fd(),
+		lockFileExclusive,
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped syscall.Overlapped
+	r1, _, err := unlockFileProc.Call(
+		file.Fd(),
+		0,
+		uintptr(^uint32(0)),
+		uintptr(^uint32(0)),
+		uintptr(unsafe.Pointer(&overlapped)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/internal/fs/path_unix_test.go
+++ b/internal/fs/path_unix_test.go
@@ -1,4 +1,4 @@
-//go:build unix
+//go:build unix && !aix && !illumos && !solaris
 
 /*
 Copyright © 2026 envaar

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -5,18 +5,27 @@ SPDX-License-Identifier: Apache-2.0
 
 package fs
 
-import "os"
+import (
+	"errors"
+	"os"
+)
 
 const defaultFileMode os.FileMode = 0o644
 
 // WriteFile writes data to path, preserving the existing permission bits when
-// path already identifies a file. New files use the standard 0644 mode,
-// subject to the process umask.
+// path already identifies a file. It coordinates with AtomicFile writers for
+// the same destination. New files use the standard 0644 mode, subject to the
+// process umask.
 func WriteFile(path string, data []byte) error {
+	lock, err := acquirePathLock(path)
+	if err != nil {
+		return err
+	}
+
 	perm := defaultFileMode
 	if info, err := os.Stat(path); err == nil {
 		perm = info.Mode().Perm()
 	}
 
-	return os.WriteFile(path, data, perm)
+	return errors.Join(os.WriteFile(path, data, perm), lock.release())
 }

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -14,8 +14,8 @@ const defaultFileMode os.FileMode = 0o644
 
 // WriteFile writes data to path, preserving the existing permission bits when
 // path already identifies a file. It coordinates with AtomicFile writers for
-// the same destination. New files use the standard 0644 mode, subject to the
-// process umask.
+// the same pathname and currently resolved target. New files use the standard
+// 0644 mode, subject to the process umask.
 func WriteFile(path string, data []byte) error {
 	lock, err := acquirePathLock(path)
 	if err != nil {

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -7,6 +7,7 @@ package fs
 
 import (
 	"errors"
+	"io"
 	"os"
 )
 
@@ -22,10 +23,33 @@ func WriteFile(path string, data []byte) error {
 		return err
 	}
 
-	perm := defaultFileMode
-	if info, err := os.Stat(path); err == nil {
-		perm = info.Mode().Perm()
+	var writeErr error
+	if lock.targetFile != nil {
+		writeErr = writeLockedTarget(lock.targetFile, data)
+	} else {
+		perm := defaultFileMode
+		if info, err := os.Stat(path); err == nil {
+			perm = info.Mode().Perm()
+		}
+		writeErr = os.WriteFile(path, data, perm)
 	}
 
-	return errors.Join(os.WriteFile(path, data, perm), lock.release())
+	return errors.Join(writeErr, lock.release())
+}
+
+func writeLockedTarget(file *os.File, data []byte) error {
+	if _, err := file.Seek(0, 0); err != nil {
+		return err
+	}
+	if err := file.Truncate(0); err != nil {
+		return err
+	}
+	written, err := file.Write(data)
+	if err != nil {
+		return err
+	}
+	if written != len(data) {
+		return io.ErrShortWrite
+	}
+	return nil
 }

--- a/internal/fs/write.go
+++ b/internal/fs/write.go
@@ -14,9 +14,12 @@ import (
 const defaultFileMode os.FileMode = 0o644
 
 // WriteFile writes data to path, preserving the existing permission bits when
-// path already identifies a file. It coordinates with AtomicFile writers for
-// the same pathname and currently resolved target. New files use the standard
-// 0644 mode, subject to the process umask.
+// path already identifies a file. It coordinates with AtomicFile and other
+// WriteFile writers for the same pathname and currently resolved target. The
+// coordination applies to Vaar writers using these primitives; external
+// processes that ignore the advisory lock contract are outside the
+// stale-state guarantee. New files use the standard 0644 mode, subject to the
+// process umask.
 func WriteFile(path string, data []byte) error {
 	lock, err := acquirePathLock(path)
 	if err != nil {

--- a/internal/fs/write_test.go
+++ b/internal/fs/write_test.go
@@ -77,3 +77,29 @@ func TestWriteFileUsesDefaultModeForNewFiles(t *testing.T) {
 		t.Fatalf("created file contents differ: got %q want %q", got, want)
 	}
 }
+
+func TestWriteFileUpdatesHardLinkTarget(t *testing.T) {
+	root := t.TempDir()
+	destination := filepath.Join(root, "destination.env")
+	alias := filepath.Join(root, "alias.env")
+	if err := os.WriteFile(destination, []byte("old"), 0o644); err != nil {
+		t.Fatalf("write initial file failed: %v", err)
+	}
+	if err := os.Link(destination, alias); err != nil {
+		t.Skipf("hard-link creation is unavailable: %v", err)
+	}
+
+	if err := fs.WriteFile(alias, []byte("new")); err != nil {
+		t.Fatalf("write hard-link alias failed: %v", err)
+	}
+
+	for _, path := range []string{destination, alias} {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %q failed: %v", path, err)
+		}
+		if got, want := string(contents), "new"; got != want {
+			t.Fatalf("contents in %q = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/internal/fs/write_unix_test.go
+++ b/internal/fs/write_unix_test.go
@@ -1,0 +1,38 @@
+//go:build unix
+
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fs_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/envaar/vaar/internal/fs"
+)
+
+func TestWriteFileUpdatesWriteOnlyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "write-only.env")
+	if err := os.WriteFile(path, []byte("old"), 0o200); err != nil {
+		t.Fatalf("write initial file failed: %v", err)
+	}
+	if err := os.Chmod(path, 0o200); err != nil {
+		t.Fatalf("set write-only permissions failed: %v", err)
+	}
+
+	if err := fs.WriteFile(path, []byte("new")); err != nil {
+		t.Fatalf("write write-only file failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o200); got != want {
+		t.Fatalf("file mode = %o, want %o", got, want)
+	}
+}

--- a/internal/mutations/doc.go
+++ b/internal/mutations/doc.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 // fixes. Planning consumes already-loaded source documents and selected rule
 // fix functions without reading or writing the filesystem. Application
 // validates every planned original state before replacing any destination,
-// preserves captured permission bits through atomic replacement, and cleans
-// temporary files.
+// coordinates destination writers through the shared filesystem lock, preserves
+// captured permission bits through atomic replacement, and cleans temporary
+// files.
 //
 // Mutation state may contain source bytes because it belongs to the mutation
 // boundary, not the value-free analysis boundary. This package does not own

--- a/internal/mutations/doc.go
+++ b/internal/mutations/doc.go
@@ -9,7 +9,9 @@ SPDX-License-Identifier: Apache-2.0
 // validates every planned original state before replacing any destination,
 // coordinates destination writers through the shared filesystem lock, preserves
 // captured permission bits through atomic replacement, and cleans temporary
-// files.
+// files. Its stale-state guarantee applies to Vaar-cooperating writers that
+// use the shared filesystem primitives; an independent process that ignores
+// advisory locks is outside this internal API's coordination boundary.
 //
 // Mutation state may contain source bytes because it belongs to the mutation
 // boundary, not the value-free analysis boundary. This package does not own

--- a/internal/mutations/doc.go
+++ b/internal/mutations/doc.go
@@ -1,0 +1,17 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+// Package mutations owns the bounded plan-and-apply pipeline for safe lint
+// fixes. Planning consumes already-loaded source documents and selected rule
+// fix functions without reading or writing the filesystem. Application
+// validates every planned original state before replacing any destination,
+// preserves captured permission bits through atomic replacement, and cleans
+// temporary files.
+//
+// Mutation state may contain source bytes because it belongs to the mutation
+// boundary, not the value-free analysis boundary. This package does not own
+// rule semantics, analysis facts, CLI behavior, output rendering, exit-code
+// mapping, persistent backups, or multi-file rollback.
+package mutations

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -19,12 +19,17 @@ import (
 // Change describes one planned replacement. Original and Replacement are
 // owned by the plan and are never exposed through the plan's backing storage.
 // Mode is the permission state captured when the source document was loaded.
+// The unexported destination and identity fields retain the safe target state
+// required to reject retargeting and duplicate physical destinations.
 type Change struct {
 	SourcePath  string
 	DisplayPath string
 	Original    []byte
 	Replacement []byte
 	Mode        os.FileMode
+
+	destination string
+	identity    fs.FileIdentity
 }
 
 // Plan is an immutable, ordered collection of file replacements. A plan is
@@ -46,6 +51,9 @@ func BuildPlan(documents []sourcedotenv.Document, rules []lint.Rule) (Plan, erro
 		if document.SourcePath == "" {
 			return Plan{}, fmt.Errorf("plan lint fix: document source path is empty")
 		}
+		if document.ResolvedPath == "" || !document.Identity.Valid() {
+			return Plan{}, fmt.Errorf("plan lint fix: document %q has no captured file identity", document.SourcePath)
+		}
 		if _, exists := seen[document.SourcePath]; exists {
 			return Plan{}, fmt.Errorf("plan lint fix: duplicate source path %q", document.SourcePath)
 		}
@@ -63,6 +71,8 @@ func BuildPlan(documents []sourcedotenv.Document, rules []lint.Rule) (Plan, erro
 			Original:    original,
 			Replacement: cloneBytes(replacement),
 			Mode:        document.Mode.Perm(),
+			destination: document.ResolvedPath,
+			identity:    document.Identity,
 		})
 	}
 
@@ -85,46 +95,78 @@ func (p Plan) Changes() []Change {
 	return changes
 }
 
-// Apply resolves source paths through symlinks, validates every planned
-// destination before creating any replacement file, and then acquires the
-// destination writer lock before revalidating each change. The lock is held
-// through temporary-file preparation and a final stale-state validation before
-// atomic replacement. Replacements occur in plan order using same-directory
-// atomic files, with each captured permission mode applied to its temporary
-// file before finalization. It intentionally does not roll back earlier
-// successful replacements if a later replacement fails.
+// Apply resolves and validates every planned destination before creating any
+// replacement file, rejects duplicate physical destinations, and then
+// acquires the destination writer lock before revalidating each change. The
+// lock is held through temporary-file preparation and a final stale-state
+// validation before atomic replacement. Replacements occur in plan order
+// using same-directory atomic files, with each captured permission mode
+// applied to its temporary file before finalization. It intentionally does
+// not roll back earlier successful replacements if a later replacement fails.
 func (p Plan) Apply() error {
-	for _, change := range p.changes {
-		if err := validateChange(change); err != nil {
-			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
-		}
+	prepared, err := prepareChanges(p.changes)
+	if err != nil {
+		return err
 	}
 
-	for _, change := range p.changes {
-		destination, err := resolveDestination(change.SourcePath)
-		if err != nil {
-			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
-		}
-		if err := validateChangeAt(change, destination); err != nil {
-			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
-		}
-		if err := applyChange(change, destination); err != nil {
-			return fmt.Errorf("apply mutation %q: %w", changeLabel(change), err)
+	for _, item := range prepared {
+		if err := applyChange(item.change, item.destination); err != nil {
+			return fmt.Errorf("apply mutation %q: %w", changeLabel(item.change), err)
 		}
 	}
 
 	return nil
 }
 
-func validateChange(change Change) error {
+type preparedChange struct {
+	change      Change
+	destination string
+}
+
+func prepareChanges(changes []Change) ([]preparedChange, error) {
+	prepared := make([]preparedChange, 0, len(changes))
+	for _, change := range changes {
+		item, err := prepareChange(change)
+		if err != nil {
+			return nil, fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
+		}
+		for _, prior := range prepared {
+			if item.destination == prior.destination || item.change.identity.Same(prior.change.identity) {
+				return nil, fmt.Errorf(
+					"validate mutation %q: duplicate destination also selected by %q",
+					changeLabel(change),
+					changeLabel(prior.change),
+				)
+			}
+		}
+		prepared = append(prepared, item)
+	}
+	return prepared, nil
+}
+
+func prepareChange(change Change) (preparedChange, error) {
 	destination, err := resolveDestination(change.SourcePath)
 	if err != nil {
-		return err
+		return preparedChange{}, err
 	}
-	return validateChangeAt(change, destination)
+	if destination != change.destination {
+		return preparedChange{}, fmt.Errorf("source target changed since planning")
+	}
+	if err := validateChangeAt(change, destination); err != nil {
+		return preparedChange{}, err
+	}
+	return preparedChange{change: change, destination: destination}, nil
 }
 
 func validateChangeAt(change Change, destination string) error {
+	matched, err := change.identity.MatchesPath(destination)
+	if err != nil {
+		return fmt.Errorf("check source identity: %w", err)
+	}
+	if !matched {
+		return fmt.Errorf("source file identity changed since planning")
+	}
+
 	current, err := fs.ReadFile(destination)
 	if err != nil {
 		return fmt.Errorf("read destination: %w", err)

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -86,11 +86,13 @@ func (p Plan) Changes() []Change {
 }
 
 // Apply resolves source paths through symlinks, validates every planned
-// destination before creating any replacement file, and then revalidates each
-// destination immediately before replacing it. Replacements occur in plan
-// order using same-directory atomic files, with each captured permission mode
-// applied to its temporary file before finalization. It intentionally does not
-// roll back earlier successful replacements if a later replacement fails.
+// destination before creating any replacement file, and then acquires the
+// destination writer lock before revalidating each change. The lock is held
+// through temporary-file preparation and a final stale-state validation before
+// atomic replacement. Replacements occur in plan order using same-directory
+// atomic files, with each captured permission mode applied to its temporary
+// file before finalization. It intentionally does not roll back earlier
+// successful replacements if a later replacement fails.
 func (p Plan) Apply() error {
 	for _, change := range p.changes {
 		if err := validateChange(change); err != nil {
@@ -160,11 +162,17 @@ func applyChange(change Change, destination string) (err error) {
 		}
 	}()
 
+	if err := validateChangeAt(change, destination); err != nil {
+		return fmt.Errorf("revalidate destination: %w", err)
+	}
 	if _, err := file.Write(change.Replacement); err != nil {
 		return fmt.Errorf("write replacement: %w", err)
 	}
 	if err := file.Chmod(change.Mode); err != nil {
 		return fmt.Errorf("preserve permissions: %w", err)
+	}
+	if err := validateChangeAt(change, destination); err != nil {
+		return fmt.Errorf("revalidate before finalization: %w", err)
 	}
 	if err := file.Finalize(); err != nil {
 		return fmt.Errorf("finalize replacement: %w", err)

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -103,6 +103,9 @@ func (p Plan) Changes() []Change {
 // using same-directory atomic files, with each captured permission mode
 // applied to its temporary file before finalization. It intentionally does
 // not roll back earlier successful replacements if a later replacement fails.
+// The stale-state guarantee covers Vaar-cooperating writers; independent
+// processes that ignore the shared advisory lock are outside this API's
+// coordination boundary.
 func (p Plan) Apply() error {
 	prepared, err := prepareChanges(p.changes)
 	if err != nil {

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -7,6 +7,7 @@ package mutations
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 
@@ -84,11 +85,12 @@ func (p Plan) Changes() []Change {
 	return changes
 }
 
-// Apply validates every planned destination before creating any replacement
-// file. It then replaces changed files in plan order using same-directory
-// atomic files, applying each captured permission mode to its temporary file
-// before finalization. It intentionally does not roll back earlier successful
-// replacements if a later replacement fails.
+// Apply resolves source paths through symlinks, validates every planned
+// destination before creating any replacement file, and then revalidates each
+// destination immediately before replacing it. Replacements occur in plan
+// order using same-directory atomic files, with each captured permission mode
+// applied to its temporary file before finalization. It intentionally does not
+// roll back earlier successful replacements if a later replacement fails.
 func (p Plan) Apply() error {
 	for _, change := range p.changes {
 		if err := validateChange(change); err != nil {
@@ -97,7 +99,14 @@ func (p Plan) Apply() error {
 	}
 
 	for _, change := range p.changes {
-		if err := applyChange(change); err != nil {
+		destination, err := resolveDestination(change.SourcePath)
+		if err != nil {
+			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
+		}
+		if err := validateChangeAt(change, destination); err != nil {
+			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
+		}
+		if err := applyChange(change, destination); err != nil {
 			return fmt.Errorf("apply mutation %q: %w", changeLabel(change), err)
 		}
 	}
@@ -106,7 +115,15 @@ func (p Plan) Apply() error {
 }
 
 func validateChange(change Change) error {
-	current, err := fs.ReadFile(change.SourcePath)
+	destination, err := resolveDestination(change.SourcePath)
+	if err != nil {
+		return err
+	}
+	return validateChangeAt(change, destination)
+}
+
+func validateChangeAt(change Change, destination string) error {
+	current, err := fs.ReadFile(destination)
 	if err != nil {
 		return fmt.Errorf("read destination: %w", err)
 	}
@@ -114,7 +131,7 @@ func validateChange(change Change) error {
 		return fmt.Errorf("destination changed since planning")
 	}
 
-	info, err := os.Stat(change.SourcePath)
+	info, err := os.Stat(destination)
 	if err != nil {
 		return fmt.Errorf("stat destination: %w", err)
 	}
@@ -124,12 +141,24 @@ func validateChange(change Change) error {
 	return nil
 }
 
-func applyChange(change Change) error {
-	file, err := fs.NewAtomicFile(change.SourcePath)
+func resolveDestination(sourcePath string) (string, error) {
+	destination, err := fs.CanonicalPath(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("resolve destination: %w", err)
+	}
+	return destination, nil
+}
+
+func applyChange(change Change, destination string) (err error) {
+	file, err := fs.NewAtomicFile(destination)
 	if err != nil {
 		return fmt.Errorf("create atomic replacement: %w", err)
 	}
-	defer func() { _ = file.Cleanup() }()
+	defer func() {
+		if cleanupErr := file.Cleanup(); cleanupErr != nil {
+			err = errors.Join(err, fmt.Errorf("cleanup temporary replacement: %w", cleanupErr))
+		}
+	}()
 
 	if _, err := file.Write(change.Replacement); err != nil {
 		return fmt.Errorf("write replacement: %w", err)

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -1,0 +1,160 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mutations
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/envaar/vaar/internal/fs"
+	"github.com/envaar/vaar/internal/lint"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+// Change describes one planned replacement. Original and Replacement are
+// owned by the plan and are never exposed through the plan's backing storage.
+// Mode is the permission state captured when the source document was loaded.
+type Change struct {
+	SourcePath  string
+	DisplayPath string
+	Original    []byte
+	Replacement []byte
+	Mode        os.FileMode
+}
+
+// Plan is an immutable, ordered collection of file replacements. A plan is
+// created from already-loaded source documents and performs no filesystem I/O
+// until Apply is called.
+type Plan struct {
+	changes []Change
+}
+
+// BuildPlan composes the selected rule fixes over each loaded document and
+// returns only files whose replacement bytes differ from their original bytes.
+// Documents remain in caller-provided order, and all planned byte slices are
+// copied into plan-owned storage.
+func BuildPlan(documents []sourcedotenv.Document, rules []lint.Rule) (Plan, error) {
+	changes := make([]Change, 0, len(documents))
+	seen := make(map[string]struct{}, len(documents))
+
+	for _, document := range documents {
+		if document.SourcePath == "" {
+			return Plan{}, fmt.Errorf("plan lint fix: document source path is empty")
+		}
+		if _, exists := seen[document.SourcePath]; exists {
+			return Plan{}, fmt.Errorf("plan lint fix: duplicate source path %q", document.SourcePath)
+		}
+		seen[document.SourcePath] = struct{}{}
+
+		original := cloneBytes(document.Original)
+		replacement := lint.FixData(rules, cloneBytes(original))
+		if bytes.Equal(replacement, original) {
+			continue
+		}
+
+		changes = append(changes, Change{
+			SourcePath:  document.SourcePath,
+			DisplayPath: document.Path,
+			Original:    original,
+			Replacement: cloneBytes(replacement),
+			Mode:        document.Mode.Perm(),
+		})
+	}
+
+	return Plan{changes: changes}, nil
+}
+
+// Changes returns a deep copy of the ordered planned replacements. An empty
+// plan returns a non-nil empty slice.
+func (p Plan) Changes() []Change {
+	changes := make([]Change, len(p.changes))
+	for i, change := range p.changes {
+		changes[i] = Change{
+			SourcePath:  change.SourcePath,
+			DisplayPath: change.DisplayPath,
+			Original:    cloneBytes(change.Original),
+			Replacement: cloneBytes(change.Replacement),
+			Mode:        change.Mode,
+		}
+	}
+	return changes
+}
+
+// Apply validates every planned destination before creating any replacement
+// file. It then replaces changed files in plan order using same-directory
+// atomic files, applying each captured permission mode to its temporary file
+// before finalization. It intentionally does not roll back earlier successful
+// replacements if a later replacement fails.
+func (p Plan) Apply() error {
+	for _, change := range p.changes {
+		if err := validateChange(change); err != nil {
+			return fmt.Errorf("validate mutation %q: %w", changeLabel(change), err)
+		}
+	}
+
+	for _, change := range p.changes {
+		if err := applyChange(change); err != nil {
+			return fmt.Errorf("apply mutation %q: %w", changeLabel(change), err)
+		}
+	}
+
+	return nil
+}
+
+func validateChange(change Change) error {
+	current, err := fs.ReadFile(change.SourcePath)
+	if err != nil {
+		return fmt.Errorf("read destination: %w", err)
+	}
+	if !bytes.Equal(current, change.Original) {
+		return fmt.Errorf("destination changed since planning")
+	}
+
+	info, err := os.Stat(change.SourcePath)
+	if err != nil {
+		return fmt.Errorf("stat destination: %w", err)
+	}
+	if got, want := info.Mode().Perm(), change.Mode.Perm(); got != want {
+		return fmt.Errorf("destination permissions changed since planning: got %o, want %o", got, want)
+	}
+	return nil
+}
+
+func applyChange(change Change) error {
+	file, err := fs.NewAtomicFile(change.SourcePath)
+	if err != nil {
+		return fmt.Errorf("create atomic replacement: %w", err)
+	}
+	defer func() { _ = file.Cleanup() }()
+
+	if _, err := file.Write(change.Replacement); err != nil {
+		return fmt.Errorf("write replacement: %w", err)
+	}
+	if err := file.Chmod(change.Mode); err != nil {
+		return fmt.Errorf("preserve permissions: %w", err)
+	}
+	if err := file.Finalize(); err != nil {
+		return fmt.Errorf("finalize replacement: %w", err)
+	}
+	return nil
+}
+
+func changeLabel(change Change) string {
+	if change.DisplayPath != "" {
+		return change.DisplayPath
+	}
+	return change.SourcePath
+}
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+	cloned := make([]byte, len(data))
+	copy(cloned, data)
+	return cloned
+}

--- a/internal/mutations/plan.go
+++ b/internal/mutations/plan.go
@@ -152,13 +152,13 @@ func prepareChange(change Change) (preparedChange, error) {
 	if destination != change.destination {
 		return preparedChange{}, fmt.Errorf("source target changed since planning")
 	}
-	if err := validateChangeAt(change, destination); err != nil {
+	if err := validateChangeAt(change, destination, nil); err != nil {
 		return preparedChange{}, err
 	}
 	return preparedChange{change: change, destination: destination}, nil
 }
 
-func validateChangeAt(change Change, destination string) error {
+func validateChangeAt(change Change, destination string, atomicFile *fs.AtomicFile) error {
 	matched, err := change.identity.MatchesPath(destination)
 	if err != nil {
 		return fmt.Errorf("check source identity: %w", err)
@@ -167,7 +167,7 @@ func validateChangeAt(change Change, destination string) error {
 		return fmt.Errorf("source file identity changed since planning")
 	}
 
-	current, err := fs.ReadFile(destination)
+	current, err := readDestination(destination, atomicFile)
 	if err != nil {
 		return fmt.Errorf("read destination: %w", err)
 	}
@@ -204,7 +204,7 @@ func applyChange(change Change, destination string) (err error) {
 		}
 	}()
 
-	if err := validateChangeAt(change, destination); err != nil {
+	if err := validateChangeAt(change, destination, file); err != nil {
 		return fmt.Errorf("revalidate destination: %w", err)
 	}
 	if _, err := file.Write(change.Replacement); err != nil {
@@ -213,13 +213,20 @@ func applyChange(change Change, destination string) (err error) {
 	if err := file.Chmod(change.Mode); err != nil {
 		return fmt.Errorf("preserve permissions: %w", err)
 	}
-	if err := validateChangeAt(change, destination); err != nil {
+	if err := validateChangeAt(change, destination, file); err != nil {
 		return fmt.Errorf("revalidate before finalization: %w", err)
 	}
 	if err := file.Finalize(); err != nil {
 		return fmt.Errorf("finalize replacement: %w", err)
 	}
 	return nil
+}
+
+func readDestination(destination string, atomicFile *fs.AtomicFile) ([]byte, error) {
+	if atomicFile != nil {
+		return atomicFile.ReadDestination()
+	}
+	return fs.ReadFile(destination)
 }
 
 func changeLabel(change Change) string {

--- a/internal/mutations/plan_test.go
+++ b/internal/mutations/plan_test.go
@@ -39,6 +39,23 @@ func (markerStripRule) Fix(data []byte) []byte {
 	return bytes.ReplaceAll(data, []byte("X"), []byte("lf"))
 }
 
+type sequencedFixRule struct {
+	calls int
+}
+
+func (r *sequencedFixRule) ID() string          { return "sequenced-fix" }
+func (r *sequencedFixRule) Description() string { return "test-only sequenced replacement" }
+func (r *sequencedFixRule) Run(lint.Context) ([]lint.Finding, error) {
+	return nil, nil
+}
+func (r *sequencedFixRule) Fix([]byte) []byte {
+	r.calls++
+	if r.calls == 1 {
+		return []byte("FIRST=changed\n")
+	}
+	return []byte("SECOND=changed\n")
+}
+
 func TestBuildPlanEmpty(t *testing.T) {
 	plan, err := mutations.BuildPlan(nil, nil)
 	if err != nil {
@@ -244,6 +261,92 @@ func TestApplyPreservesCRLFForScopedFix(t *testing.T) {
 		t.Fatalf("apply plan failed: %v", err)
 	}
 	assertFileBytes(t, path, []byte("KEY=value\r\nNEXT=1\r\n"))
+}
+
+func TestApplyPreservesFileSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file symlink behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.env")
+	alias := filepath.Join(root, "alias.env")
+	mustWrite(t, target, []byte("KEY=value  \n"), 0o640)
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	document := loadDocument(t, alias, ".env")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply plan failed: %v", err)
+	}
+
+	info, err := os.Lstat(alias)
+	if err != nil {
+		t.Fatalf("lstat alias failed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("alias mode = %v, want symlink", info.Mode())
+	}
+	linkedTarget, err := os.Readlink(alias)
+	if err != nil {
+		t.Fatalf("read alias target failed: %v", err)
+	}
+	if linkedTarget != target {
+		t.Fatalf("alias target = %q, want %q", linkedTarget, target)
+	}
+	assertFileBytes(t, target, []byte("KEY=value\n"))
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestApplyRevalidatesEachDestinationBeforeReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file symlink behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.env")
+	alias := filepath.Join(root, "alias.env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, target, original, 0o644)
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	first := loadDocument(t, target, ".env.first")
+	second := loadDocument(t, alias, ".env.second")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{first, second}, []lint.Rule{
+		&sequencedFixRule{},
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if changes := plan.Changes(); len(changes) != 2 {
+		t.Fatalf("planned changes = %d, want 2", len(changes))
+	}
+
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected second destination to be rejected after the first replacement")
+	}
+	if !strings.Contains(err.Error(), ".env.second") {
+		t.Fatalf("error = %v, want affected display path", err)
+	}
+	assertFileBytes(t, target, []byte("FIRST=changed\n"))
+	info, err := os.Lstat(alias)
+	if err != nil {
+		t.Fatalf("lstat alias failed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("alias mode = %v, want symlink", info.Mode())
+	}
+	assertNoAtomicTemporaryFiles(t, root)
 }
 
 func TestApplyRejectsStaleDestinationBeforeWritingAnyFile(t *testing.T) {

--- a/internal/mutations/plan_test.go
+++ b/internal/mutations/plan_test.go
@@ -1,0 +1,402 @@
+/*
+Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mutations_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/envaar/vaar/internal/lint"
+	"github.com/envaar/vaar/internal/lint/rules"
+	"github.com/envaar/vaar/internal/mutations"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+type plainRule struct{}
+
+func (plainRule) ID() string                               { return "plain" }
+func (plainRule) Description() string                      { return "no fix half" }
+func (plainRule) Run(lint.Context) ([]lint.Finding, error) { return nil, nil }
+
+type markerStripRule struct{}
+
+func (markerStripRule) ID() string { return "zz-custom" }
+func (markerStripRule) Description() string {
+	return "resolves the marker by line-ending state"
+}
+func (markerStripRule) Run(lint.Context) ([]lint.Finding, error) { return nil, nil }
+func (markerStripRule) Fix(data []byte) []byte {
+	if bytes.Contains(data, []byte("\r")) {
+		return bytes.ReplaceAll(data, []byte("X"), []byte("crlf"))
+	}
+	return bytes.ReplaceAll(data, []byte("X"), []byte("lf"))
+}
+
+func TestBuildPlanEmpty(t *testing.T) {
+	plan, err := mutations.BuildPlan(nil, nil)
+	if err != nil {
+		t.Fatalf("build empty plan failed: %v", err)
+	}
+	if changes := plan.Changes(); changes == nil || len(changes) != 0 {
+		t.Fatalf("empty plan changes = %#v, want non-nil empty slice", changes)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply empty plan failed: %v", err)
+	}
+}
+
+func TestBuildPlanIsSideEffectFreeAndOwnsReplacementBytes(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, path, original, 0o640)
+	document := loadDocument(t, path, ".env")
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove source after loading failed: %v", err)
+	}
+
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("planning touched removed source: stat error = %v", err)
+	}
+	changes := plan.Changes()
+	if len(changes) != 1 {
+		t.Fatalf("planned changes = %d, want 1", len(changes))
+	}
+	if changes[0].SourcePath != path || changes[0].DisplayPath != ".env" {
+		t.Fatalf("planned provenance = %#v", changes[0])
+	}
+	if !bytes.Equal(changes[0].Original, original) {
+		t.Fatalf("planned original = %q, want %q", changes[0].Original, original)
+	}
+	if want := []byte("KEY=value\n"); !bytes.Equal(changes[0].Replacement, want) {
+		t.Fatalf("planned replacement = %q, want %q", changes[0].Replacement, want)
+	}
+
+	changes[0].Original[0] = 'X'
+	changes[0].Replacement[0] = 'X'
+	changes[0].SourcePath = "mutated"
+	again := plan.Changes()
+	if again[0].SourcePath != path {
+		t.Fatalf("plan source path changed through accessor: %q", again[0].SourcePath)
+	}
+	if !bytes.Equal(again[0].Original, original) {
+		t.Fatalf("plan original changed through accessor: %q", again[0].Original)
+	}
+	if want := []byte("KEY=value\n"); !bytes.Equal(again[0].Replacement, want) {
+		t.Fatalf("plan replacement changed through accessor: %q", again[0].Replacement)
+	}
+}
+
+func TestApplyOneChangedFilePreservesContentAndMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit preservation is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	mustWrite(t, path, []byte("KEY=value  \n"), 0o601)
+	document := loadDocument(t, path, ".env")
+	if document.Mode.Perm() == 0o644 {
+		t.Fatalf("fixture did not retain a non-default mode: %o", document.Mode.Perm())
+	}
+
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply plan failed: %v", err)
+	}
+
+	assertFileBytes(t, path, []byte("KEY=value\n"))
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat replaced file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), document.Mode.Perm(); got != want {
+		t.Fatalf("replaced file mode = %o, want %o", got, want)
+	}
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestApplyMultipleChangesPreservesDocumentOrder(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, ".env.first")
+	secondPath := filepath.Join(root, ".env.second")
+	mustWrite(t, firstPath, []byte("FIRST=value  \n"), 0o644)
+	mustWrite(t, secondPath, []byte("SECOND=value  \n"), 0o644)
+
+	first := loadDocument(t, firstPath, ".env.first")
+	second := loadDocument(t, secondPath, ".env.second")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{second, first}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	changes := plan.Changes()
+	if len(changes) != 2 {
+		t.Fatalf("planned changes = %d, want 2", len(changes))
+	}
+	if changes[0].SourcePath != secondPath || changes[1].SourcePath != firstPath {
+		t.Fatalf("planned order = %#v, want second then first", changes)
+	}
+
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply plan failed: %v", err)
+	}
+	assertFileBytes(t, firstPath, []byte("FIRST=value\n"))
+	assertFileBytes(t, secondPath, []byte("SECOND=value\n"))
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestBuildPlanHonorsSelectedFixableRules(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \n\n\n")
+	mustWrite(t, path, original, 0o644)
+	document := loadDocument(t, path, ".env")
+
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply plan failed: %v", err)
+	}
+	assertFileBytes(t, path, []byte("KEY=value\n\n\n"))
+}
+
+func TestBuildPlanOmitsUnfixableOnlySelection(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, path, original, 0o644)
+	document := loadDocument(t, path, ".env")
+
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{plainRule{}})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if changes := plan.Changes(); changes == nil || len(changes) != 0 {
+		t.Fatalf("unfixable-only changes = %#v, want non-nil empty slice", changes)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply unfixable-only plan failed: %v", err)
+	}
+	assertFileBytes(t, path, original)
+}
+
+func TestBuildPlanPreservesCanonicalFixOrder(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=valueX  \r\nZ=1\n")
+	mustWrite(t, path, original, 0o644)
+	document := loadDocument(t, path, ".env")
+
+	selected := append(rules.All(), markerStripRule{})
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, selected)
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	changes := plan.Changes()
+	if len(changes) != 1 {
+		t.Fatalf("planned changes = %d, want 1", len(changes))
+	}
+	if want := []byte("KEY=valuelf\nZ=1\n"); !bytes.Equal(changes[0].Replacement, want) {
+		t.Fatalf("canonical replacement = %q, want %q", changes[0].Replacement, want)
+	}
+}
+
+func TestApplyPreservesCRLFForScopedFix(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \r\nNEXT=1\r\n")
+	mustWrite(t, path, original, 0o644)
+	document := loadDocument(t, path, ".env")
+
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if err := plan.Apply(); err != nil {
+		t.Fatalf("apply plan failed: %v", err)
+	}
+	assertFileBytes(t, path, []byte("KEY=value\r\nNEXT=1\r\n"))
+}
+
+func TestApplyRejectsStaleDestinationBeforeWritingAnyFile(t *testing.T) {
+	root := t.TempDir()
+	firstPath := filepath.Join(root, ".env.first")
+	secondPath := filepath.Join(root, ".env.second")
+	firstOriginal := []byte("FIRST=value  \n")
+	secondOriginal := []byte("SECOND=value  \n")
+	mustWrite(t, firstPath, firstOriginal, 0o644)
+	mustWrite(t, secondPath, secondOriginal, 0o644)
+
+	first := loadDocument(t, firstPath, ".env.first")
+	second := loadDocument(t, secondPath, ".env.second")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{first, second}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	stale := []byte("SECOND=changed\n")
+	mustWrite(t, secondPath, stale, 0o644)
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected stale destination error")
+	}
+	if !strings.Contains(err.Error(), ".env.second") {
+		t.Fatalf("error = %v, want affected display path", err)
+	}
+	assertFileBytes(t, firstPath, firstOriginal)
+	assertFileBytes(t, secondPath, stale)
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestApplyRejectsStalePermissionsBeforeWriting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission-bit validation is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, path, original, 0o640)
+	document := loadDocument(t, path, ".env")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("change destination permissions failed: %v", err)
+	}
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected stale permission error")
+	}
+	if !strings.Contains(err.Error(), ".env") {
+		t.Fatalf("error = %v, want affected path", err)
+	}
+	assertFileBytes(t, path, original)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat stale file failed: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o600); got != want {
+		t.Fatalf("stale file mode = %o, want %o", got, want)
+	}
+}
+
+func TestApplyFailureLeavesDestinationIntact(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permission fixtures are not portable on Windows")
+	}
+
+	root := t.TempDir()
+	path := filepath.Join(root, ".env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, path, original, 0o644)
+	document := loadDocument(t, path, ".env")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	if err := os.Chmod(root, 0o500); err != nil {
+		t.Fatalf("lock destination directory failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(root, 0o755); err != nil {
+			t.Errorf("restore destination directory failed: %v", err)
+		}
+	})
+	probe, probeErr := os.CreateTemp(root, "vaar-permission-probe-*")
+	if probeErr == nil {
+		_ = probe.Close()
+		_ = os.Remove(probe.Name())
+		t.Skip("directory permissions are not enforced by this test environment")
+	}
+
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected atomic replacement failure")
+	}
+	if !strings.Contains(err.Error(), ".env") {
+		t.Fatalf("error = %v, want affected path", err)
+	}
+	assertFileBytes(t, path, original)
+	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func loadDocument(t *testing.T, path, displayPath string) sourcedotenv.Document {
+	t.Helper()
+	document, err := sourcedotenv.Load(path, displayPath)
+	if err != nil {
+		t.Fatalf("load document failed: %v", err)
+	}
+	return document
+}
+
+func mustWrite(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatalf("write %q failed: %v", path, err)
+	}
+	if err := os.Chmod(path, mode.Perm()); err != nil {
+		t.Fatalf("chmod %q failed: %v", path, err)
+	}
+}
+
+func assertFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q failed: %v", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("bytes in %q = %q, want %q", path, got, want)
+	}
+}
+
+func assertNoAtomicTemporaryFiles(t *testing.T, root string) {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read temporary directory failed: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), "vaar-atomic-") {
+			t.Fatalf("temporary file was not cleaned up: %q", entry.Name())
+		}
+	}
+}

--- a/internal/mutations/plan_test.go
+++ b/internal/mutations/plan_test.go
@@ -333,12 +333,12 @@ func TestApplyRevalidatesEachDestinationBeforeReplacement(t *testing.T) {
 
 	err = plan.Apply()
 	if err == nil {
-		t.Fatal("expected second destination to be rejected after the first replacement")
+		t.Fatal("expected duplicate destination to be rejected during preflight")
 	}
-	if !strings.Contains(err.Error(), ".env.second") {
-		t.Fatalf("error = %v, want affected display path", err)
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want duplicate destination error", err)
 	}
-	assertFileBytes(t, target, []byte("FIRST=changed\n"))
+	assertFileBytes(t, target, original)
 	info, err := os.Lstat(alias)
 	if err != nil {
 		t.Fatalf("lstat alias failed: %v", err)
@@ -347,6 +347,81 @@ func TestApplyRevalidatesEachDestinationBeforeReplacement(t *testing.T) {
 		t.Fatalf("alias mode = %v, want symlink", info.Mode())
 	}
 	assertNoAtomicTemporaryFiles(t, root)
+}
+
+func TestApplyRejectsRetargetedSourceSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file symlink behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	firstTarget := filepath.Join(root, "first.env")
+	secondTarget := filepath.Join(root, "second.env")
+	alias := filepath.Join(root, "alias.env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, firstTarget, original, 0o644)
+	mustWrite(t, secondTarget, original, 0o644)
+	if err := os.Symlink(firstTarget, alias); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	document := loadDocument(t, alias, ".env")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{document}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+	if err := os.Remove(alias); err != nil {
+		t.Fatalf("remove original alias failed: %v", err)
+	}
+	if err := os.Symlink(secondTarget, alias); err != nil {
+		t.Fatalf("retarget alias failed: %v", err)
+	}
+
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected retargeted source symlink to be rejected")
+	}
+	if !strings.Contains(err.Error(), "identity") && !strings.Contains(err.Error(), "target") {
+		t.Fatalf("error = %v, want source identity or target error", err)
+	}
+	assertFileBytes(t, firstTarget, original)
+	assertFileBytes(t, secondTarget, original)
+}
+
+func TestApplyRejectsDuplicateHardLinkDestinationsBeforeWriting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("hard-link behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	firstPath := filepath.Join(root, "first.env")
+	secondPath := filepath.Join(root, "second.env")
+	original := []byte("KEY=value  \n")
+	mustWrite(t, firstPath, original, 0o644)
+	if err := os.Link(firstPath, secondPath); err != nil {
+		t.Skipf("hard-link creation is unavailable: %v", err)
+	}
+
+	first := loadDocument(t, firstPath, ".env.first")
+	second := loadDocument(t, secondPath, ".env.second")
+	plan, err := mutations.BuildPlan([]sourcedotenv.Document{first, second}, []lint.Rule{
+		rules.NewTrailingWhitespace(),
+	})
+	if err != nil {
+		t.Fatalf("build plan failed: %v", err)
+	}
+
+	err = plan.Apply()
+	if err == nil {
+		t.Fatal("expected duplicate hard-link destination to be rejected")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want duplicate destination error", err)
+	}
+	assertFileBytes(t, firstPath, original)
+	assertFileBytes(t, secondPath, original)
 }
 
 func TestApplyRejectsStaleDestinationBeforeWritingAnyFile(t *testing.T) {

--- a/internal/source/dotenv/loader.go
+++ b/internal/source/dotenv/loader.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/envaar/vaar/internal/envfile"
+	"github.com/envaar/vaar/internal/fs"
 )
 
 // Document is one selected dotenv source together with the parsed model and
@@ -21,14 +22,20 @@ import (
 // File remains embedded temporarily so source consumers can use the existing
 // parser facts without duplicating the envfile model. SourcePath identifies
 // the on-disk input, while File.Path retains the caller-provided display path.
+// ResolvedPath and Identity capture the target observed during loading so a
+// later mutation can reject a retargeted or replaced source safely.
 type Document struct {
 	envfile.File
-	SourcePath string
-	Mode       os.FileMode
+	SourcePath   string
+	ResolvedPath string
+	Mode         os.FileMode
+	Identity     fs.FileIdentity
 }
 
 // Load validates, reads and parses one selected dotenv file. displayPath is
-// preserved as the parsed document path for diagnostics and reports.
+// preserved as the parsed document path for diagnostics and reports. It also
+// captures the resolved target path and filesystem identity needed by safe
+// mutation planning.
 func Load(path, displayPath string) (Document, error) {
 	// O_NONBLOCK prevents opening a Unix FIFO from blocking before its type can
 	// be checked. Windows ignores this flag because its file handles are already
@@ -53,6 +60,12 @@ func Load(path, displayPath string) (Document, error) {
 		return Document{}, fmt.Errorf("dotenv source %q is not a regular file", path)
 	}
 
+	resolvedPath, err := fs.CanonicalPath(path)
+	if err != nil {
+		_ = file.Close()
+		return Document{}, fmt.Errorf("resolve dotenv source %q: %w", path, err)
+	}
+
 	data, readErr := io.ReadAll(file)
 	closeErr := file.Close()
 	if readErr != nil {
@@ -68,9 +81,11 @@ func Load(path, displayPath string) (Document, error) {
 	}
 
 	return Document{
-		File:       parsed,
-		SourcePath: path,
-		Mode:       info.Mode().Perm(),
+		File:         parsed,
+		SourcePath:   path,
+		ResolvedPath: resolvedPath,
+		Mode:         info.Mode().Perm(),
+		Identity:     fs.NewFileIdentity(info),
 	}, nil
 }
 

--- a/internal/source/dotenv/loader_test.go
+++ b/internal/source/dotenv/loader_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/envaar/vaar/internal/fs"
 	"github.com/envaar/vaar/internal/source/dotenv"
 )
 
@@ -105,7 +106,11 @@ func TestLoadCapturesResolvedTargetAndIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load failed: %v", err)
 	}
-	if got, want := document.ResolvedPath, target; got != want {
+	want, err := fs.CanonicalPath(target)
+	if err != nil {
+		t.Fatalf("canonicalize target failed: %v", err)
+	}
+	if got := document.ResolvedPath; got != want {
 		t.Fatalf("resolved path = %q, want %q", got, want)
 	}
 	if !document.Identity.Valid() {

--- a/internal/source/dotenv/loader_test.go
+++ b/internal/source/dotenv/loader_test.go
@@ -88,6 +88,38 @@ func TestLoadPreservesFileMode(t *testing.T) {
 	}
 }
 
+func TestLoadCapturesResolvedTargetAndIdentity(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file symlink behavior is not portable on Windows")
+	}
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target.env")
+	alias := filepath.Join(root, "alias.env")
+	mustWrite(t, target, []byte("KEY=value\n"))
+	if err := os.Symlink(target, alias); err != nil {
+		t.Skipf("symlink creation is unavailable: %v", err)
+	}
+
+	document, err := dotenv.Load(alias, ".env")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if got, want := document.ResolvedPath, target; got != want {
+		t.Fatalf("resolved path = %q, want %q", got, want)
+	}
+	if !document.Identity.Valid() {
+		t.Fatal("loaded document has no file identity")
+	}
+	matched, err := document.Identity.MatchesPath(target)
+	if err != nil {
+		t.Fatalf("match target identity failed: %v", err)
+	}
+	if !matched {
+		t.Fatal("loaded identity does not match resolved target")
+	}
+}
+
 func TestLoadManyPreservesInputOrderAndDisplayPaths(t *testing.T) {
 	root := t.TempDir()
 	firstPath := filepath.Join(root, "first.env")


### PR DESCRIPTION
Closes #94

## Summary

Add a bounded mutation pipeline for planning and safely applying lint fixes while preserving existing behavior and compatibility.

## Why

The refactor needs a dedicated mutation boundary that can prepare deterministic fix plans without filesystem side effects, then apply them safely with stale-file protection, atomic replacement, cleanup, and permission preservation.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/mutations` with deterministic, side-effect-free lint fix planning.
- Added immutable plan accessors with owned original and replacement bytes.
- Added validation of all original file contents and permission modes before any write.
- Added atomic replacement support with temporary-file permission preservation and cleanup.
- Preserved document order, canonical fix ordering, CRLF content, and existing lint fix behavior.
- Kept legacy lint fix APIs and CLI behavior unchanged; CLI integration is deferred to the later migration ticket.

## User-visible changes

**None.**

This ticket does not migrate the CLI or change lint output, exit codes, rule behavior, or command behavior.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go test ./internal/mutations ./internal/fs
GOCACHE=/tmp/vaar-go-cache go vet ./...
GOCACHE=/tmp/vaar-go-cache make build
git diff --check
```

`go run ./cmd/vaar lint ...` was not run because this ticket intentionally does not migrate the lint CLI or expose mutation commands.

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

Tests cover empty plans, selected and skipped fixes, unfixable-only rules, canonical fix ordering, CRLF preservation, document ordering, defensive ownership, file mode preservation, stale content detection, stale permission detection, failed replacement safety, and temporary-file cleanup.

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Added package-level documentation describing the mutation boundary and its safety guarantees.

## Release notes

Introduces a safe internal lint-fix planning and atomic application pipeline without changing current CLI behavior.

## Reviewer notes

Please pay particular attention to:

- The separation between side-effect-free planning and filesystem-mutating application.
- Validation of every planned file before the first replacement.
- Atomic replacement behavior and preservation of captured permission bits.
- Cleanup of temporary files on write, permission, and finalization failures.
- Preservation of existing canonical lint fix ordering and byte-level output behavior.
- The intentional absence of CLI migration, post-fix lint reruns, rollback, backups, and public mutation commands.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for planning and applying lint fixes across multiple files.
  * Preserves file permissions, line endings, symlinks, and document order when applying fixes.
  * Coordinates concurrent updates to the same file or linked file safely.
  * Supports atomic updates while preserving existing file permissions.
  * Added cross-platform file locking for safer concurrent updates.

* **Bug Fixes**
  * Validates files, links, content, and permissions before replacement.
  * Improved error reporting for cleanup and replacement failures.
  * Ensures failed updates leave destination files intact and temporary files cleaned up.
  * Prevents unsafe lock-file and lock-directory symlink usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->