### PR TITLE
docs(diff): document diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,31 @@ SPDX-License-Identifier: Apache-2.0 -->
 
 # Vaar
 
-Vaar is an intelligent linter for environment correctness.
+Vaar is an intelligent environment analysis toolkit for validating, understanding, and safely working with .env files across developer and agentic workflows.
 
-It catches broken `.env` files, misconfiguratons in environments and helps you work with your secrets safely both during development as well as in production.
+It helps you catch broken `.env` files, misconfigurations in environments and helps you work with your secrets safely, be it development or production, for both humans and agents.
 
 ## Why Vaar?
 
 Issues with `.env` files are usually missed or overlooked during code review due to them being difficult to share and compare thanks to their sensitive nature. Since environment variables are not as easily reviewable as code artifacts, it is all the more important to ensure their hygiene and quality.
 
-Vaar encompasses linting and hygiene for various environment configurations, thus enforcing better environment management standards. A single execution discovers files, selects a customisable set of rules to enforce, reports findings and repairs any formatting drift that can be safely fixed.
+Vaar provides various tools to analyse your environment configuration safely. Each tool selects a safe scope, parses information from multiple sources, analyses it safely without leaking secrets, applies its
+own semantics and produces stable results.
 
 ## What makes Vaar different?
 
 Most dotenv linters are limited to `.env` files while secret scanners look for leaked credentials. Generic code-quality tools are not centered on environment correctness. Additionally, runtime validators only run after application code starts.
 
-The endeavour with Vaar has begun with deterministic `.env` hygiene, but is envisioned to grow into repo-aware, intelligent environment correctness tooling.
+Vaar has begun with simple `.env` hygiene, but is envisioned to grow into a suite of repo-aware, intelligent environment correctness tooling.
 
-Vaar aims to :
+Vaar currently provides:
 
-- detect env vars used in source code and flag issues
-- compare code usage against `.env.example`
-- detect stale, missing, duplicated and undocumented variables
-- understand Docker and Docker Compose env behavior and flag misconfigurations
-- understand CI env references in GitHub Actions and flag anamolous configurations
-- add framework-specific rules for Next.js, Vite, Prisma, Node, Docker and GitHub Actions
-- emit machine-readable output for CI, review tools and future integrations
+- deterministic dotenv linting through `vaar lint`
+- key-presence comparison between dotenv files through `vaar diff`
+- stable text and JSON output for command-line users and automation
+- safe, deterministic formatting fixes for supported lint findings
 
