### PR TITLE
refactor(diff): migrate diff command to shared loading and reporting

### DIFF
--- a/internal/application/diff/application.go
+++ b/internal/application/diff/application.go
@@ -1,0 +1,131 @@
+// Copyright © 2026 envaar
+// SPDX-License-Identifier: Apache-2.0
+
+// Package diff coordinates the diff application use case. It composes source
+// loading, analysis conversion and key-inventory comparison without rendering
+// output or deciding command exit codes.
+package diff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
+	diffengine "github.com/envaar/vaar/internal/diff"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+// Options identifies the two user-selected dotenv operands. The values are
+// retained as display labels so relative, absolute and space-containing paths
+// remain unchanged in diff results.
+type Options struct {
+	LeftPath  string
+	RightPath string
+}
+
+// Dependencies provides the source-loading seam used by application tests.
+// Analysis and diff remain concrete boundaries: the service must always build
+// an analysis snapshot and invoke the analysis-backed diff engine.
+type Dependencies struct {
+	LoadDotenv func(paths, displayPaths []string) ([]sourcedotenv.Document, error)
+}
+
+// Service coordinates one diff execution.
+type Service struct {
+	loadDotenv func(paths, displayPaths []string) ([]sourcedotenv.Document, error)
+}
+
+// New constructs a diff application service with the standard dotenv loader.
+func New() *Service {
+	return NewWithDependencies(Dependencies{})
+}
+
+// NewWithDependencies constructs a diff application service with explicit
+// source-loading dependencies for focused orchestration tests.
+func NewWithDependencies(dependencies Dependencies) *Service {
+	if dependencies.LoadDotenv == nil {
+		dependencies.LoadDotenv = sourcedotenv.LoadMany
+	}
+
+	return &Service{loadDotenv: dependencies.LoadDotenv}
+}
+
+// Run loads both operands through the shared dotenv source boundary, converts
+// them into a value-free analysis snapshot, and compares their key inventories.
+func (s *Service) Run(ctx context.Context, opts Options) (diffengine.Result, error) {
+	if err := ctx.Err(); err != nil {
+		return diffengine.Result{}, err
+	}
+
+	paths := []string{opts.LeftPath, opts.RightPath}
+	documents, err := s.loadDotenv(paths, paths)
+	if err != nil {
+		return diffengine.Result{}, normalizeLoadError(err)
+	}
+	if len(documents) != len(paths) {
+		return diffengine.Result{}, fmt.Errorf(
+			"load diff sources: got %d documents for %d selected paths",
+			len(documents), len(paths),
+		)
+	}
+	for i, document := range documents {
+		if document.SourcePath != paths[i] {
+			return diffengine.Result{}, fmt.Errorf(
+				"load diff sources: document %d has source path %q, want %q",
+				i, document.SourcePath, paths[i],
+			)
+		}
+		if document.Path != paths[i] {
+			return diffengine.Result{}, fmt.Errorf(
+				"load diff sources: document %d has display path %q, want %q",
+				i, document.Path, paths[i],
+			)
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return diffengine.Result{}, err
+	}
+
+	inputs := make([]analysisdotenv.DocumentInput, len(documents))
+	for i, document := range documents {
+		inputs[i] = analysisdotenv.DocumentInput{
+			ID:     analysis.DocumentID(paths[i]),
+			Source: document,
+		}
+	}
+
+	snapshot := analysis.NewSnapshot(analysisdotenv.FromDocuments(inputs))
+	analysisDocuments := snapshot.Documents()
+	leftInventory := analysis.NewKeyInventory(analysisDocuments[0])
+	rightInventory := analysis.NewKeyInventory(analysisDocuments[1])
+
+	return diffengine.CompareInventories(
+		paths[0], leftInventory,
+		paths[1], rightInventory,
+	), nil
+}
+
+func normalizeLoadError(err error) error {
+	var loadErr *sourcedotenv.LoadError
+	if !errors.As(err, &loadErr) {
+		return err
+	}
+
+	switch {
+	case errors.Is(loadErr.Err, sourcedotenv.ErrIsDirectory):
+		return fmt.Errorf("%s is a directory, expected a dotenv file", loadErr.Path)
+	case errors.Is(loadErr.Err, sourcedotenv.ErrNotRegularFile):
+		return fmt.Errorf("%s is not a regular file, expected a dotenv file", loadErr.Path)
+	case errors.Is(loadErr.Err, os.ErrNotExist):
+		return fmt.Errorf("reading %s: file does not exist", loadErr.Path)
+	}
+
+	var pathErr *os.PathError
+	if errors.As(loadErr.Err, &pathErr) {
+		return fmt.Errorf("reading %s: %w", loadErr.Path, pathErr)
+	}
+	return fmt.Errorf("reading %s: %w", loadErr.Path, loadErr.Err)
+}

--- a/internal/application/diff/application_test.go
+++ b/internal/application/diff/application_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2026 envaar
+// SPDX-License-Identifier: Apache-2.0
+
+package diff_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	applicationdiff "github.com/envaar/vaar/internal/application/diff"
+	"github.com/envaar/vaar/internal/envfile"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
+)
+
+func TestServiceLoadsBothOperandsThroughSharedSourceLoader(t *testing.T) {
+	var loadCalls int
+	var gotPaths, gotDisplayPaths []string
+
+	service := applicationdiff.NewWithDependencies(applicationdiff.Dependencies{
+		LoadDotenv: func(paths, displayPaths []string) ([]sourcedotenv.Document, error) {
+			loadCalls++
+			gotPaths = append([]string(nil), paths...)
+			gotDisplayPaths = append([]string(nil), displayPaths...)
+
+			return []sourcedotenv.Document{
+				{
+					File: envfile.File{
+						Path: displayPaths[0],
+						Lines: []envfile.Line{
+							{Number: 1, Key: "COMMON", HasKey: true, HasAssignment: true},
+							{Number: 2, Key: "LEFT_ONLY", HasKey: true, HasAssignment: true},
+						},
+					},
+					SourcePath: paths[0],
+				},
+				{
+					File: envfile.File{
+						Path: displayPaths[1],
+						Lines: []envfile.Line{
+							{Number: 1, Key: "COMMON", HasKey: true, HasAssignment: true},
+							{Number: 2, Key: "RIGHT_ONLY", HasKey: true, HasAssignment: true},
+						},
+					},
+					SourcePath: paths[1],
+				},
+			}, nil
+		},
+	})
+
+	result, err := service.Run(context.Background(), applicationdiff.Options{
+		LeftPath:  "left env",
+		RightPath: "right env",
+	})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+
+	if loadCalls != 1 {
+		t.Fatalf("source loader calls = %d, want 1", loadCalls)
+	}
+	if want := []string{"left env", "right env"}; !reflect.DeepEqual(gotPaths, want) {
+		t.Fatalf("loaded paths = %#v, want %#v", gotPaths, want)
+	}
+	if want := []string{"left env", "right env"}; !reflect.DeepEqual(gotDisplayPaths, want) {
+		t.Fatalf("display paths = %#v, want %#v", gotDisplayPaths, want)
+	}
+
+	if result.Left != "left env" || result.Right != "right env" {
+		t.Fatalf("result labels = (%q, %q), want (%q, %q)", result.Left, result.Right, "left env", "right env")
+	}
+	if want := []string{"RIGHT_ONLY"}; !reflect.DeepEqual(result.MissingFromLeft, want) {
+		t.Fatalf("missing from left = %#v, want %#v", result.MissingFromLeft, want)
+	}
+	if want := []string{"LEFT_ONLY"}; !reflect.DeepEqual(result.MissingFromRight, want) {
+		t.Fatalf("missing from right = %#v, want %#v", result.MissingFromRight, want)
+	}
+}
+
+func TestServiceStopsBeforeLoadingWhenContextIsCanceled(t *testing.T) {
+	loadCalls := 0
+	service := applicationdiff.NewWithDependencies(applicationdiff.Dependencies{
+		LoadDotenv: func([]string, []string) ([]sourcedotenv.Document, error) {
+			loadCalls++
+			return nil, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := service.Run(ctx, applicationdiff.Options{LeftPath: "left", RightPath: "right"})
+	if err != context.Canceled {
+		t.Fatalf("run error = %v, want %v", err, context.Canceled)
+	}
+	if loadCalls != 0 {
+		t.Fatalf("source loader calls = %d, want 0", loadCalls)
+	}
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -6,12 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 package cli
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
-	"github.com/envaar/vaar/internal/diff"
-	"github.com/envaar/vaar/internal/fs"
+	applicationdiff "github.com/envaar/vaar/internal/application/diff"
 	diffoutput "github.com/envaar/vaar/internal/output/diff"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +16,7 @@ import (
 func newDiffCmd() *cobra.Command {
 	var jsonOutput bool
 	var quiet bool
+	service := applicationdiff.New()
 
 	cmd := &cobra.Command{
 		Use:   "diff <left> <right>",
@@ -32,29 +30,26 @@ func newDiffCmd() *cobra.Command {
 			leftPath := args[0]
 			rightPath := args[1]
 
-			leftData, err := readDiffFile(leftPath)
+			result, err := service.Run(cmd.Context(), applicationdiff.Options{
+				LeftPath:  leftPath,
+				RightPath: rightPath,
+			})
 			if err != nil {
 				return err
-			}
-
-			rightData, err := readDiffFile(rightPath)
-			if err != nil {
-				return err
-			}
-
-			result, err := diff.Compare(leftPath, leftData, rightPath, rightData)
-			if err != nil {
-				return NewToolError("comparing dotenv files", err)
 			}
 
 			different := result.HasDifferences()
 
 			if jsonOutput {
-				if err := writeDiffJSON(cmd, result); err != nil {
+				data, err := diffoutput.JSON(result)
+				if err != nil {
+					return NewToolError("rendering diff JSON output failed", err)
+				}
+				if err := writeDiffLine(cmd, string(data)); err != nil {
 					return err
 				}
 			} else if !quiet {
-				if err := writeDiffText(cmd, result); err != nil {
+				if err := writeDiffLine(cmd, diffoutput.Text(result)); err != nil {
 					return err
 				}
 			}
@@ -78,36 +73,6 @@ func exactDiffArgs(_ *cobra.Command, args []string) error {
 		return NewToolError("diff requires exactly two dotenv files", nil)
 	}
 	return nil
-}
-
-func readDiffFile(path string) ([]byte, error) {
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		switch {
-		case errors.Is(err, fs.ErrIsDirectory):
-			return nil, NewToolError(fmt.Sprintf("%s is a directory, expected a dotenv file", path), nil)
-		case errors.Is(err, fs.ErrNotRegularFile):
-			return nil, NewToolError(fmt.Sprintf("%s is not a regular file, expected a dotenv file", path), nil)
-		case errors.Is(err, os.ErrNotExist):
-			return nil, NewToolError(fmt.Sprintf("reading %s: file does not exist", path), nil)
-		default:
-			return nil, NewToolError(fmt.Sprintf("reading %s", path), err)
-		}
-	}
-	return data, nil
-}
-
-func writeDiffText(cmd *cobra.Command, result diff.Result) error {
-	return writeDiffLine(cmd, diffoutput.Text(result))
-}
-
-func writeDiffJSON(cmd *cobra.Command, result diff.Result) error {
-	data, err := diffoutput.JSON(result)
-	if err != nil {
-		return NewToolError("rendering diff JSON output failed", err)
-	}
-
-	return writeDiffLine(cmd, string(data))
 }
 
 func writeDiffLine(cmd *cobra.Command, line string) error {

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestDiffCLIUsesOutputDiffPackage(t *testing.T) {
+func TestDiffCLIUsesApplicationAndOutputBoundaries(t *testing.T) {
 	workingDirectory, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("get test working directory: %v", err)
@@ -44,6 +44,20 @@ func TestDiffCLIUsesOutputDiffPackage(t *testing.T) {
 	const outputDiffPath = "github.com/envaar/vaar/internal/output/diff"
 	if !imports[outputDiffPath] {
 		t.Fatalf("diff CLI must import %q", outputDiffPath)
+	}
+	const applicationDiffPath = "github.com/envaar/vaar/internal/application/diff"
+	if !imports[applicationDiffPath] {
+		t.Fatalf("diff CLI must import %q", applicationDiffPath)
+	}
+	for _, forbidden := range []string{
+		"github.com/envaar/vaar/internal/diff",
+		"github.com/envaar/vaar/internal/fs",
+		"github.com/envaar/vaar/internal/envfile",
+		"github.com/envaar/vaar/internal/source/dotenv",
+	} {
+		if imports[forbidden] {
+			t.Fatalf("diff CLI must not import %q", forbidden)
+		}
 	}
 	if imports["github.com/envaar/vaar/internal/report"] {
 		t.Fatal("diff CLI must not import internal/report")

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -7,11 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package diff
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/envaar/vaar/internal/analysis"
-	"github.com/envaar/vaar/internal/envfile"
 )
 
 // Result describes the key-presence difference between two dotenv files.
@@ -31,23 +29,6 @@ func (r Result) HasDifferences() bool {
 	return len(r.MissingFromLeft) > 0 || len(r.MissingFromRight) > 0
 }
 
-// Compare parses two dotenv inputs and compares assignment key presence only.
-// It remains a compatibility wrapper until the diff command migrates to the
-// shared source and analysis pipeline.
-func Compare(leftPath string, leftData []byte, rightPath string, rightData []byte) (Result, error) {
-	left, err := envfile.Parse(leftPath, leftData)
-	if err != nil {
-		return Result{}, fmt.Errorf("parse %q: %w", leftPath, err)
-	}
-
-	right, err := envfile.Parse(rightPath, rightData)
-	if err != nil {
-		return Result{}, fmt.Errorf("parse %q: %w", rightPath, err)
-	}
-
-	return CompareFiles(left, right), nil
-}
-
 // CompareInventories compares two value-free analysis key inventories. Labels
 // are supplied separately because an empty inventory has no declaration from
 // which a display path could be recovered.
@@ -61,35 +42,6 @@ func CompareInventories(leftLabel string, left analysis.KeyInventory, rightLabel
 		MissingFromLeft:  missingInventoryKeys(leftKeys, rightKeys),
 		MissingFromRight: missingInventoryKeys(rightKeys, leftKeys),
 	}
-}
-
-// CompareFiles compares key presence between two already parsed dotenv files.
-// It is a temporary compatibility adapter for callers that have not yet
-// migrated to analysis key inventories.
-func CompareFiles(left envfile.File, right envfile.File) Result {
-	return CompareInventories(
-		left.Path,
-		inventoryFromFile(left),
-		right.Path,
-		inventoryFromFile(right),
-	)
-}
-
-func inventoryFromFile(file envfile.File) analysis.KeyInventory {
-	lines := make([]analysis.Line, 0, len(file.Lines))
-	for _, line := range file.Lines {
-		lines = append(lines, analysis.Line{
-			Number:        line.Number,
-			Key:           line.Key,
-			HasKey:        line.HasKey,
-			HasAssignment: line.HasAssignment,
-		})
-	}
-
-	return analysis.NewKeyInventory(analysis.Document{
-		DisplayPath: file.Path,
-		Lines:       lines,
-	})
 }
 
 func missingInventoryKeys(have, want []string) []string {

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -11,7 +11,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/envaar/vaar/internal/analysis"
+	analysisdotenv "github.com/envaar/vaar/internal/analysis/dotenv"
 	"github.com/envaar/vaar/internal/envfile"
+	sourcedotenv "github.com/envaar/vaar/internal/source/dotenv"
 )
 
 func TestCompareKeyPresence(t *testing.T) {
@@ -131,7 +134,7 @@ func TestCompareKeyPresence(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := Compare(".env", []byte(tc.left), ".env.example", []byte(tc.right))
+			result, err := compareParsedFiles(t, ".env", tc.left, ".env.example", tc.right)
 			if err != nil {
 				t.Fatalf("compare failed: %v", err)
 			}
@@ -142,11 +145,12 @@ func TestCompareKeyPresence(t *testing.T) {
 }
 
 func TestCompareOnlyIncludesAssignmentKeys(t *testing.T) {
-	result, err := Compare(
+	result, err := compareParsedFiles(
+		t,
 		".env",
-		[]byte("FOO\nBAR:wrong-delimiter\nBAZ=value\n"),
+		"FOO\nBAR:wrong-delimiter\nBAZ=value\n",
 		".env.example",
-		[]byte("BAZ=example\n"),
+		"BAZ=example\n",
 	)
 	if err != nil {
 		t.Fatalf("compare failed: %v", err)
@@ -202,17 +206,17 @@ func TestResultHasDifferences(t *testing.T) {
 	}
 }
 
-func TestCompareFilesReusesParsedFiles(t *testing.T) {
-	left, err := envfile.Parse("left.env", []byte("FOO=left\n"))
-	if err != nil {
-		t.Fatalf("parse left failed: %v", err)
-	}
-	right, err := envfile.Parse("right.env", []byte("BAR=right\n"))
-	if err != nil {
-		t.Fatalf("parse right failed: %v", err)
-	}
+func TestCompareInventoriesUsesLabels(t *testing.T) {
+	left := analysis.NewKeyInventory(analysis.Document{
+		DisplayPath: "left.env",
+		Lines:       []analysis.Line{{Key: "FOO", HasKey: true, HasAssignment: true}},
+	})
+	right := analysis.NewKeyInventory(analysis.Document{
+		DisplayPath: "right.env",
+		Lines:       []analysis.Line{{Key: "BAR", HasKey: true, HasAssignment: true}},
+	})
 
-	result := CompareFiles(left, right)
+	result := CompareInventories("left.env", left, "right.env", right)
 
 	assertResult(t, result, []string{"BAR"}, []string{"FOO"})
 	if result.Left != "left.env" {
@@ -226,11 +230,12 @@ func TestCompareFilesReusesParsedFiles(t *testing.T) {
 func TestCompareResultDoesNotExposeValues(t *testing.T) {
 	const value = "fake-password-value"
 
-	result, err := Compare(
+	result, err := compareParsedFiles(
+		t,
 		".env",
-		[]byte("DATABASE_PASSWORD="+value+"\n"),
+		"DATABASE_PASSWORD="+value+"\n",
 		".env.example",
-		[]byte("DATABASE_URL=fake-example-url\n"),
+		"DATABASE_URL=fake-example-url\n",
 	)
 	if err != nil {
 		t.Fatalf("compare failed: %v", err)
@@ -246,10 +251,13 @@ func TestCompareResultDoesNotExposeValues(t *testing.T) {
 }
 
 func TestCompareResultUsesPaths(t *testing.T) {
-	result, err := Compare("left.env", []byte("FOO=left\n"), "right.env", []byte("BAR=right\n"))
-	if err != nil {
-		t.Fatalf("compare failed: %v", err)
-	}
+	left := analysis.NewKeyInventory(analysis.Document{
+		Lines: []analysis.Line{{Key: "FOO", HasKey: true, HasAssignment: true}},
+	})
+	right := analysis.NewKeyInventory(analysis.Document{
+		Lines: []analysis.Line{{Key: "BAR", HasKey: true, HasAssignment: true}},
+	})
+	result := CompareInventories("left.env", left, "right.env", right)
 
 	if result.Left != "left.env" {
 		t.Fatalf("unexpected left path: got %q want %q", result.Left, "left.env")
@@ -257,6 +265,41 @@ func TestCompareResultUsesPaths(t *testing.T) {
 	if result.Right != "right.env" {
 		t.Fatalf("unexpected right path: got %q want %q", result.Right, "right.env")
 	}
+}
+
+func compareParsedFiles(t *testing.T, leftPath, leftData, rightPath, rightData string) (Result, error) {
+	t.Helper()
+
+	left, err := envfile.Parse(leftPath, []byte(leftData))
+	if err != nil {
+		return Result{}, err
+	}
+	right, err := envfile.Parse(rightPath, []byte(rightData))
+	if err != nil {
+		return Result{}, err
+	}
+
+	leftAnalysis := analysisdotenv.FromDocument(analysisdotenv.DocumentInput{
+		ID: analysis.DocumentID(leftPath),
+		Source: sourcedotenv.Document{
+			File:       left,
+			SourcePath: leftPath,
+		},
+	})
+	rightAnalysis := analysisdotenv.FromDocument(analysisdotenv.DocumentInput{
+		ID: analysis.DocumentID(rightPath),
+		Source: sourcedotenv.Document{
+			File:       right,
+			SourcePath: rightPath,
+		},
+	})
+
+	return CompareInventories(
+		leftPath,
+		analysis.NewKeyInventory(leftAnalysis),
+		rightPath,
+		analysis.NewKeyInventory(rightAnalysis),
+	), nil
 }
 
 func assertResult(t *testing.T, result Result, wantMissingFromLeft, wantMissingFromRight []string) {

--- a/internal/source/dotenv/loader.go
+++ b/internal/source/dotenv/loader.go
@@ -32,11 +32,44 @@ type Document struct {
 	Identity     fs.FileIdentity
 }
 
+// ErrIsDirectory identifies a source path that resolves to a directory.
+var ErrIsDirectory = errors.New("dotenv source is a directory")
+
+// ErrNotRegularFile identifies a source path that is not a regular file.
+var ErrNotRegularFile = errors.New("dotenv source is not a regular file")
+
+// LoadError identifies the display path whose source loading failed while
+// preserving the underlying cause for callers that need to classify it.
+type LoadError struct {
+	// Path is the caller-supplied display path for the failed source.
+	Path string
+	// Err is the underlying source-loading error.
+	Err error
+}
+
+// Error returns a path-qualified source-loading error.
+func (e *LoadError) Error() string {
+	return fmt.Sprintf("load dotenv document %q: %v", e.Path, e.Err)
+}
+
+// Unwrap exposes the underlying source-loading error for classification.
+func (e *LoadError) Unwrap() error {
+	return e.Err
+}
+
 // Load validates, reads and parses one selected dotenv file. displayPath is
 // preserved as the parsed document path for diagnostics and reports. It also
 // captures the resolved target path and filesystem identity needed by safe
 // mutation planning.
 func Load(path, displayPath string) (Document, error) {
+	pathInfo, err := os.Stat(path)
+	if err != nil {
+		return Document{}, fmt.Errorf("open dotenv source %q: %w", path, err)
+	}
+	if err := validateSourceInfo(pathInfo, path); err != nil {
+		return Document{}, err
+	}
+
 	// O_NONBLOCK prevents opening a Unix FIFO from blocking before its type can
 	// be checked. Windows ignores this flag because its file handles are already
 	// non-blocking.
@@ -51,13 +84,9 @@ func Load(path, displayPath string) (Document, error) {
 		return Document{}, fmt.Errorf("stat dotenv source %q: %w", path, err)
 	}
 
-	if info.IsDir() {
+	if err := validateSourceInfo(info, path); err != nil {
 		_ = file.Close()
-		return Document{}, fmt.Errorf("dotenv source %q is a directory", path)
-	}
-	if !info.Mode().IsRegular() {
-		_ = file.Close()
-		return Document{}, fmt.Errorf("dotenv source %q is not a regular file", path)
+		return Document{}, err
 	}
 
 	resolvedPath, err := fs.CanonicalPath(path)
@@ -104,10 +133,20 @@ func LoadMany(paths, displayPaths []string) ([]Document, error) {
 	for i, path := range paths {
 		document, err := Load(path, displayPaths[i])
 		if err != nil {
-			return nil, fmt.Errorf("load dotenv document %q: %w", displayPaths[i], err)
+			return nil, &LoadError{Path: displayPaths[i], Err: err}
 		}
 		documents = append(documents, document)
 	}
 
 	return documents, nil
+}
+
+func validateSourceInfo(info os.FileInfo, path string) error {
+	if info.IsDir() {
+		return fmt.Errorf("dotenv source %q is a directory: %w", path, ErrIsDirectory)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("dotenv source %q is not a regular file: %w", path, ErrNotRegularFile)
+	}
+	return nil
 }

--- a/internal/source/dotenv/loader_test.go
+++ b/internal/source/dotenv/loader_test.go
@@ -210,6 +210,9 @@ func TestLoadRejectsDirectory(t *testing.T) {
 	if !strings.Contains(err.Error(), "directory") {
 		t.Fatalf("error does not identify directory input: %v", err)
 	}
+	if !errors.Is(err, dotenv.ErrIsDirectory) {
+		t.Fatalf("directory error should preserve dotenv.ErrIsDirectory: %v", err)
+	}
 	if !strings.Contains(err.Error(), filepath.Base(path)) {
 		t.Fatalf("error does not identify path: %v", err)
 	}
@@ -231,6 +234,29 @@ func TestLoadRejectsNonRegularFileWhereSupported(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "regular") {
 		t.Fatalf("error does not identify non-regular input: %v", err)
+	}
+	if !errors.Is(err, dotenv.ErrNotRegularFile) {
+		t.Fatalf("non-regular error should preserve dotenv.ErrNotRegularFile: %v", err)
+	}
+}
+
+func TestLoadManyPreservesFailingDisplayPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.env")
+
+	_, err := dotenv.LoadMany([]string{path}, []string{"service/.env"})
+	if err == nil {
+		t.Fatal("expected load error")
+	}
+
+	var loadErr *dotenv.LoadError
+	if !errors.As(err, &loadErr) {
+		t.Fatalf("load error does not preserve typed context: %v", err)
+	}
+	if loadErr.Path != "service/.env" {
+		t.Fatalf("load error path = %q, want %q", loadErr.Path, "service/.env")
+	}
+	if !errors.Is(loadErr, os.ErrNotExist) {
+		t.Fatalf("load error should preserve not-exist cause: %v", loadErr)
 	}
 }
 


### PR DESCRIPTION
Closes #97

<!--
Copyright © 2026 envaar
SPDX-License-Identifier: Apache-2.0
-->

## Summary

Migrate `vaar diff` to the shared source, analysis, diff-engine, application, and output boundaries while preserving existing behavior.

## Why

The diff command previously performed direct filesystem reads and invoked raw-byte compatibility wrappers. This change aligns it with the architecture defined in Discussion #58 and makes the CLI a thin application boundary.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [ ] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [x] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added `internal/application/diff` to coordinate source loading, analysis conversion, snapshot creation, inventory comparison, and error normalization.
- Updated `internal/cli/diff.go` to delegate loading and comparison while retaining argument validation, flags, output writing, and exit-code mapping.
- Removed obsolete raw-byte and parsed-file wrappers from `internal/diff`.
- Preserved path labels, output formats, operational errors, `--quiet`, `--json`, conflict handling, and existing exit behavior.
- Added typed dotenv loading errors to preserve source-path context and compatibility error messages.
- Updated engine, application, source, and CLI tests.

## User-visible changes

**None.**

The command syntax, output formats, flags, path handling, and exit behavior remain unchanged.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
GOCACHE=/tmp/vaar-go-cache go test -count=1 ./...
GOCACHE=/tmp/vaar-go-cache go vet ./...
GOCACHE=/tmp/vaar-go-cache make lint
GOCACHE=/tmp/vaar-go-cache make build
GOCACHE=/tmp/vaar-go-cache GOOS=windows GOARCH=amd64 go vet ./...
GOCACHE=/tmp/vaar-go-cache GOOS=windows GOARCH=amd64 go build -buildvcs=false -o /tmp/vaar-diff-cli-windows-final.exe ./cmd/vaar
git diff --check
```

`go run ./cmd/vaar lint ...` was not run because this ticket does not change lint behavior.

## Tests

- [x] Added tests
- [x] Updated existing tests
- [ ] No tests needed

## Documentation

- [x] Updated documentation
- [ ] Not applicable

Updated affected package comments and API documentation.

## Release notes

Migrates `vaar diff` to the shared source and analysis pipeline without changing user-visible behavior.

## Reviewer notes

Please pay particular attention to:

- The new `internal/application/diff` orchestration boundary.
- Shared dotenv loading and analysis snapshot construction.
- Preservation of user-supplied relative, absolute, and space-containing path labels.
- Preservation of operational error messages and exit codes.
- Removal of obsolete raw-byte and parsed-file compatibility wrappers.
- Continued value non-disclosure.
- Cross-platform Windows compatibility.
- No introduction of an `engines` package or unrelated query functionality.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dotenv file comparison through a unified application workflow.
  - Added clearer error messages for missing files, directories, and unsupported file types.
  - Preserved the relevant file paths in comparison results and loading errors.

- **Bug Fixes**
  - The comparison command now stops immediately when its context is canceled.
  - Improved handling and reporting of failures when loading multiple dotenv files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->