### PR TITLE
refactor(diff): compare analysis key inventories

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/envaar/vaar/internal/analysis"
 	"github.com/envaar/vaar/internal/envfile"
 )
 
@@ -31,6 +32,8 @@ func (r Result) HasDifferences() bool {
 }
 
 // Compare parses two dotenv inputs and compares assignment key presence only.
+// It remains a compatibility wrapper until the diff command migrates to the
+// shared source and analysis pipeline.
 func Compare(leftPath string, leftData []byte, rightPath string, rightData []byte) (Result, error) {
 	left, err := envfile.Parse(leftPath, leftData)
 	if err != nil {
@@ -45,33 +48,59 @@ func Compare(leftPath string, leftData []byte, rightPath string, rightData []byt
 	return CompareFiles(left, right), nil
 }
 
-// CompareFiles compares key presence between two already parsed dotenv files.
-func CompareFiles(left envfile.File, right envfile.File) Result {
-	leftKeys := keySet(left)
-	rightKeys := keySet(right)
+// CompareInventories compares two value-free analysis key inventories. Labels
+// are supplied separately because an empty inventory has no declaration from
+// which a display path could be recovered.
+func CompareInventories(leftLabel string, left analysis.KeyInventory, rightLabel string, right analysis.KeyInventory) Result {
+	leftKeys := left.Keys()
+	rightKeys := right.Keys()
 
 	return Result{
-		Left:             left.Path,
-		Right:            right.Path,
-		MissingFromLeft:  missingKeys(leftKeys, rightKeys),
-		MissingFromRight: missingKeys(rightKeys, leftKeys),
+		Left:             leftLabel,
+		Right:            rightLabel,
+		MissingFromLeft:  missingInventoryKeys(leftKeys, rightKeys),
+		MissingFromRight: missingInventoryKeys(rightKeys, leftKeys),
 	}
 }
 
-func keySet(file envfile.File) map[string]struct{} {
-	keys := make(map[string]struct{})
+// CompareFiles compares key presence between two already parsed dotenv files.
+// It is a temporary compatibility adapter for callers that have not yet
+// migrated to analysis key inventories.
+func CompareFiles(left envfile.File, right envfile.File) Result {
+	return CompareInventories(
+		left.Path,
+		inventoryFromFile(left),
+		right.Path,
+		inventoryFromFile(right),
+	)
+}
+
+func inventoryFromFile(file envfile.File) analysis.KeyInventory {
+	lines := make([]analysis.Line, 0, len(file.Lines))
 	for _, line := range file.Lines {
-		if line.HasAssignment && line.HasKey {
-			keys[line.Key] = struct{}{}
-		}
+		lines = append(lines, analysis.Line{
+			Number:        line.Number,
+			Key:           line.Key,
+			HasKey:        line.HasKey,
+			HasAssignment: line.HasAssignment,
+		})
 	}
-	return keys
+
+	return analysis.NewKeyInventory(analysis.Document{
+		DisplayPath: file.Path,
+		Lines:       lines,
+	})
 }
 
-func missingKeys(have map[string]struct{}, want map[string]struct{}) []string {
-	missing := make([]string, 0)
-	for key := range want {
-		if _, ok := have[key]; !ok {
+func missingInventoryKeys(have, want []string) []string {
+	haveSet := make(map[string]struct{}, len(have))
+	for _, key := range have {
+		haveSet[key] = struct{}{}
+	}
+
+	missing := make([]string, 0, len(want))
+	for _, key := range want {
+		if _, ok := haveSet[key]; !ok {
 			missing = append(missing, key)
 		}
 	}

--- a/internal/diff/inventory_test.go
+++ b/internal/diff/inventory_test.go
@@ -1,0 +1,153 @@
+// Copyright © 2026 envaar
+// SPDX-License-Identifier: Apache-2.0
+
+package diff_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/envaar/vaar/internal/analysis"
+	"github.com/envaar/vaar/internal/diff"
+)
+
+func TestCompareInventoriesPreservesKeyPresenceSemantics(t *testing.T) {
+	tests := []struct {
+		name                 string
+		left                 analysis.KeyInventory
+		right                analysis.KeyInventory
+		wantLeft             string
+		wantRight            string
+		wantMissingFromLeft  []string
+		wantMissingFromRight []string
+	}{
+		{
+			name: "matching inventories including empty assignments",
+			left: inventory("left.env",
+				assignment("COMMON"),
+				assignment("EMPTY"),
+			),
+			right: inventory("right.env",
+				assignment("COMMON"),
+				assignment("EMPTY"),
+			),
+			wantLeft:             "left.env",
+			wantRight:            "right.env",
+			wantMissingFromLeft:  []string{},
+			wantMissingFromRight: []string{},
+		},
+		{
+			name: "missing keys are sorted independently",
+			left: inventory("left.env",
+				assignment("ZED"),
+				assignment("COMMON"),
+			),
+			right: inventory("right.env",
+				assignment("BETA"),
+				assignment("ALPHA"),
+			),
+			wantLeft:             "left.env",
+			wantRight:            "right.env",
+			wantMissingFromLeft:  []string{"ALPHA", "BETA"},
+			wantMissingFromRight: []string{"COMMON", "ZED"},
+		},
+		{
+			name: "duplicates collapse and comparison is case sensitive",
+			left: inventory("left.env",
+				assignment("TOKEN"),
+				assignment("TOKEN"),
+			),
+			right: inventory("right.env",
+				assignment("token"),
+			),
+			wantLeft:             "left.env",
+			wantRight:            "right.env",
+			wantMissingFromLeft:  []string{"token"},
+			wantMissingFromRight: []string{"TOKEN"},
+		},
+		{
+			name: "bare and malformed declarations are excluded",
+			left: inventory("left.env",
+				bareKey("BARE"),
+				malformedKey("COLON"),
+				assignment("VALID"),
+			),
+			right: inventory("right.env",
+				assignment("VALID"),
+			),
+			wantLeft:             "left.env",
+			wantRight:            "right.env",
+			wantMissingFromLeft:  []string{},
+			wantMissingFromRight: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := diff.CompareInventories(tc.wantLeft, tc.left, tc.wantRight, tc.right)
+
+			if result.Left != tc.wantLeft || result.Right != tc.wantRight {
+				t.Fatalf("labels = (%q, %q), want (%q, %q)", result.Left, result.Right, tc.wantLeft, tc.wantRight)
+			}
+			if !reflect.DeepEqual(result.MissingFromLeft, tc.wantMissingFromLeft) {
+				t.Fatalf("MissingFromLeft = %#v, want %#v", result.MissingFromLeft, tc.wantMissingFromLeft)
+			}
+			if !reflect.DeepEqual(result.MissingFromRight, tc.wantMissingFromRight) {
+				t.Fatalf("MissingFromRight = %#v, want %#v", result.MissingFromRight, tc.wantMissingFromRight)
+			}
+		})
+	}
+}
+
+func TestCompareInventoriesDoesNotExposeValues(t *testing.T) {
+	left := inventory("left.env", assignment("DATABASE_PASSWORD"))
+	right := inventory("right.env", assignment("DATABASE_URL"))
+
+	result := diff.CompareInventories("left.env", left, "right.env", right)
+	rendered := fmt.Sprintf("%#v", result)
+	if rendered != "diff.Result{Left:\"left.env\", Right:\"right.env\", MissingFromLeft:[]string{\"DATABASE_URL\"}, MissingFromRight:[]string{\"DATABASE_PASSWORD\"}}" {
+		t.Fatalf("unexpected value-bearing or unstable result rendering: %s", rendered)
+	}
+}
+
+func TestCompareInventoriesHasDifferencesMatchesResult(t *testing.T) {
+	matching := diff.CompareInventories(
+		"left.env",
+		inventory("left.env", assignment("COMMON")),
+		"right.env",
+		inventory("right.env", assignment("COMMON")),
+	)
+	if matching.HasDifferences() {
+		t.Fatal("matching inventories reported differences")
+	}
+
+	different := diff.CompareInventories(
+		"left.env",
+		inventory("left.env", assignment("LEFT_ONLY")),
+		"right.env",
+		inventory("right.env", assignment("RIGHT_ONLY")),
+	)
+	if !different.HasDifferences() {
+		t.Fatal("different inventories reported no differences")
+	}
+}
+
+func inventory(displayPath string, lines ...analysis.Line) analysis.KeyInventory {
+	return analysis.NewKeyInventory(analysis.Document{
+		DisplayPath: displayPath,
+		Lines:       lines,
+	})
+}
+
+func assignment(key string) analysis.Line {
+	return analysis.Line{Key: key, HasKey: true, HasAssignment: true}
+}
+
+func bareKey(key string) analysis.Line {
+	return analysis.Line{Key: key, HasKey: true, DelimiterState: analysis.DelimiterMissing}
+}
+
+func malformedKey(key string) analysis.Line {
+	return analysis.Line{Key: key, HasKey: true, DelimiterState: analysis.DelimiterColon}
+}


### PR DESCRIPTION
Closes #96

<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Move diff key comparison onto the analysis-owned key inventory while preserving the existing diff result and compatibility behavior.

## Why

Discussion #58 defines analysis as the normalized fact boundary consumed by command engines. Diff should compare analysis key inventories instead of deriving private key sets directly from parser-owned files.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `diff.CompareInventories` for comparing two `analysis.KeyInventory` values.
- Preserved `diff.Result`, `HasDifferences`, deterministic missing-key ordering, case sensitivity, empty assignments, duplicate handling, malformed-line filtering, and value non-disclosure.
- Updated `CompareFiles` to convert parsed documents into value-free analysis inventories before comparison.
- Retained `Compare` and `CompareFiles` as temporary compatibility wrappers for the later diff CLI migration in #97.
- Added focused inventory comparison tests.

## User-visible changes

**None.**

The diff CLI, output formats, exit behavior, and command syntax are unchanged. CLI migration is intentionally deferred to #97.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go test -count=1 ./...
GOCACHE=/tmp/vaar-go-cache go vet ./...
GOCACHE=/tmp/vaar-go-cache make build
GOCACHE=/tmp/vaar-go-cache GOOS=windows GOARCH=amd64 go vet ./...
GOCACHE=/tmp/vaar-go-cache GOOS=windows GOARCH=amd64 go build -buildvcs=false -o /tmp/vaar-diff-windows.exe ./cmd/vaar
git diff --check
```

`go run ./cmd/vaar lint ...` was not run because this ticket does not modify the lint command.

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed

Tests cover matching inventories, missing keys, deterministic ordering, empty assignments, duplicate declarations, case-sensitive comparison, bare and malformed declarations, `HasDifferences`, labels, and value non-disclosure.

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Added API and compatibility-wrapper documentation describing the analysis boundary and the temporary migration seam.

## Release notes

Moves diff key comparison onto value-free analysis inventories without changing current CLI behavior.

## Reviewer notes

Please pay particular attention to:

- `CompareInventories` depending only on `analysis.KeyInventory`.
- Preservation of existing `diff.Result` and `HasDifferences` behavior.
- Sorted and case-sensitive missing-key results.
- Empty assignments counting as present keys.
- Duplicate declarations collapsing to one inventory entry.
- Bare keys and malformed declarations remaining excluded.
- No value comparison or value disclosure.
- `Compare` and `CompareFiles` remaining temporary compatibility wrappers for #97.
- No CLI, reporter, filesystem, or output changes in this ticket.

The legacy `internal/envfile` wrapper remains intentionally until the diff command migration in #97.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated
- [x] Release note added
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved comparison results to consistently identify missing keys, including when files contain empty assignments.
  - Preserved clear left/right labels when displaying differences, including comparisons involving empty files.
  - Duplicate keys are handled consistently, while bare or malformed declarations are excluded from comparison results.
  - Comparison output continues to show key differences without exposing assigned values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->