-For more details about the planned scope and future direction of Vaar, read the [Roadmap](#roadmap).
+The roadmap extends this foundation toward repository-aware analysis across source code, contracts, infrastructure and external providers. Read the [Roadmap](#roadmap) for the planned direction.
 
 ## Installation
 
@@ -101,132 +99,73 @@ Expand-Archive .\$archive -DestinationPath .
 
 ## Quick start
 
+Vaar has command-specific guides for detailed flags, output formats and exit
+codes. The examples below are simplified for an easy quick start.
+
+### Lint
+
 To test out the linter's capabilities, run Vaar from the repository you want to check:
 
 ```bash
 vaar lint
 ```
 
-Use the `--json` flag output for a portable export in the form of a JSON:
+See the [Lint guide](./docs/lint/README.md) for rule selection, JSON output,
+safe fixes, explicit targets, exit codes and the rule catalog. The
+[basic example](./examples/basic/README.md) and [broken example](./examples/broken/README.md)
+show representative lint input.
+
+### Diff
+
+Compare the keys declared/present in two dotenv files:
 
 ```bash
-vaar lint --json
+vaar diff .env .env.example
 ```
 
-To write that JSON report to a file instead of `stdout`, use:
+Diff compares key presence only and never compares or prints dotenv values. See
+the [Diff guide](./docs/diff/README.md) for JSON output, quiet mode, exit codes
+and CI usage.
 
-```bash
-vaar lint --json --output=report.json
-```
+## Command documentation
 
-This writes the JSON report to a file. For the full file-output behavior, see [docs/lint/README.md](./docs/lint/README.md).
+Use the [command map](./docs/usage.md) to find the supported commands and
+their detailed references:
 
-To apply safe, non destructive formatting fixes, use:
-
-```bash
-vaar lint --fix
-```
-
-> [!NOTE]
-> `--fix` can be scoped with `--only` and `--skip` as well, so that it applies only the fixes of the selected rules. So `vaar lint --fix --only=trailing-whitespace` repairs trailing whitespace and leaves everything else untouched. Selecting a rule that has no fix (its `FIXABLE` column reads `no`) repairs nothing and is not an error. The finding simply remains in the output report.
-
-To lint only using specific rules:
-
-```bash
-vaar lint --only=duplicate-key --only=invalid-key-name
-```
-
-To lint while skipping specific rules:
-
-```bash
-vaar lint --skip=trailing-whitespace
-```
-
-To lint one explicit dotenv file or one directory tree:
-
-```bash
-vaar lint --target=.env.staging
-vaar lint --target-dir=src
-```
-
-To list every registered rule, whether `--fix` repairs it and its description:
-
-```bash
-vaar lint --list-rules
-```
-
-For the lint-specific command reference and rule catalog, see [docs/lint/README.md](./docs/lint/README.md).
-
-### Examples
-
-To try out `vaar lint` quickly, you can use some of the examples given below:
-
-- [Basic example](./examples/basic/README.md)
-- [Broken example](./examples/broken/README.md)
-
-To use these, simply create a new `.env` file at your repository and copy paste the values from the respective `.env.example`.
-
-## Example Output
-
-```text
-warn space-character .env:2 line has spaces around the key, delimiter or value
-warn trailing-whitespace .env:2 line has trailing whitespace
-error duplicate-key .env:4 APP_ENV is defined more than once
-error incorrect-delimiter .env:5 DATABASE_URL uses ':' instead of '='
-error invalid-key-name .env:6 api-key is not a portable env key name
-warn ending-blank-line .env:8 file must end with exactly one final newline
-warn extra-blank-line .env:8 repeated blank line
-exit status 1
-```
-
-## Implemented Rules
-
-To see the complete list of implemented rules, see [docs/lint/rules](./docs/lint/rules/README.md) for the full rule reference.
-
-## Usage
-
-For details about the supported commands (and their flags), supported behaviour and so on, please read [Usage](/docs/usage.md).
-
-For specific details about the lint functionality command, please see [Lint Usage Guide](/docs/lint/README.md) for more information about Output and Exit Codes, Rule Selection etc.
+- [Lint guide](./docs/lint/README.md), including the [rule catalog](./docs/lint/rules/README.md)
+- [Diff guide](./docs/diff/README.md)
+- [Help guide](./docs/help/README.md) and command-specific help references
+- [Developer primer](./docs/primer/README.md) for a practical codebase tour
 
 ## Roadmap
 
 Vaar's intends to become the one stop solution for all things related to environment variables.
 
-For now, this includes all possible linting rules that can help prevent issues related to environments in codebases broadly divided into the given [Evidence-Based Categories](/docs/lint/rules/README.md).
+### Current commands
 
-### Deterministic
+- `vaar lint` checks dotenv syntax and deterministic formatting rules, with safe
+  fixes where the result is unambiguous.
+- `vaar diff` compares key presence between two dotenv documents without
+  exposing their values.
 
-These findings are deterministic in nature.
+### Planned analysis sources
 
-- Already implemented: deterministic `.env` hygiene, stable text and JSON reporting and safe normalization fixes.
-- Straightforward next steps: a few more line-level hygiene rules and small parser or reporter refinements.
-- Examples: duplicate keys, trailing whitespace, a missing final newline, mixed line endings or a UTF-8 BOM.
+- source-code usage and repository structure
+- contracts and schemas
+- Docker, CI and framework configuration
+- optional external providers and cloud state
 
-### Contextual
+### Planned command capabilities
 
-These findings are based on project and it requires codebase context.
-
-- Straightforward next steps: compare `.env` with `.env.example`, scan source and config files for env usage and look for drift in Docker Compose or GitHub Actions.
-- Requires more design: smarter inventory checks, framework-aware rules and better drift detection.
-- Examples: a variable used in code but missing from the example file, stale keys that no longer appear in the repo or undocumented env names.
-
-### Heuristic
-
-These findings are based on general practices and heuristic patterns which are suspicious or potentially dangerous.
-
-- Requires more design: suspicious public env names or secret-like values that should be reviewed by a human should be flagged by Vaar as warnings.
-- Examples: a token-shaped string in a public example file or a naming pattern that looks risky but still needs review.
-
-### External
-
-These findings are dependent on external APIs or third-party tools for verification
-
-- Out of scope for now: cloud or provider drift, external scanners, team sync, access-control checks and audit integrations.
-- Examples: confirming exposure through a third-party service or checking provider state through an API.
+- `vaar query` for inspecting supported environment facts and status
+- broader lint rules that use repository context and explicit contracts
+- richer diff comparisons across supported sources and scopes
+- machine-readable integrations such as SARIF and CI annotations
 
 > [!NOTE]
-> These goals are not set in stone and are subject to change. If you wish to request a goal to be modified, added/removed or some new direction/scope that the team should explore, please reach out by sending a mail to [core@envaar.dev](mailto:core@envaar.dev) or open a [Discussion](https://github.com/envaar/vaar/discussions).
+> These goals are not set in stone and are subject to change. To propose a
+> change in direction or scope, contact [core@envaar.dev](mailto:core@envaar.dev)
+> or open a [Discussion](https://github.com/envaar/vaar/discussions).
 
 ## Non-goals
 
@@ -238,7 +177,7 @@ Vaar is intentionally focused on environment and configurational correctness acr
 - a generic configuration platform for arbitrary file formats rather than environment-variable correctness.
 - a secret manager or vault replacement.
 - a guessy scanner that reports weak patterns without clear evidence or reviewable context.
-- a deployment or infrastructure orchestration tool that goes overreaches beyond environment correctness.
+- a deployment or infrastructure orchestration tool that goes beyond environment correctness.
 
 Those boundaries are intentional. Vaar should stay focused before it grows broader.
 
@@ -260,7 +199,15 @@ Those boundaries are intentional. Vaar should stay focused before it grows broad
 
 ## Documentation
 
-Please refer to [/docs](/docs/) for all necessary documentation. If you are unsure where to start, try reading [Usage](/docs/usage.md). New developers can read the [Primer](/docs/primer/README.md) for a fast, hands-on tour of how Vaar works.
+Vaar's documentation is being moved to
+[vaar.envaar.dev/docs](https://vaar.envaar.dev/docs), where command usage and other reference material will be organized.
+
+The documentation at /docs is the developer and maintainer documentation:
+
+- [Map of Commands](./docs/usage.md)
+- [Developer Primer](./docs/primer/README.md)
+- [System Overview](./docs/system-overview.md)
+- [Contributing Guide](./CONTRIBUTING.md)
 
 ## System Overview and Repository Layout
 
@@ -272,9 +219,9 @@ Please read [Development Workflow](./CONTRIBUTING.md) to understand the typical 
 
 ## FAQ / Troubleshooting
 
-- If nothing was flagged, Vaar scanned the current working tree and did not find anything to report. Confirm you are in the repository/root you meant to scan.
+- If lint reports nothing, Vaar scanned the selected scope and found no remaining findings. Confirm you are in the repository/root you meant to scan.
+- If diff reports no key differences, both dotenv files contain the same declared key set. Values are not compared.
 - To verify a downloaded binary, compare it against `vaar_checksums.txt` and then run `vaar --version` after extraction.
-- Exit codes are intentionally simple: `0` means no findings remain after an optional `--fix` pass, `1` means findings remain and `2` means the command failed before producing results.
 
 ## Contributing
 

--- a/docs/diff/README.md
+++ b/docs/diff/README.md
@@ -1,0 +1,111 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
+# Diff Guide
+
+This page contains the diff-specific command reference for Vaar. Refer to [README](../../README.md) for installation, verification and the shortest possible first-run steps.
+
+## Description of the Command
+
+`vaar diff` compares the keys declared by two dotenv files. It reports which
+keys are missing from each operand without comparing, printing, masking,
+hashing or otherwise exposing dotenv values.
+
+To use diff, run the command with exactly two dotenv file paths:
+
+- `vaar diff .env .env.example`
+
+The first path is the left operand and the second path is the right operand.
+Relative and absolute paths are supported, including paths containing spaces
+when the shell argument is quoted as required.
+
+Diff also comes with additional flags such as:
+
+- `vaar diff --json .env .env.example`
+- `vaar diff --quiet .env .env.example`
+
+## Diff Flags
+
+### `--json`
+
+Renders the comparison result as JSON for CI jobs, editor integrations and
+wrapper scripts that need structured output instead of text.
+
+The JSON result contains the operand labels, missing key names and a boolean
+indicating whether the key sets differ:
+
+```bash
+vaar diff --json .env .env.example
+```
+
+Example output:
+
+```json
+{
+  "left": ".env",
+  "right": ".env.example",
+  "missing_from_left": ["API_URL"],
+  "missing_from_right": ["LOCAL_ONLY"],
+  "different": true
+}
+```
+
+`--json` writes the report to standard output. Diff does not provide JSON file
+export.
+
+### `--quiet`
+
+Suppresses normal success and difference output when the caller only needs the
+exit status:
+
+```bash
+vaar diff --quiet .env .env.example
+```
+
+`--quiet` cannot be combined with `--json`; that combination is a usage error.
+
+## Output and Exit Codes
+
+`vaar diff` uses simple exit codes that are useful for scripting:
+
+- `0` means no key differences were reported.
+- `1` means key differences were reported.
+- `2` means the command failed before producing results.
+
+The default output of `vaar diff` is plain text. Use `--json` when you want
+machine-readable key differences for automation purposes; use `--quiet` when
+you only need the exit status.
+
+When `--quiet` is not used, text or JSON is written to `stdout`. When
+`--quiet` is used, normal comparison output is suppressed and no result is
+written to `stdout`.
+
+Producing comparison output and passing diff are separate outcomes:
+
+- If both files contain the same key set, `vaar diff` prints `No key differences found` and exits with code `0`.
+- If the files contain different key sets, `vaar diff` reports the missing keys or renders the JSON result and exits with code `1`.
+- If the arguments are invalid, a file cannot be read, an output operation fails or the flags conflict, `vaar diff` fails before producing a comparison result and exits with code `2`.
+
+## Examples
+
+Vaar parses both files and compares their declared keys. It does not compare
+the values assigned to those keys.
+
+These files have the same key set, so the diff is clean even though their
+values differ:
+
+```dotenv
+# .env
+API_URL=https://local.invalid
+LOG_LEVEL=debug
+```
+
+```dotenv
+# .env.example
+API_URL=https://example.invalid
+LOG_LEVEL=info
+```
+
+Empty assignments still declare a key. Duplicate declarations contribute one
+key to the comparison. Text and JSON output contain paths and key names only;
+they do not include dotenv values or raw source lines.

--- a/docs/diff/README.md
+++ b/docs/diff/README.md
@@ -68,8 +68,8 @@ vaar diff --quiet .env .env.example
 
 `vaar diff` uses simple exit codes that are useful for scripting:
 
-- `0` means no key differences were reported.
-- `1` means key differences were reported.
+- `0` means no key differences were found.
+- `1` means key differences were found.
 - `2` means the command failed before producing results.
 
 The default output of `vaar diff` is plain text. Use `--json` when you want
@@ -84,7 +84,7 @@ Producing comparison output and passing diff are separate outcomes:
 
 - If both files contain the same key set, `vaar diff` prints `No key differences found` and exits with code `0`.
 - If the files contain different key sets, `vaar diff` reports the missing keys or renders the JSON result and exits with code `1`.
-- If the arguments are invalid, a file cannot be read, an output operation fails or the flags conflict, `vaar diff` fails before producing a comparison result and exits with code `2`.
+- If the arguments are invalid, a file cannot be read, an output operation fails or the flags conflict, `vaar diff` fails before producing a comparison result and exits with code `2`. (It is possible that an output failure can occur after comparison, but the command still fails because it cannot deliver the result.)
 
 ## Examples
 

--- a/docs/help/README.md
+++ b/docs/help/README.md
@@ -31,6 +31,7 @@ This page only covers the root help screen.
 Command-specific help pages are linked below:
 
 - [Lint help](./help-lint.md)
+- [Diff help](./help-diff.md)
 - [Completion help](./help-completion.md)
 
 > [!NOTE]

--- a/docs/help/help-diff.md
+++ b/docs/help/help-diff.md
@@ -1,0 +1,30 @@
+<!-- Copyright © 2026 envaar
+SPDX-License-Identifier: Apache-2.0 -->
+
+# Diff Help Guide
+
+This page contains the help reference for `vaar diff`. Refer to [README](../../README.md) for installation, verification and the shortest possible first-run steps. For the full diff behavior and walkthrough, see [docs/diff/README.md](../diff/README.md).
+
+## Description of the Command
+
+`vaar diff --help` and `vaar help diff` show the diff help screen. It explains
+the two required dotenv paths and the supported output modes.
+
+To view the diff help, run:
+
+- `vaar diff --help`
+- `vaar help diff`
+
+Both commands print the same diff help text.
+
+## Scope
+
+This page only covers the help screen. The [Diff Guide](../diff/README.md)
+covers key-presence comparison, output formats and exit codes.
+
+## Examples
+
+```bash
+vaar diff --help
+vaar help diff
+```

--- a/docs/lint/README.md
+++ b/docs/lint/README.md
@@ -3,7 +3,7 @@ SPDX-License-Identifier: Apache-2.0 -->
 
 # Lint Guide
 
-This page contains the lint-specific command reference for Vaar. Refer to [README](../README.md) for installation, verification and the shortest possible first-run steps.
+This page contains the lint-specific command reference for Vaar. Refer to [README](../../README.md) for installation, verification and the shortest possible first-run steps.
 
 ## Description of the Command
 
@@ -31,7 +31,7 @@ Lint also comes with additional flags such as:
 
 Applies only the safe formatting fixes that can be made deterministically. Vaar reports the findings from the original file and marks findings that disappeared after the fix with `[fixed]`. It then reports any findings that remain in the post-fix file. The exit code is based on the remaining findings, so a file with only repaired findings exits successfully.
 
-`--fix` is affected by `--only` and `--skip`. It applies the supported fixes of only the selected rules, so `vaar lint --fix --only=trailing-whitespace` repairs trailing whitespace while leaving blank-line and other formatting untouched, and `vaar lint --fix --skip=trailing-whitespace` repairs everything except trailing whitespace. Plain `vaar lint --fix` applies every rule's fix. Selecting a rule with no fix half (its `FIXABLE` column reads `no`) repairs nothing and is not an error. That rule's finding simply remains in the report.
+`--fix` is affected by `--only` and `--skip`. It applies the supported fixes of only the selected rules, so `vaar lint --fix --only=trailing-whitespace` repairs trailing whitespace while leaving blank-line and other formatting untouched, and `vaar lint --fix --skip=trailing-whitespace` repairs everything except trailing whitespace. Plain `vaar lint --fix` applies every rule's fix. Selecting a rule with no fix (its `FIXABLE` column reads `no`) repairs nothing and is not an error. That rule's finding simply remains in the report.
 
 ### `--json`
 
@@ -62,7 +62,7 @@ vaar lint \
 
 ### `--target`
 
-Lints only the specified file path. The path can be relative or absolute, and the file does not need to match the default dotenv filename list. 
+Lints only the specified file path. The path can be relative or absolute, and the file does not need to match the default dotenv filename list.
 
 `--target` and `--target-dir` are mutually exclusive. If both `--target` and `--target-dir` are supplied, `vaar lint` returns an error.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,27 +1,30 @@
 <!-- Copyright © 2026 envaar
 SPDX-License-Identifier: Apache-2.0 -->
 
-# Usage Guide
+> [!NOTE]
+> This page is soon to be deprecated. Command documentation is being moved to [vaar.envaar.dev/docs](https://vaar.envaar.dev/docs).
 
-This page is the top-level guide to using Vaar from the command line.
-For installation, verification and the fastest first run, start with [README](../README.md).
+# Command Map
 
-## Command Map
+This page is a short and simple codebase-side map of Vaar's available commands, as well as the related developer-maintained references.
 
-| Command                                                                          | What it does                            | Read more                                          |
-| -------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------- |
-| `vaar lint`                                                                      | Runs the repository lint checks.        | [Lint guide](./lint/README.md)                     |
-| `vaar lint --fix` / `vaar lint --json` / `vaar lint --output` / `vaar lint --only` / `vaar lint --skip` / `vaar lint --target` / `vaar lint --target-dir` | Adjusts lint output, JSON file export, rule selection and scope. | [Lint guide](./lint/README.md)                     |
-| `vaar --help` / `vaar help`                                                      | Shows the root help screen.             | [Help guide](./help/README.md)                     |
-| `vaar lint --help` / `vaar help lint`                                            | Shows the lint help screen.             | [Lint help guide](./help/help-lint.md)             |
-| `vaar completion <shell>`                                                        | Prints a shell completion script.       | [Completion guide](./completion/README.md)         |
-| `vaar completion --help` / `vaar help completion`                                | Shows the completion help screen.       | [Completion help guide](./help/help-completion.md) |
-| `vaar --version`                                                                 | Prints the installed version.           | [README](../README.md)                             |
+For installation, verification and the fastest first run, start with the [README](../README.md).
+
+## Available Commands
+
+| Command                               | What it does                                         | Read more                                  |
+| ------------------------------------- | ---------------------------------------------------- | ------------------------------------------ |
+| `vaar lint [flags]`                   | Runs repository lint checks and optional safe fixes. | [Lint guide](./lint/README.md)             |
+| `vaar diff <left> <right> [flags]`    | Compares key presence between two dotenv files.      | [Diff guide](./diff/README.md)             |
+| `vaar --help` / `vaar help [command]` | Shows command help.                                  | [Help guide](./help/README.md)             |
+| `vaar completion <shell>`             | Prints a shell completion script.                    | [Completion guide](./completion/README.md) |
+| `vaar --version`                      | Prints the installed version.                        | [README](../README.md)                     |
 
 ## Where To Go Next
 
 - Need the lint command reference, flags, exit codes or rule catalog? Read [docs/lint/README.md](./lint/README.md).
 - Need rule-by-rule behavior and examples? Read [docs/lint/rules/README.md](./lint/rules/README.md).
+- Need to compare two dotenv files or use diff in CI? Read [docs/diff/README.md](./diff/README.md).
 - Need the root help screen or help-screen behavior? Read [docs/help/README.md](./help/README.md).
 - Need shell setup instructions for completions? Read [docs/completion/README.md](./completion/README.md).
 
@@ -30,4 +33,5 @@ For installation, verification and the fastest first run, start with [README](..
 1. Install Vaar and verify the binary from [README](../README.md).
 2. Run `vaar lint` in the repository you want to check.
 3. Use `vaar lint --json --output=lint-report.json` when you want to export the JSON report to a file instead of `stdout`.
-4. Open [docs/lint/README.md](./lint/README.md) when you need to use/exclude specific rules or need the detailed exit-code behavior.
+4. Run `vaar diff .env .env.example` to compare presence of keys between a local dotenv file and example dotenv file.
+5. Open [docs/lint/README.md](./lint/README.md) or [docs/diff/README.md](./diff/README.md) for detailed command behavior and exit codes.

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -21,7 +21,15 @@ func newDiffCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff <left> <right>",
 		Short: "Compare dotenv key presence",
-		Args:  exactDiffArgs,
+		Long: `Compare the names of keys declared in two dotenv files.
+
+Vaar compares key presence only. It never compares or prints dotenv values.
+Use --json for machine-readable output or --quiet when you only need the exit
+status.`,
+		Example: `  vaar diff .env .env.example
+  vaar diff --json .env .env.example
+  vaar diff --quiet .env .env.example`,
+		Args: exactDiffArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if jsonOutput && quiet {
 				return NewToolError("--quiet and --json cannot be used together", nil)

--- a/internal/cli/diff_test.go
+++ b/internal/cli/diff_test.go
@@ -63,6 +63,30 @@ func TestDiffCLIUsesApplicationAndOutputBoundaries(t *testing.T) {
 	}
 }
 
+func TestDiffHelpDocumentsSupportedOutputModes(t *testing.T) {
+	var stdout bytes.Buffer
+
+	cmd := newDiffCmd()
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute help failed: %v", err)
+	}
+
+	for _, want := range []string{
+		"Compare the names of keys declared in two dotenv files.",
+		"It never compares or prints dotenv values.",
+		"vaar diff .env .env.example",
+		"vaar diff --json .env .env.example",
+		"vaar diff --quiet .env .env.example",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("diff help does not contain %q: %q", want, stdout.String())
+		}
+	}
+}
+
 func TestDiffCommandReportsDifferencesForRelativePaths(t *testing.T) {
 	root := t.TempDir()
 	mustWriteFile(t, filepath.Join(root, ".env"), "FOO=local\nCOMMON=local\n")


### PR DESCRIPTION
Closes #52

## Summary

Document the `vaar diff` command across the repository’s user-facing and CLI help documentation.

## Why

Users need a clear reference for comparing dotenv key presence without exposing values. This also keeps diff documentation consistent with the existing lint documentation.

## Type

- [ ] Bug fix
- [ ] New rule
- [ ] Parser change/fix
- [ ] Reporter change/fix
- [x] Documentation
- [ ] CI / Release
- [ ] Build
- [ ] Performance improvement/change
- [ ] Internal refactor
- [ ] Hotfix

## Breaking change

- [x] No
- [ ] Yes (describe required migration)

## Changes

- Added a dedicated `vaar diff` command guide covering usage, flags, JSON output, quiet mode, exit codes and examples.
- Added diff help documentation and linked it from the help index.
- Updated the root README and command map to include diff.
- Expanded `vaar diff --help` with command descriptions and examples.
- Added a test verifying the documented diff help content.
- Corrected the lint guide’s repository README link and minor wording issues.

## User-visible changes

The diff command behavior is unchanged. Documentation and help output now provide clearer guidance:

```text
vaar diff .env .env.example
vaar diff --json .env .env.example
vaar diff --quiet .env .env.example
```

Diff continues to compare key presence only and never compares or prints dotenv values.

## Validation

Commands run:

- [x] `gofmt -w <touched Go files>`
- [x] `make lint`
- [x] `go test ./...`
- [ ] `go run ./cmd/vaar lint ...`

Additional commands:

```text
go vet ./...
go test ./internal/cli
git diff --cached --check
```

`go run ./cmd/vaar lint ...` was not run because this change does not modify lint behavior.

## Tests

- [x] Added tests
- [ ] Updated existing tests
- [ ] No tests needed (explain)

## Documentation

- [x] Updated documentation
- [ ] Not applicable

## Release notes

Document the `vaar diff` command and its supported output modes without changing runtime behavior.

## Reviewer notes

Please review:

- Diff documentation consistency with the lint command guide.
- The value-free behavior described across README, command documentation and CLI help.
- Accuracy of `--json`, `--quiet` and exit-code documentation.
- The new CLI help coverage test.
- Confirmation that no diff execution behavior or output semantics changed.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Code is formatted
- [x] Tests pass
- [x] Documentation is updated (if needed)
- [x] Release note added (if needed)
- [x] No real secrets, credentials or sensitive data is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guides and help content for `vaar diff`, including usage, output modes, exit codes, examples, and key-only comparison behavior.
  - Updated the README and usage guide with streamlined command overviews, revised quick-start examples, roadmap information, and links to the hosted documentation.
  - Added `vaar diff` to the command help index and corrected minor lint documentation issues.
  - Clarified that diff comparisons do not expose environment values or source lines.
- **Help**
  - Expanded `diff --help` with supported modes, comparison scope, and invocation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->